### PR TITLE
[TensorSplit] Add Set/Get Properties - @open sesame 08/31 22:14

### DIFF
--- a/gst/tensor_split/gsttensorsplit.h
+++ b/gst/tensor_split/gsttensorsplit.h
@@ -17,7 +17,7 @@
  */
 /**
  * @file	gsttensorsplit.h
- * @date	03 July 2018
+ * @date	27 Aug 2018
  * @brief	GStreamer plugin to split tensor (as a filter for other general neural network filters)
  * @bug         No known bugs
  *


### PR DESCRIPTION
# PR Description

In order to get/set tensor split size, TENSORSEG property is added. To
Manupilate set and get properties function is modified.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>