### PR TITLE
[TensorSplit] Add testcases - @open sesame 09/05 16:28

### DIFF
--- a/gst/tensor_split/gsttensorsplit.c
+++ b/gst/tensor_split/gsttensorsplit.c
@@ -37,6 +37,9 @@
  * <refsect2>
  * <title>Example launch line</title>
  * |[
+ * gst-launch -v -m filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1 ! tensor_converter
+ * ! tensorsplit name=split tensorseg=1:100:100:2,1:100:100:1 split.src_0 ! queue ! filesink location=src0.log
+ * split.src_1 ! queue ! filesink location=src1.log
  * ]|
  *
  * </refsect2>

--- a/tests/gen24bBMP.py
+++ b/tests/gen24bBMP.py
@@ -463,3 +463,4 @@ def gen_BMP_stream(filename_prefix, golden_filename, num_sink):
             saveBMP(filename_prefix + '_' + str(i) + '.bmp', string[i], 'RGB', 16, 16)
             for j in range(0, num_sink):
                 file.write(string[i])
+    return string

--- a/tests/nnstreamer_converter/generateGoldenTestResult.py
+++ b/tests/nnstreamer_converter/generateGoldenTestResult.py
@@ -47,3 +47,51 @@ if target == -1 or target == 10:
     buf = bmp.gen_BMP_random('RGB', 100, 100, 'testcase')[0]
     bmp.write('testcase.golden', buf)
     bmp.gen_BMP_stream('testsequence', 'testcase_stream.golden', 1)
+if target == -1 or target == 11:
+    buf = bmp.gen_BMP_random('RGB', 100, 100, 'testcase')[0]
+    bmp.write('testcase_0_0.golden', buf)
+
+    s=b''
+    for y in range(0,100):
+        for x in range(0,100):
+            s+=buf[y*100+x];
+    bmp.write('testcase_1_0.golden', s);
+
+    s = b''
+    for i in range(1, 3):
+        for y in range(0,100):
+            for x in range(0,100):
+                s+=buf[y*100+x + i*100*100];
+    bmp.write('testcase_1_1.golden', s);
+
+    for i in range(0,3):
+        s = b''
+        for y in range(0,100):
+            for x in range(0,100):
+                s += buf[y*100+x + i*100*100]
+        bmp.write('testcase_2_'+str(i)+'.golden', s)
+
+    string = bmp.gen_BMP_stream('testsequence', 'testcase_stream.golden', 1)
+
+    s=b''
+    for i in range (0,10):
+        for y in range(0,16):
+            for x in range(0,16):
+                s += string[i][y*16+x]
+    bmp.write('testcase_stream_1_0.golden',s)
+
+    s=b''
+    for i in range (0,10):
+        for j in range (1,3):
+            for y in range(0,16):
+                for x in range(0,16):
+                    s += string[i][j*16*16+ y*16+x]
+    bmp.write('testcase_stream_1_1.golden',s)
+
+    for j in range (0,3):
+        s=b''
+        for i in range (0,10):
+            for y in range(0,16):
+                for x in range(0,16):
+                    s += string[i][j*16*16+ y*16+x]
+        bmp.write('testcase_stream_2_'+str(j)+'.golden',s)

--- a/tests/nnstreamer_split/runTest.sh
+++ b/tests/nnstreamer_split/runTest.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+source ../testAPI.sh
+
+if [ "$SKIPGEN" == "YES" ]
+then
+  echo "Test Case Generation Skipped"
+  sopath=$2
+else
+  echo "Test Case Generation Started"
+  python ../nnstreamer_converter/generateGoldenTestResult.py 11
+  sopath=$1
+fi
+convertBMP2PNG
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensorsplit name=split tensorseg=1:100:100:3 split. ! queue ! filesink location=split00.log" 1
+
+compareAllSizeLimit testcase_0_0.golden split00.log 1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensorsplit name=split tensorseg=1:100:100:1,1:100:100:2 split. ! queue ! filesink location=split01_0.log split. ! queue ! filesink location=split01_1.log" 2
+
+compareAllSizeLimit testcase_1_0.golden split01_0.log 2_0
+compareAllSizeLimit testcase_1_1.golden split01_1.log 2_1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensorsplit name=split tensorseg=1:100:100:1,1:100:100:1,1:100:100:1 split. ! queue ! filesink location=split02_0.log split. ! queue ! filesink location=split02_1.log split. ! queue ! filesink location=split02_2.log" 3
+
+compareAllSizeLimit testcase_2_0.golden split02_0.log 3_0
+compareAllSizeLimit testcase_2_1.golden split02_1.log 3_1
+compareAllSizeLimit testcase_2_2.golden split02_2.log 3_2
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensorsplit name=split tensorseg=1:16:16:3 split. ! queue ! filesink location=split03.log" 4
+
+compareAllSizeLimit testcase_stream.golden split03.log 4
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensorsplit name=split tensorseg=1:16:16:1,1:16:16:2 split. ! queue ! filesink location=split04_0.log split. ! queue ! filesink location=split04_1.log" 5
+
+compareAllSizeLimit testcase_stream_1_0.golden split04_0.log 5_0
+compareAllSizeLimit testcase_stream_1_1.golden split04_1.log 5_1
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensordsplit:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensorsplit name=split tensorseg=1:16:16:1,1:16:16:1,1:16:16:1 split. ! queue ! filesink location=split05_0.log split. ! queue ! filesink location=split05_1.log split. ! queue ! filesink location=split05_2.log" 6
+
+compareAllSizeLimit testcase_stream_2_0.golden split05_0.log 6_0
+compareAllSizeLimit testcase_stream_2_1.golden split05_1.log 6_1
+compareAllSizeLimit testcase_stream_2_2.golden split05_2.log 6_2
+
+report


### PR DESCRIPTION
# PR Description

In order to check the tensor_split plugin, testcases are added.

**Changes proposed in this PR:**
- Add 3 tensor split test cases from file source
- Add 3 tensor split test cases from multiplefile sources

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>