### PR TITLE
[Common] Support GRAY8, the 8-bit grayscale video format - @open sesame 09/03 16:57

### DIFF
--- a/common/tensor_common.c
+++ b/common/tensor_common.c
@@ -449,6 +449,9 @@ gst_tensor_config_from_tensor_structure (GstTensorConfig * config,
   if (config->tensor_media_type == _NNS_VIDEO) {
     if (config->type == _NNS_UINT8) {
       switch (config->dimension[0]) {
+        case 1:
+          config->tensor_media_format = GST_VIDEO_FORMAT_GRAY8;
+          break;
         case 3:
           config->tensor_media_format = GST_VIDEO_FORMAT_RGB;
           break;
@@ -584,6 +587,10 @@ gst_tensor_config_from_video_info (GstTensorConfig * config,
   config->rank = 3;
 
   switch (v_info->format) {
+    case GST_VIDEO_FORMAT_GRAY8:
+      config->type = _NNS_UINT8;
+      config->dimension[0] = 1;
+      break;
     case GST_VIDEO_FORMAT_RGB:
       config->type = _NNS_UINT8;
       config->dimension[0] = 3;
@@ -889,6 +896,7 @@ gst_tensor_video_stride_padding_per_row (GstVideoFormat format, gint width)
 {
   /** @todo The actual list is much longer. fill them (read https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html ) */
   switch (format) {
+    case GST_VIDEO_FORMAT_GRAY8:
     case GST_VIDEO_FORMAT_RGB:
     case GST_VIDEO_FORMAT_BGR:
     case GST_VIDEO_FORMAT_I420:

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -36,7 +36,7 @@
 G_BEGIN_DECLS
 
 #define GST_TENSOR_VIDEO_CAPS_STR \
-    GST_VIDEO_CAPS_MAKE ("{ RGB, BGRx }") \
+    GST_VIDEO_CAPS_MAKE ("{ RGB, BGRx, GRAY8 }") \
     ", views = (int) 1, interlace-mode = (string) progressive"
 
 #define GST_TENSOR_AUDIO_CAPS_STR \

--- a/tests/nnstreamer_converter/generateGoldenTestResult.py
+++ b/tests/nnstreamer_converter/generateGoldenTestResult.py
@@ -24,11 +24,14 @@ if len(sys.argv) >= 2:  # There's some arguments
 if target == -1 or target == 1:
     bmp.write('testcase01.rgb.golden', bmp.gen_RGB()[0])
     bmp.write('testcase01.bgrx.golden', bmp.gen_BGRx()[0])
+    bmp.write('testcase01.gray8.golden', bmp.gen_GRAY8()[0])
 if target == -1 or target == 2:
     bmp.write('testcase02_RGB_640x480.golden', bmp.gen_BMP_random('RGB', 640, 480, 'testcase02')[0])
     bmp.write('testcase02_BGRx_640x480.golden', bmp.gen_BMP_random('BGRx', 640, 480, 'testcase02')[0])
+    bmp.write('testcase02_GRAY8_640x480.golden', bmp.gen_BMP_random('GRAY8', 640, 480, 'testcase02')[0])
     bmp.write('testcase02_RGB_642x480.golden', bmp.gen_BMP_random('RGB', 642, 480, 'testcase02')[0])
     bmp.write('testcase02_BGRx_642x480.golden', bmp.gen_BMP_random('BGRx', 642, 480, 'testcase02')[0])
+    bmp.write('testcase02_GRAY8_642x480.golden', bmp.gen_BMP_random('GRAY8', 642, 480, 'testcase02')[0])
 if target == -1 or target == 8:
     bmp.gen_BMP_stream('testsequence', 'testcase08.golden', 1)
 if target == -1 or target == 9:

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -14,8 +14,11 @@ convertBMP2PNG
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! videoconvert ! video/x-raw, format=BGRx ! tensor_converter silent=TRUE ! filesink location=\"test.bgrx.log\" sync=true t. ! queue ! filesink location=\"test.rgb.log\" sync=true" 1
 
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=GRAY8,width=280,height=40,framerate=0/1 ! queue ! tensor_converter silent=TRUE ! filesink location=\"test.gray8.log\" sync=true" 1
+
 compareAllSizeLimit testcase01.bgrx.golden test.bgrx.log 1-1
 compareAllSizeLimit testcase01.rgb.golden test.rgb.log 1-2
+compareAllSizeLimit testcase01.gray8.golden test.gray8.log 1-3
 
 function do_test {
 	gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase02_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! tensor_converter silent=TRUE ! filesink location=\"testcase02_${1}_${2}x${3}.log\" sync=true" ${4}
@@ -30,13 +33,17 @@ function do_test_nonip {
 
 do_test BGRx 640 480 2-1
 do_test RGB 640 480 2-2
-do_test BGRx 642 480 2-3
-do_test RGB 642 480 2-4
+do_test GRAY8 640 480 2-3
+do_test BGRx 642 480 2-4
+do_test RGB 642 480 2-5
+do_test GRAY8 642 480 2-6
 
 do_test_nonip BGRx 640 480 3-1
 do_test_nonip RGB 640 480 3-2
-do_test_nonip BGRx 642 480 3-3
-do_test_nonip RGB 642 480 3-4
+do_test_nonip GRAY8 640 480 3-3
+do_test_nonip BGRx 642 480 3-4
+do_test_nonip RGB 642 480 3-5
+do_test_nonip GRAY8 642 480 3-6
 
 # @TODO Change this when YUV becomes supported by tensor_converter
 # Fail Test: YUV is given

--- a/tests/testAPI.sh
+++ b/tests/testAPI.sh
@@ -210,6 +210,10 @@ function convertBMP2PNG {
 	fi
 	for X in `ls *.bmp`
 	do
-		$tool $X
+		if [[ $X  = *"GRAY8"* ]]; then
+			$tool $X --GRAY8
+		else
+			$tool $X
+		fi
 	done
 }


### PR DESCRIPTION
Relates: #74 

**Changes proposed in this PR:**
- Adding support for the 8-bit graycale video format, GRAY8
- Modifying tools (such as bmp2png, gen24bBMP.py, and testAPI.sh) in the test framework to support the newly added color format, GRAY8
- Adding test cases for the 8-bit graycale video format (i.e., video/x-raw,format=GRAY8)

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>