### PR TITLE
[Decode] remove dependency of media type in tensor config

### DIFF
--- a/gst/tensor_decoder/tensordec.h
+++ b/gst/tensor_decoder/tensordec.h
@@ -62,6 +62,7 @@ struct _GstTensorDec
   gboolean negotiated; /**< TRUE if tensor metadata is set */
   gboolean add_padding; /**< If TRUE, zero-padding must be added during transform */
   gboolean silent; /**< True if logging is minimized */
+  guint output_type; /**< Denotes the output type */
 
   /** For Tensor */
   gboolean configured; /**< TRUE if already successfully configured tensor metadata */


### PR DESCRIPTION
Updates tensordec before removing media type and format in GstTensorConfig structure

1. add property to set output media type
2. add functions for media caps
 - some functions in tensor_common will be removed

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
