### PR TITLE
[Convert] refactor tensor-converter

### DIFF
--- a/gst/tensor_converter/tensor_converter.c
+++ b/gst/tensor_converter/tensor_converter.c
@@ -13,8 +13,8 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Library General Public License for more details.
- *
  */
+
 /**
  * @file	tensor_converter.c
  * @date	26 Mar 2018
@@ -23,9 +23,7 @@
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
- *
  */
-
 
 /**
  *  @mainpage nnstreamer
@@ -50,12 +48,12 @@
  * SECTION:element-tensor_converter
  *
  * A filter that converts media stream to tensor stream for NN frameworks.
- * The output is always in the format of other/tensor
+ * The output is always in the format of other/tensor.
  *
  * <refsect2>
  * <title>Example launch line</title>
  * |[
- * gst-launch -v -m fakesrc ! tensor_converter ! fakesink silent=TRUE
+ * gst-launch-1.0 videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_convert ! tensor_sink
  * ]|
  * </refsect2>
  */
@@ -74,34 +72,40 @@
 #define DBG (!self->silent)
 #endif
 
+/**
+ * @brief Macro for debug message.
+ */
 #define silent_debug(...) \
     debug_print (DBG, __VA_ARGS__)
 
-#define silent_debug_caps(caps,msg) if (DBG) { \
-  if (caps) { \
-    GstStructure *caps_s; \
-    gchar *caps_s_string; \
-    guint caps_size, caps_idx; \
-    caps_size = gst_caps_get_size (caps);\
-    for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
-      caps_s = gst_caps_get_structure (caps, caps_idx); \
-      caps_s_string = gst_structure_to_string (caps_s); \
-      debug_print (TRUE, msg " = %s\n", caps_s_string); \
-      g_free (caps_s_string); \
+#define silent_debug_caps(caps,msg) do {\
+  if (DBG) { \
+    if (caps) { \
+      GstStructure *caps_s; \
+      gchar *caps_s_string; \
+      guint caps_size, caps_idx; \
+      caps_size = gst_caps_get_size (caps);\
+      for (caps_idx = 0; caps_idx < caps_size; caps_idx++) { \
+        caps_s = gst_caps_get_structure (caps, caps_idx); \
+        caps_s_string = gst_structure_to_string (caps_s); \
+        debug_print (TRUE, msg " = %s\n", caps_s_string); \
+        g_free (caps_s_string); \
+      } \
     } \
   } \
-}
+} while (0)
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_converter_debug);
 #define GST_CAT_DEFAULT gst_tensor_converter_debug
 
-/** properties */
+/**
+ * @brief tensor_converter properties
+ */
 enum
 {
   PROP_0,
-  PROP_SILENT,
-  PROP_FORCE_MEMCPY,
-  PROP_FRAMES_PER_BUFFER
+  PROP_FRAMES_PER_TENSOR,
+  PROP_SILENT
 };
 
 /**
@@ -110,436 +114,177 @@ enum
 #define DEFAULT_SILENT TRUE
 
 /**
- * @brief Disable in-place mode and do memcpy.
+ * @brief Frames in output tensor.
  */
-#define DEFAULT_FORCE_MEMCPY FALSE
+#define DEFAULT_FRAMES_PER_TENSOR 1
 
 /**
- * @brief Samples per buffer to set tensor metadata.
- * (0 means sample rate for audio stream)
+ * @brief Template for sink pad.
  */
-#define DEFAULT_FRAMES_PER_BUFFER 0
-
-/**
- * @brief The capabilities of the inputs
- */
-static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_MEDIA_CAPS_STR));
 
 /**
- * @brief The capabilities of the outputs
+ * @brief Template for src pad.
  */
-static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
+static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT));
 
 #define gst_tensor_converter_parent_class parent_class
-G_DEFINE_TYPE (GstTensorConverter, gst_tensor_converter,
-    GST_TYPE_BASE_TRANSFORM);
+G_DEFINE_TYPE (GstTensorConverter, gst_tensor_converter, GST_TYPE_ELEMENT);
 
-/** GObject vmethod implementations */
-static void gst_tensor_converter_set_property (GObject * object, guint prop_id,
-    const GValue * value, GParamSpec * pspec);
-static void gst_tensor_converter_get_property (GObject * object, guint prop_id,
-    GValue * value, GParamSpec * pspec);
+static void gst_tensor_converter_finalize (GObject * object);
+static void gst_tensor_converter_set_property (GObject * object,
+    guint prop_id, const GValue * value, GParamSpec * pspec);
+static void gst_tensor_converter_get_property (GObject * object,
+    guint prop_id, GValue * value, GParamSpec * pspec);
 
-/** GstBaseTransform vmethod implementations */
-static GstFlowReturn gst_tensor_converter_transform (GstBaseTransform * trans,
-    GstBuffer * inbuf, GstBuffer * outbuf);
-static GstFlowReturn gst_tensor_converter_transform_ip (GstBaseTransform *
-    trans, GstBuffer * buf);
-static GstCaps *gst_tensor_converter_transform_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * filter);
-static GstCaps *gst_tensor_converter_fixate_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps);
-static gboolean gst_tensor_converter_set_caps (GstBaseTransform * trans,
-    GstCaps * incaps, GstCaps * outcaps);
-static gboolean gst_tensor_converter_transform_size (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, gsize size,
-    GstCaps * othercaps, gsize * othersize);
+static gboolean gst_tensor_converter_sink_event (GstPad * pad,
+    GstObject * parent, GstEvent * event);
+static gboolean gst_tensor_converter_sink_query (GstPad * pad,
+    GstObject * parent, GstQuery * query);
+static gboolean gst_tensor_converter_src_query (GstPad * pad,
+    GstObject * parent, GstQuery * query);
+static GstFlowReturn gst_tensor_converter_chain (GstPad * pad,
+    GstObject * parent, GstBuffer * buf);
+static GstStateChangeReturn
+gst_tensor_converter_change_state (GstElement * element,
+    GstStateChange transition);
 
-/**
- * @brief Check tensor config is consistent
- * @param self "this" pointer to check consistency
- * @param config newly configured tensor metadata
- */
-static gboolean
-gst_tensor_converter_check_consistency (GstTensorConverter * self,
-    const GstTensorConfig * config)
-{
-  g_return_val_if_fail (self != NULL, FALSE);
-  g_return_val_if_fail (config != NULL, FALSE);
-
-  if (self->tensor_configured) {
-    return gst_tensor_config_is_same (&self->tensor_config, config);
-  }
-
-  /** not configured yet */
-  return FALSE;
-}
+static void gst_tensor_converter_reset (GstTensorConverter * self);
+static GstCaps *gst_tensor_converter_query_caps (GstTensorConverter * self,
+    GstPad * pad, GstCaps * filter);
+static gboolean gst_tensor_converter_parse_caps (GstTensorConverter * self,
+    const GstCaps * caps);
 
 /**
- * @brief Validate newly configured tensor metadata
- * @param self "this" pointer
- * @param config newly configured tensor metadata
- */
-static gboolean
-gst_tensor_converter_validate_config (GstTensorConverter * self,
-    const GstTensorConfig * config)
-{
-  g_return_val_if_fail (self != NULL, FALSE);
-  g_return_val_if_fail (config != NULL, FALSE);
-
-  if (self->tensor_configured &&
-      !gst_tensor_converter_check_consistency (self, config)) {
-    /** mismatched to old metadata */
-    return FALSE;
-  }
-
-  if (!gst_tensor_config_validate (config)) {
-    /** not fully configured */
-    return FALSE;
-  }
-
-  return TRUE;
-}
-
-/**
- * @brief Get output frame size
- * @param self "this" pointer
- * @param in_size received buffer size
- */
-static gsize
-gst_tensor_converter_get_frame_size (GstTensorConverter * self, gsize in_size)
-{
-  GstTensorConfig *config;
-  gsize out_size = 0;
-
-  g_assert (self->tensor_configured);
-  config = &self->tensor_config;
-
-  /**
-   * @todo Do we need to aggregate the buffers to meet tensor dimension?
-   * video : supposed 1 frame per buffer.
-   * audio : we can get samples in buffer, but it would not be equal to tensor dimension.
-   * text : just passes the size of bytearray.
-   */
-  switch (config->tensor_media_type) {
-    case _NNS_VIDEO:
-      out_size =
-          tensor_element_size[config->type] *
-          get_tensor_element_count (config->dimension);
-      break;
-    case _NNS_AUDIO:
-      /**
-       * samples in buffer = size / GST_AUDIO_INFO_BPF (&self->in_info.audio)
-       */
-      out_size = in_size;
-      break;
-    case _NNS_STRING:
-      out_size = in_size;
-      break;
-    default:
-      /** unsupported type */
-      break;
-  }
-
-  return out_size;
-}
-
-/**
- * @brief Parse structure and return tensor caps
- * @param self "this" pointer
- * @param structure structure to be interpreted
- */
-static GstCaps *
-gst_tensor_converter_caps_from_structure (GstTensorConverter * self,
-    const GstStructure * structure)
-{
-  GstTensorConfig config;
-
-  if (!gst_tensor_config_from_structure (&config, structure)) {
-    return NULL;
-  }
-
-  /**
-   * @todo How can we get the frames per buffer?
-   * It depends on the tensorflow model, so added property frames-per-buffer.
-   * If frames-per-buffer is 0, do nothing. (default sample rate)
-   */
-  if (config.tensor_media_type == _NNS_AUDIO) {
-    if (self->frames_per_buffer > 0) {
-      config.dimension[1] = self->frames_per_buffer;
-    }
-  }
-
-  return gst_tensor_caps_from_config (&config);
-}
-
-/**
- * @brief Configure tensor metadata for video (internal static function)
- * @param self "this" pointer to be configured.
- * @param caps the sink cap.
- * @return FALSE if error. TRUE if ok.
- */
-static gboolean
-gst_tensor_converter_configure_for_video (GstTensorConverter * self,
-    const GstCaps * caps)
-{
-  GstVideoInfo info;
-  GstTensorConfig config;
-  GstTensorVideoInfo v_info;
-
-  gst_video_info_init (&info);
-  if (!gst_video_info_from_caps (&info, caps)) {
-    err_print ("Failed to get video info from caps.\n");
-    return FALSE;
-  }
-
-  v_info.format = GST_VIDEO_INFO_FORMAT (&info);
-  v_info.w = GST_VIDEO_INFO_WIDTH (&info);
-  v_info.h = GST_VIDEO_INFO_HEIGHT (&info);
-  v_info.fn = GST_VIDEO_INFO_FPS_N (&info);
-  v_info.fd = GST_VIDEO_INFO_FPS_D (&info);
-
-  silent_debug ("video info : format[%d] width[%d] height[%d] fps[%d/%d]",
-      v_info.format, v_info.w, v_info.h, v_info.fn, v_info.fd);
-
-  if (!gst_tensor_config_from_video_info (&config, &v_info)) {
-    /** unsupported format */
-    return FALSE;
-  }
-
-  if (!gst_tensor_converter_validate_config (self, &config)) {
-    return FALSE;
-  }
-
-  /**
-   * Emit Warning if RSTRIDE = RU4 (3BPP) && Width % 4 > 0
-   * @todo: Add more conditions!
-   */
-  if (gst_tensor_video_stride_padding_per_row (v_info.format, v_info.w)) {
-    self->removePadding = TRUE;
-  }
-
-  self->tensor_config = config;
-  self->in_info.video = info;
-  return TRUE;
-}
-
-/**
- * @brief Configure tensor metadata for audio (internal static function)
- * @param self "this" pointer to be configured.
- * @param caps the sink cap.
- * @return FALSE if error. TRUE if ok.
- */
-static gboolean
-gst_tensor_converter_configure_for_audio (GstTensorConverter * self,
-    const GstCaps * caps)
-{
-  GstAudioInfo info;
-  GstTensorConfig config;
-  GstTensorAudioInfo a_info;
-
-  gst_audio_info_init (&info);
-  if (!gst_audio_info_from_caps (&info, caps)) {
-    err_print ("Failed to get audio info from caps.\n");
-    return FALSE;
-  }
-
-  a_info.format = GST_AUDIO_INFO_FORMAT (&info);
-  a_info.ch = GST_AUDIO_INFO_CHANNELS (&info);
-  a_info.rate = GST_AUDIO_INFO_RATE (&info);
-  a_info.frames =
-      (self->frames_per_buffer > 0) ? self->frames_per_buffer : a_info.rate;
-
-  silent_debug ("audio info : format[%d] channel[%d] rate[%d] bpf[%d]",
-      a_info.format, a_info.ch, a_info.rate, GST_AUDIO_INFO_BPF (&info));
-
-  if (!gst_tensor_config_from_audio_info (&config, &a_info)) {
-    /** unsupported format */
-    return FALSE;
-  }
-
-  if (!gst_tensor_converter_validate_config (self, &config)) {
-    return FALSE;
-  }
-
-  self->tensor_config = config;
-  self->in_info.audio = info;
-  return TRUE;
-}
-
-/**
- * @brief Configure tensor metadata for text (internal static function)
- * @param self "this" pointer to be configured.
- * @param caps the sink cap.
- * @return FALSE if error. TRUE if ok.
- */
-static gboolean
-gst_tensor_converter_configure_for_text (GstTensorConverter * self,
-    const GstCaps * caps)
-{
-  GstStructure *structure;
-  GstTensorConfig config;
-  GstTensorTextInfo t_info;
-
-  structure = gst_caps_get_structure (caps, 0);
-  gst_tensor_text_info_from_structure (&t_info, structure);
-
-  if (!gst_tensor_config_from_text_info (&config, &t_info)) {
-    /** unsupported format */
-    return FALSE;
-  }
-
-  if (!gst_tensor_converter_validate_config (self, &config)) {
-    return FALSE;
-  }
-
-  self->tensor_config = config;
-  return TRUE;
-}
-
-/**
- * @brief Configure tensor metadata from sink caps (internal static function)
- * @param self "this" pointer to be configured.
- * @param caps the sink cap.
- * @return FALSE if error. TRUE if ok.
- */
-static gboolean
-gst_tensor_converter_configure_tensor (GstTensorConverter * self,
-    const GstCaps * caps)
-{
-  media_type m_type;
-
-  m_type = gst_tensor_media_type_from_caps (caps);
-
-  switch (m_type) {
-    case _NNS_VIDEO:
-      if (!gst_tensor_converter_configure_for_video (self, caps)) {
-        return FALSE;
-      }
-      break;
-    case _NNS_AUDIO:
-      if (!gst_tensor_converter_configure_for_audio (self, caps)) {
-        return FALSE;
-      }
-      break;
-    case _NNS_STRING:
-      if (!gst_tensor_converter_configure_for_text (self, caps)) {
-        return FALSE;
-      }
-      break;
-    default:
-      err_print ("Unsupported type %d\n", m_type);
-      return FALSE;
-  }
-
-  self->tensor_configured = TRUE;
-  return TRUE;
-}
-
-/**
- * @brief initialize the tensor_converter's class
+ * @brief Initialize the tensor_converter's class.
  */
 static void
 gst_tensor_converter_class_init (GstTensorConverterClass * klass)
 {
-  GObjectClass *gobject_class;
-  GstElementClass *gstelement_class;
-  GstBaseTransformClass *trans_class;
+  GObjectClass *object_class;
+  GstElementClass *element_class;
 
-  trans_class = (GstBaseTransformClass *) klass;
-  gstelement_class = (GstElementClass *) trans_class;
-  gobject_class = (GObjectClass *) gstelement_class;
+  object_class = (GObjectClass *) klass;
+  element_class = (GstElementClass *) klass;
 
-  gobject_class->set_property = gst_tensor_converter_set_property;
-  gobject_class->get_property = gst_tensor_converter_get_property;
+  object_class->set_property = gst_tensor_converter_set_property;
+  object_class->get_property = gst_tensor_converter_get_property;
+  object_class->finalize = gst_tensor_converter_finalize;
 
-  g_object_class_install_property (gobject_class, PROP_SILENT,
-      g_param_spec_boolean ("silent", "Silent", "Produce verbose output ?",
+  /**
+   * GstTensorConverter:frames-per-tensor:
+   *
+   * The number of frames in outgoing buffer. (buffer is a sinle tensor instance)
+   * GstTensorConverter can push a buffer with multiple media frames.
+   */
+  g_object_class_install_property (object_class, PROP_FRAMES_PER_TENSOR,
+      g_param_spec_uint ("frames-per-tensor", "Frames per tensor",
+          "The number of frames in output tensor", 1, G_MAXUINT,
+          DEFAULT_FRAMES_PER_TENSOR,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  /**
+   * GstTensorConverter:silent:
+   *
+   * The flag to enable/disable debugging messages.
+   */
+  g_object_class_install_property (object_class, PROP_SILENT,
+      g_param_spec_boolean ("silent", "Silent", "Produce verbose output",
           DEFAULT_SILENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_FORCE_MEMCPY,
-      g_param_spec_boolean ("force-memcpy", "Force Memcpy",
-          "Disable in-place mode and do memcpy ?", DEFAULT_FORCE_MEMCPY,
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  g_object_class_install_property (gobject_class, PROP_FRAMES_PER_BUFFER,
-      g_param_spec_uint ("frames-per-buffer", "Frames per buffer",
-          "Sample count per buffer", 0, G_MAXUINT32, DEFAULT_FRAMES_PER_BUFFER,
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
-  gst_element_class_set_details_simple (gstelement_class,
-      "Tensor_Converter",
-      "Convert media stream to tensor stream",
+  gst_element_class_set_static_metadata (element_class,
+      "TensorConverter",
+      "Converter/Tensor",
       "Converts audio or video stream to tensor stream of C-Array for neural network framework filters",
       "MyungJoo Ham <myungjoo.ham@samsung.com>");
 
-  gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&src_factory));
-  gst_element_class_add_pad_template (gstelement_class,
-      gst_static_pad_template_get (&sink_factory));
-  /** Refer: https://gstreamer.freedesktop.org/documentation/design/element-transform.html */
-  trans_class->passthrough_on_same_caps = FALSE;
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&src_template));
+  gst_element_class_add_pad_template (element_class,
+      gst_static_pad_template_get (&sink_template));
 
-  /** Processing units */
-  trans_class->transform = GST_DEBUG_FUNCPTR (gst_tensor_converter_transform);
-  trans_class->transform_ip =
-      GST_DEBUG_FUNCPTR (gst_tensor_converter_transform_ip);
-
-  /** Negotiation units */
-  trans_class->transform_caps =
-      GST_DEBUG_FUNCPTR (gst_tensor_converter_transform_caps);
-  trans_class->fixate_caps =
-      GST_DEBUG_FUNCPTR (gst_tensor_converter_fixate_caps);
-  trans_class->set_caps = GST_DEBUG_FUNCPTR (gst_tensor_converter_set_caps);
-
-  /** Allocation units */
-  trans_class->transform_size =
-      GST_DEBUG_FUNCPTR (gst_tensor_converter_transform_size);
+  element_class->change_state = gst_tensor_converter_change_state;
 }
 
 /**
- * @brief initialize the new element (G_DEFINE_TYPE requires this)
- * instantiate pads and add them to element
- * set pad calback functions
- * initialize instance structure
+ * @brief Initialize tensor_converter element.
  */
 static void
 gst_tensor_converter_init (GstTensorConverter * self)
 {
+  /** setup sink pad */
+  self->sinkpad = gst_pad_new_from_static_template (&sink_template, "sink");
+  gst_pad_set_event_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_converter_sink_event));
+  gst_pad_set_query_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_converter_sink_query));
+  gst_pad_set_chain_function (self->sinkpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_converter_chain));
+  GST_PAD_SET_PROXY_CAPS (self->sinkpad);
+  gst_element_add_pad (GST_ELEMENT (self), self->sinkpad);
+
+  /** setup src pad */
+  self->srcpad = gst_pad_new_from_static_template (&src_template, "src");
+  gst_pad_set_query_function (self->srcpad,
+      GST_DEBUG_FUNCPTR (gst_tensor_converter_src_query));
+  GST_PAD_SET_PROXY_CAPS (self->srcpad);
+  gst_element_add_pad (GST_ELEMENT (self), self->srcpad);
+
+  /** init properties */
   self->silent = DEFAULT_SILENT;
-  self->tensor_configured = FALSE;
-  self->negotiated = FALSE;
-  self->removePadding = FALSE;
-  self->disableInPlace = DEFAULT_FORCE_MEMCPY;
-  self->frames_per_buffer = DEFAULT_FRAMES_PER_BUFFER;
-  gst_tensor_config_init (&self->tensor_config);
+  self->frames_per_tensor = DEFAULT_FRAMES_PER_TENSOR;
+  self->in_media_type = _NNS_MEDIA_END;
+  self->remove_padding = FALSE;
+
+  self->adapter = gst_adapter_new ();
+  gst_tensor_converter_reset (self);
 }
 
 /**
- * @brief Set property (GObject vmethod)
+ * @brief Function to finalize instance.
+ */
+static void
+gst_tensor_converter_finalize (GObject * object)
+{
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (object);
+
+  gst_tensor_converter_reset (self);
+
+  if (self->adapter) {
+    g_object_unref (self->adapter);
+    self->adapter = NULL;
+  }
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+/**
+ * @brief Setter for tensor_converter properties.
  */
 static void
 gst_tensor_converter_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTensorConverter *self = GST_TENSOR_CONVERTER (object);
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (object);
 
   switch (prop_id) {
+    case PROP_FRAMES_PER_TENSOR:
+      self->frames_per_tensor = g_value_get_uint (value);
+      silent_debug ("Set frames in output = %d", self->frames_per_tensor);
+      break;
     case PROP_SILENT:
       self->silent = g_value_get_boolean (value);
-      break;
-    case PROP_FORCE_MEMCPY:
-      self->disableInPlace = g_value_get_boolean (value);
-      break;
-    case PROP_FRAMES_PER_BUFFER:
-      self->frames_per_buffer = g_value_get_uint (value);
-      silent_debug ("Set frames per buffer = %d", self->frames_per_buffer);
+      silent_debug ("Set silent = %d", self->silent);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -548,23 +293,22 @@ gst_tensor_converter_set_property (GObject * object, guint prop_id,
 }
 
 /**
- * @brief Get property (GObject vmethod)
+ * @brief Getter for tensor_converter properties.
  */
 static void
 gst_tensor_converter_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTensorConverter *self = GST_TENSOR_CONVERTER (object);
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (object);
 
   switch (prop_id) {
+    case PROP_FRAMES_PER_TENSOR:
+      g_value_set_uint (value, self->frames_per_tensor);
+      break;
     case PROP_SILENT:
       g_value_set_boolean (value, self->silent);
-      break;
-    case PROP_FORCE_MEMCPY:
-      g_value_set_boolean (value, self->disableInPlace);
-      break;
-    case PROP_FRAMES_PER_BUFFER:
-      g_value_set_uint (value, self->frames_per_buffer);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -573,49 +317,193 @@ gst_tensor_converter_get_property (GObject * object, guint prop_id,
 }
 
 /**
- * @brief copies sink pad buffer to src pad buffer (internal static function)
- * @param self "this" pointer
- * @param inbuf sink pad buffer
- * @param outbuf src pad buffer
- * @return GST_FLOW_OK if ok. other values represents error
+ * @brief This function handles sink event.
+ */
+static gboolean
+gst_tensor_converter_sink_event (GstPad * pad, GstObject * parent,
+    GstEvent * event)
+{
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (parent);
+
+  GST_LOG_OBJECT (self, "Received %s event: %" GST_PTR_FORMAT,
+      GST_EVENT_TYPE_NAME (event), event);
+
+  switch (GST_EVENT_TYPE (event)) {
+    case GST_EVENT_CAPS:
+    {
+      GstCaps *in_caps;
+      GstCaps *out_caps;
+
+      gst_event_parse_caps (event, &in_caps);
+      silent_debug_caps (in_caps, "in-caps");
+
+      if (gst_tensor_converter_parse_caps (self, in_caps)) {
+        out_caps = gst_tensor_caps_from_config (&self->tensor_config);
+        silent_debug_caps (out_caps, "out-caps");
+
+        gst_pad_set_caps (self->srcpad, out_caps);
+        gst_pad_push_event (self->srcpad, gst_event_new_caps (out_caps));
+        gst_caps_unref (out_caps);
+        return TRUE;
+      }
+      break;
+    }
+    case GST_EVENT_FLUSH_STOP:
+      gst_tensor_converter_reset (self);
+      break;
+    default:
+      break;
+  }
+
+  return gst_pad_event_default (pad, parent, event);
+}
+
+/**
+ * @brief This function handles sink pad query.
+ */
+static gboolean
+gst_tensor_converter_sink_query (GstPad * pad, GstObject * parent,
+    GstQuery * query)
+{
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (parent);
+
+  GST_LOG_OBJECT (self, "Received %s query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
+
+      gst_query_parse_caps (query, &filter);
+      caps = gst_tensor_converter_query_caps (self, pad, filter);
+
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+      return TRUE;
+    }
+    case GST_QUERY_ACCEPT_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *template_caps;
+      gboolean res;
+
+      gst_query_parse_accept_caps (query, &caps);
+      silent_debug_caps (caps, "accept-caps");
+
+      template_caps = gst_pad_get_pad_template_caps (pad);
+      res = gst_caps_can_intersect (template_caps, caps);
+
+      gst_query_set_accept_caps_result (query, res);
+      gst_caps_unref (template_caps);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_query_default (pad, parent, query);
+}
+
+/**
+ * @brief This function handles src pad query.
+ */
+static gboolean
+gst_tensor_converter_src_query (GstPad * pad, GstObject * parent,
+    GstQuery * query)
+{
+  GstTensorConverter *self;
+
+  self = GST_TENSOR_CONVERTER (parent);
+
+  GST_LOG_OBJECT (self, "Received %s query: %" GST_PTR_FORMAT,
+      GST_QUERY_TYPE_NAME (query), query);
+
+  switch (GST_QUERY_TYPE (query)) {
+    case GST_QUERY_CAPS:
+    {
+      GstCaps *caps;
+      GstCaps *filter;
+
+      gst_query_parse_caps (query, &filter);
+      caps = gst_tensor_converter_query_caps (self, pad, filter);
+
+      gst_query_set_caps_result (query, caps);
+      gst_caps_unref (caps);
+      return TRUE;
+    }
+    default:
+      break;
+  }
+
+  return gst_pad_query_default (pad, parent, query);
+}
+
+/**
+ * @brief Chain function, this function does the actual processing.
  */
 static GstFlowReturn
-gst_tensor_converter_copy_buffer (GstTensorConverter * self,
-    GstBuffer * inbuf, GstBuffer * outbuf)
+gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 {
-  GstMapInfo src_info, dest_info;
-  unsigned char *srcptr, *destptr;
+  GstTensorConverter *self;
   GstTensorConfig *config;
-  gsize block_size;
+  GstAdapter *adapter;
+  GstBuffer *inbuf;
+  gsize avail, buf_size, frame_size, out_size;
+  guint frames_in, frames_out;
+  GstFlowReturn ret = GST_FLOW_OK;
+
+  buf_size = gst_buffer_get_size (buf);
+  g_return_val_if_fail (buf_size > 0, GST_FLOW_ERROR);
+
+  self = GST_TENSOR_CONVERTER (parent);
 
   g_assert (self->tensor_configured);
-
   config = &self->tensor_config;
 
-  g_assert (gst_buffer_map (inbuf, &src_info, GST_MAP_READ));
-  g_assert (gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE));
+  frames_out = self->frames_per_tensor;
+  inbuf = buf;
 
-  block_size = gst_tensor_converter_get_frame_size (self, src_info.size);
-  g_assert (gst_buffer_get_size (outbuf) >= block_size);
-
-  srcptr = src_info.data;
-  destptr = dest_info.data;
-
-  switch (config->tensor_media_type) {
+  switch (self->in_media_type) {
     case _NNS_VIDEO:
-      if (self->removePadding == TRUE) {
+      frame_size =
+          config->dimension[0] * config->dimension[1] * config->dimension[2] *
+          tensor_element_size[config->type];
+      frames_in = 1; /** supposed 1 frame in buffer */
+
+      if (self->remove_padding) {
+        GstMapInfo src_info, dest_info;
+        unsigned char *srcptr, *destptr;
         int d0, d1;
         unsigned int src_idx = 0, dest_idx = 0;
         size_t size, offset;
 
+        inbuf = gst_buffer_new_and_alloc (frame_size);
+        gst_buffer_memset (inbuf, 0, 0, frame_size);
+
+        g_assert (gst_buffer_map (buf, &src_info, GST_MAP_READ));
+        g_assert (gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE));
+
+        srcptr = src_info.data;
+        destptr = dest_info.data;
+
+        /**
+         * Refer: https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html
+         */
         size = offset = config->dimension[0] * config->dimension[1];
 
         g_assert (offset % 4);
-        if (offset % 4)
+        if (offset % 4) {
           offset += 4 - (offset % 4);
-        /** Refer: https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html */
+        }
 
-        for (d0 = 0; d0 < config->dimension[3]; d0++) { /** Supposed to be 0 only */
+        for (d0 = 0; d0 < frames_in; d0++) {
+          /** Supposed to be 0 only, 1 frame in buffer. */
           g_assert (d0 == 0);
           for (d1 = 0; d1 < config->dimension[2]; d1++) { /** Height */
             memcpy (destptr + dest_idx, srcptr + src_idx, size);
@@ -624,336 +512,267 @@ gst_tensor_converter_copy_buffer (GstTensorConverter * self,
           }
         }
 
-        err_print
-            ("\n\n\nYOUR STREAM CONFIGURATION INCURS PERFORMANCE DETERIORATION! (1)\nPlease use 4 x n as image width for inputs.\n\n\n");
-        goto done;
-      }
-      break;
+        gst_buffer_unmap (buf, &src_info);
+        gst_buffer_unmap (inbuf, &dest_info);
 
-    default:
-      break;
-  }
-
-  memcpy (destptr, srcptr, block_size);
-
-done:
-  gst_buffer_unmap (inbuf, &src_info);
-  gst_buffer_unmap (outbuf, &dest_info);
-  return GST_FLOW_OK;
-}
-
-/**
- * @brief non-ip transform. required vmethod for BaseTransform class.
- */
-static GstFlowReturn
-gst_tensor_converter_transform (GstBaseTransform * trans,
-    GstBuffer * inbuf, GstBuffer * outbuf)
-{
-  GstTensorConverter *self;
-  GstTensorConfig *config;
-  GstFlowReturn res;
-
-  self = GST_TENSOR_CONVERTER_CAST (trans);
-
-  if (G_UNLIKELY (!self->negotiated))
-    goto unknown_format;
-  if (G_UNLIKELY (!self->tensor_configured))
-    goto unknown_tensor;
-
-  config = &self->tensor_config;
-
-  switch (config->tensor_media_type) {
-    case _NNS_VIDEO:
-    case _NNS_AUDIO:
-    case _NNS_STRING:
-      res = gst_tensor_converter_copy_buffer (self, inbuf, outbuf);
-      break;
-    default:
-      err_print ("Unsupported Media Type (%d)\n", config->tensor_media_type);
-      goto unknown_type;
-  }
-
-  return res;
-
-unknown_format:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL), ("unknown format"));
-  return GST_FLOW_NOT_NEGOTIATED;
-unknown_tensor:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL),
-      ("unknown format for tensor"));
-  return GST_FLOW_NOT_NEGOTIATED;
-unknown_type:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL),
-      ("not implemented type of media"));
-  return GST_FLOW_NOT_SUPPORTED;
-}
-
-/**
- * @brief in-place transform. required vmethod for BaseTransform class.
- */
-static GstFlowReturn
-gst_tensor_converter_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
-{
-  GstTensorConverter *self;
-  GstTensorConfig *config;
-
-  self = GST_TENSOR_CONVERTER_CAST (trans);
-
-  if (G_UNLIKELY (!self->negotiated))
-    goto unknown_format;
-  if (G_UNLIKELY (!self->tensor_configured))
-    goto unknown_tensor;
-
-  config = &self->tensor_config;
-
-  switch (config->tensor_media_type) {
-    case _NNS_VIDEO:
-      if (self->removePadding == TRUE) {
-        /** Remove zero-padding between rows */
-        GstMapInfo info;
-        unsigned char *ptr;
-        unsigned int row, d0;
-        unsigned int src_idx = 0, dest_idx = 0;
-        size_t size, offset;
-
-        size = offset = config->dimension[0] * config->dimension[1];
-
-        g_assert (offset % 4);
-        if (offset % 4)
-          offset += 4 - (offset % 4);
-        /** Refer: https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html */
-
-        gst_buffer_map (buf, &info, GST_MAP_READWRITE);
-        ptr = info.data;
-
-        for (d0 = 0; d0 < config->dimension[3]; d0++) { /** Supposed to be 0 only */
-          g_assert (d0 == 0);
-          for (row = 0; row < config->dimension[2]; row++) { /** Height */
-            if (dest_idx != src_idx)
-              memmove (ptr + dest_idx, ptr + src_idx, size);
-            dest_idx += size;
-            src_idx += offset;
-          }
-        }
-        /** @todo: Remove the clutter (reduce the size?) after memcpy. (Check if that's really helpful, first) */
-        gst_buffer_unmap (buf, &info);
-
-        err_print
-            ("\n\n\nYOUR STREAM CONFIGURATION INCURS PERFORMANCE DETERIORATION! (2)\nPlease use 4 x n as image width for inputs.\n\n\n");
+        /** copy timestamps */
+        gst_buffer_copy_into (inbuf, buf, GST_BUFFER_COPY_TIMESTAMPS, 0, -1);
       }
       break;
 
     case _NNS_AUDIO:
+      frame_size = GST_AUDIO_INFO_BPF (&self->in_info.audio);
+      frames_in = buf_size / frame_size;
+      break;
+
     case _NNS_STRING:
+      frame_size = GST_TENSOR_STRING_SIZE;
+      frames_in = 1; /** supposed 1 frame in buffer */
+
+      if (buf_size != frame_size) {
+        GstMapInfo src_info, dest_info;
+
+        inbuf = gst_buffer_new_and_alloc (frame_size);
+        gst_buffer_memset (inbuf, 0, 0, frame_size);
+
+        g_assert (gst_buffer_map (buf, &src_info, GST_MAP_READ));
+        g_assert (gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE));
+
+        strncpy ((char *) dest_info.data, (char *) src_info.data,
+            frame_size - 1);
+
+        gst_buffer_unmap (buf, &src_info);
+        gst_buffer_unmap (inbuf, &dest_info);
+
+        /** copy timestamps */
+        gst_buffer_copy_into (inbuf, buf, GST_BUFFER_COPY_TIMESTAMPS, 0, -1);
+      }
       break;
 
     default:
-      err_print ("Unsupported Media Type (%d)\n", config->tensor_media_type);
-      goto unknown_type;
+      err_print ("Unsupported type %d\n", self->in_media_type);
+      g_assert (0);
+      return GST_FLOW_ERROR;
   }
 
-  /** DO NOTHING. THIS WORKS AS A PASSTHROUGH. We just remove metadata from video */
-  return GST_FLOW_OK;
+  if (frames_in == frames_out) {
+    /** do nothing, push the incoming buffer  */
+    return gst_pad_push (self->srcpad, inbuf);
+  }
 
-unknown_format:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL), ("unknown format"));
-  return GST_FLOW_NOT_NEGOTIATED;
-unknown_tensor:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL),
-      ("unknown format for tensor"));
-  return GST_FLOW_NOT_NEGOTIATED;
-unknown_type:
-  GST_ELEMENT_ERROR (self, CORE, NOT_IMPLEMENTED, (NULL),
-      ("not implemented type of media"));
-  return GST_FLOW_NOT_SUPPORTED;
+  adapter = self->adapter;
+  g_assert (adapter != NULL);
+
+  gst_adapter_push (adapter, inbuf);
+
+  out_size = frames_out * frame_size;
+  while ((avail = gst_adapter_available (adapter)) >= out_size &&
+      ret == GST_FLOW_OK) {
+    GstBuffer *outbuf;
+    GstClockTime pts, dts;
+    gsize offset;
+
+    /** offset for last frame */
+    offset = frame_size * (frames_out - 1);
+
+    pts = gst_adapter_prev_pts_at_offset (adapter, offset, NULL);
+    dts = gst_adapter_prev_dts_at_offset (adapter, offset, NULL);
+
+    outbuf = gst_adapter_take_buffer (adapter, out_size);
+
+    GST_BUFFER_PTS (outbuf) = pts;
+    GST_BUFFER_DTS (outbuf) = dts;
+
+    ret = gst_pad_push (self->srcpad, outbuf);
+  }
+
+  return ret;
 }
 
 /**
- * @brief configure srcpad cap from "proposed" cap. (required vmethod for BaseTransform)
- *
- * @param trans ("this" pointer)
- * @param direction (why do we need this?)
- * @param caps sinkpad cap
- * @param filter this element's cap (don't know specifically.)
+ * @brief Called to perform state change.
+ */
+static GstStateChangeReturn
+gst_tensor_converter_change_state (GstElement * element,
+    GstStateChange transition)
+{
+  GstTensorConverter *self;
+  GstStateChangeReturn ret;
+
+  self = GST_TENSOR_CONVERTER (element);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_READY_TO_PAUSED:
+      gst_tensor_converter_reset (self);
+      break;
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  switch (transition) {
+    case GST_STATE_CHANGE_PAUSED_TO_READY:
+      gst_tensor_converter_reset (self);
+      break;
+    default:
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Clear and reset data.
+ */
+static void
+gst_tensor_converter_reset (GstTensorConverter * self)
+{
+  if (self->adapter) {
+    gst_adapter_clear (self->adapter);
+  }
+
+  self->tensor_configured = FALSE;
+  gst_tensor_config_init (&self->tensor_config);
+}
+
+/**
+ * @brief Get pad caps for caps negotiation.
  */
 static GstCaps *
-gst_tensor_converter_transform_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * filter)
+gst_tensor_converter_query_caps (GstTensorConverter * self, GstPad * pad,
+    GstCaps * filter)
 {
-  GstTensorConverter *self;
-  GstCaps *result;
+  GstCaps *caps;
 
-  self = GST_TENSOR_CONVERTER_CAST (trans);
-
-  silent_debug ("Direction = %d\n", direction);
-  silent_debug_caps (caps, "from");
-  silent_debug_caps (filter, "filter");
-
-  if (direction == GST_PAD_SINK) {
-    GstStructure *s = gst_caps_get_structure (caps, 0);
-    result = gst_tensor_converter_caps_from_structure (self, s);
-  } else if (direction == GST_PAD_SRC) {
-    result = gst_caps_from_string (GST_TENSOR_MEDIA_CAPS_STR);
+  if (pad == self->sinkpad) {
+    caps = gst_pad_get_pad_template_caps (pad);
   } else {
-    g_assert (0);
-    return NULL;
+    caps = gst_tensor_caps_from_config (&self->tensor_config);
   }
 
-  if (filter) {
+  silent_debug_caps (caps, "caps");
+  silent_debug_caps (filter, "filter");
+
+  if (caps && filter) {
     GstCaps *intersection;
 
     intersection =
-        gst_caps_intersect_full (filter, result, GST_CAPS_INTERSECT_FIRST);
+        gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
 
-    gst_caps_unref (result);
-    result = intersection;
+    gst_caps_unref (caps);
+    caps = intersection;
   }
 
-  silent_debug_caps (result, "to");
-
-  GST_DEBUG_OBJECT (trans, "Direction[%d] transformed %" GST_PTR_FORMAT
-      " into %" GST_PTR_FORMAT, direction, caps, result);
-  return result;
+  return caps;
 }
 
 /**
- * @brief fixate caps. required vmethod of BaseTransform
+ * @brief Parse caps and set tensor info.
  */
-static GstCaps *
-gst_tensor_converter_fixate_caps (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, GstCaps * othercaps)
+static gboolean
+gst_tensor_converter_parse_caps (GstTensorConverter * self,
+    const GstCaps * caps)
 {
-  GstTensorConverter *self;
-  GstCaps *result;
+  GstStructure *structure;
+  GstTensorConfig config;
+  media_type in_type;
+  guint frames_dim; /** index of frames in tensor dimension */
 
-  self = GST_TENSOR_CONVERTER_CAST (trans);
+  g_return_val_if_fail (caps != NULL, FALSE);
+  g_return_val_if_fail (gst_caps_is_fixed (caps), FALSE);
 
-  silent_debug_caps (caps, "from caps");
-  silent_debug_caps (othercaps, "from othercaps");
+  structure = gst_caps_get_structure (caps, 0);
+  in_type = gst_tensor_media_type_from_structure (structure);
 
-  GST_DEBUG_OBJECT (trans, "trying to fixate othercaps %" GST_PTR_FORMAT
-      " based on caps %" GST_PTR_FORMAT, othercaps, caps);
+  if (!gst_tensor_config_from_structure (&config, structure)) {
+    /** cannot configure tensor */
+    return FALSE;
+  }
 
-  if (direction == GST_PAD_SINK) {
-    GstCaps *supposed;
+  if (!gst_tensor_config_validate (&config)) {
+    /** not fully configured */
+    return FALSE;
+  }
 
-    if (gst_tensor_converter_configure_tensor (self, caps)) {
-      supposed = gst_tensor_caps_from_config (&self->tensor_config);
-    } else {
+  switch (in_type) {
+    case _NNS_VIDEO:
+    {
+      GstVideoInfo info;
+
+      gst_video_info_init (&info);
+      if (!gst_video_info_from_caps (&info, caps)) {
+        err_print ("Failed to get video info from caps.\n");
+        return FALSE;
+      }
+
       /**
-       * Failed to get media info (caps is not fixed yet)
-       * Parse caps from structure.
+       * Emit Warning if RSTRIDE = RU4 (3BPP) && Width % 4 > 0
+       * @todo Add more conditions!
        */
-      GstStructure *s = gst_caps_get_structure (caps, 0);
-      supposed = gst_tensor_converter_caps_from_structure (self, s);
+      if (gst_tensor_video_stride_padding_per_row (GST_VIDEO_INFO_FORMAT
+              (&info), GST_VIDEO_INFO_WIDTH (&info))) {
+        self->remove_padding = TRUE;
+        silent_debug ("Set flag to remove padding, width = %d",
+            GST_VIDEO_INFO_WIDTH (&info));
+
+        GST_WARNING_OBJECT (self,
+            "\nYOUR STREAM CONFIGURATION INCURS PERFORMANCE DETERIORATION!\nPlease use 4 x n as image width for inputs.\n");
+      }
+
+      frames_dim = 3;
+      self->in_info.video = info;
+      break;
     }
+    case _NNS_AUDIO:
+    {
+      GstAudioInfo info;
 
-    result = gst_caps_intersect (othercaps, supposed);
-    gst_caps_unref (supposed);
-  } else {
-    result = gst_caps_copy (othercaps);
-  }
+      gst_audio_info_init (&info);
+      if (!gst_audio_info_from_caps (&info, caps)) {
+        err_print ("Failed to get audio info from caps.\n");
+        return FALSE;
+      }
 
-  if (gst_caps_is_empty (result)) {
-    gst_caps_unref (result);
-    result = othercaps;
-  } else {
-    gst_caps_unref (othercaps);
-  }
-
-  GST_DEBUG_OBJECT (trans, "now fixating %" GST_PTR_FORMAT, result);
-
-  result = gst_caps_make_writable (result);
-  result = gst_caps_fixate (result);
-
-  if (direction == GST_PAD_SINK) {
-    if (gst_caps_is_subset (caps, result)) {
-      gst_caps_replace (&result, caps);
+      frames_dim = 1;
+      self->in_info.audio = info;
+      break;
     }
+    case _NNS_STRING:
+      frames_dim = 1;
+      break;
+    default:
+      err_print ("Unsupported type %d\n", in_type);
+      return FALSE;
   }
-  return result;
+
+  /** set the number of frames in dimension */
+  config.dimension[frames_dim] = self->frames_per_tensor;
+
+  self->in_media_type = in_type;
+  self->tensor_configured = TRUE;
+  self->tensor_config = config;
+  return TRUE;
 }
 
 /**
- * @brief set caps. required vmethod of BaseTransform
- */
-static gboolean
-gst_tensor_converter_set_caps (GstBaseTransform * trans,
-    GstCaps * incaps, GstCaps * outcaps)
-{
-  /**
-   * This is notifier of cap changes for subclass.
-   * However, we do not have subclass (This is the concrete class)
-   */
-  GstTensorConverter *self;
-
-  self = GST_TENSOR_CONVERTER_CAST (trans);
-
-  silent_debug_caps (incaps, "from incaps");
-  silent_debug_caps (outcaps, "from outcaps");
-
-  GST_DEBUG_OBJECT (trans, "converting from  %" GST_PTR_FORMAT
-      " to %" GST_PTR_FORMAT, incaps, outcaps);
-
-  gst_base_transform_set_in_place (trans, !self->disableInPlace);
-
-  /** compare and verify outcaps */
-  if (gst_tensor_converter_configure_tensor (self, incaps)) {
-    GstTensorConfig config;
-    GstStructure *s = gst_caps_get_structure (outcaps, 0);
-
-    if (gst_tensor_config_from_structure (&config, s) &&
-        gst_tensor_converter_check_consistency (self, &config)) {
-      self->negotiated = TRUE;
-    }
-  }
-
-  /** now return true if negotiated */
-  return self->negotiated;
-}
-
-/**
- * @brief Tell the framework the required size of buffer based on the info of the other side pad. optional vmethod of BaseTransform
+ * @brief Function to initialize the plugin.
  *
- * We cannot directly get the value from size value, we need to review the pad-caps.
- * This is called when non-ip mode is used.
- */
-static gboolean
-gst_tensor_converter_transform_size (GstBaseTransform * trans,
-    GstPadDirection direction, GstCaps * caps, gsize size,
-    GstCaps * othercaps, gsize * othersize)
-{
-  GstTensorConverter *self;
-
-  self = GST_TENSOR_CONVERTER_CAST (trans);
-
-  g_assert (self->tensor_configured);
-  *othersize = gst_tensor_converter_get_frame_size (self, size);
-
-  return (*othersize > 0);
-}
-
-/**
- * @brief entry point to initialize the plug-in
- * initialize the plug-in itself
- * register the element factories and other features
+ * See GstPluginInitFunc() for more details.
  */
 static gboolean
 gst_tensor_converter_plugin_init (GstPlugin * plugin)
 {
-  /**
-   * debug category for fltering log messages
-   *
-   * exchange the string 'Template tensor_converter' with your description
-   */
   GST_DEBUG_CATEGORY_INIT (gst_tensor_converter_debug, "tensor_converter",
-      0, "Template tensor_converter");
+      0, "tensor_converter element");
 
   return gst_element_register (plugin, "tensor_converter",
       GST_RANK_NONE, GST_TYPE_TENSOR_CONVERTER);
 }
 
 /**
+ * @brief Definition for identifying tensor_converter plugin.
+ *
  * PACKAGE: this is usually set by autotools depending on some _INIT macro
  * in configure.ac and then written into and defined in config.h, but we can
  * just set it ourselves here in case someone doesn't use autotools to
@@ -964,13 +783,11 @@ gst_tensor_converter_plugin_init (GstPlugin * plugin)
 #endif
 
 /**
- * gstreamer looks for this structure to register tensor_converters
- *
- * exchange the string 'Template tensor_converter' with your tensor_converter description
+ * @brief Macro to define the entry point of the plugin.
  */
 GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
     GST_VERSION_MINOR,
     tensor_converter,
-    "tensor_converter",
-    gst_tensor_converter_plugin_init,
-    VERSION, "LGPL", "GStreamer", "http://gstreamer.net/");
+    "GStreamer plugin to convert media types to tensors",
+    gst_tensor_converter_plugin_init, VERSION, "LGPL", "GStreamer",
+    "http://gstreamer.net/");

--- a/gst/tensor_converter/tensor_converter.h
+++ b/gst/tensor_converter/tensor_converter.h
@@ -13,10 +13,10 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Library General Public License for more details.
- *
  */
+
 /**
- * @file	tensor_converter.c
+ * @file	tensor_converter.h
  * @date	26 Mar 2018
  * @brief	GStreamer plugin to convert media types to tensors (as a filter for other general neural network filters)
  *
@@ -30,14 +30,12 @@
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs except for NYI items
- *
  */
 
 #ifndef __GST_TENSOR_CONVERTER_H__
 #define __GST_TENSOR_CONVERTER_H__
 
 #include <gst/gst.h>
-#include <gst/base/gstbasetransform.h>
 #include <gst/video/video-info.h>
 #include <gst/audio/audio-info.h>
 #include <tensor_common.h>
@@ -54,7 +52,6 @@ G_BEGIN_DECLS
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_CONVERTER))
 #define GST_IS_TENSOR_CONVERTER_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_CONVERTER))
-#define GST_TENSOR_CONVERTER_CAST(obj)  ((GstTensorConverter *)(obj))
 
 typedef struct _GstTensorConverter GstTensorConverter;
 typedef struct _GstTensorConverterClass GstTensorConverterClass;
@@ -64,36 +61,34 @@ typedef struct _GstTensorConverterClass GstTensorConverterClass;
  */
 struct _GstTensorConverter
 {
-  GstBaseTransform element; /**< This is the parent object */
+  GstElement element; /**< parent object */
 
-  /** For transformer */
-  gboolean negotiated; /**< %TRUE if tensor metadata is set */
+  GstPad *sinkpad; /**< sink pad */
+  GstPad *srcpad; /**< src pad */
+
+  gboolean silent; /**< true to print minimized log */
+  guint frames_per_tensor; /**< number of frames in output tensor */
+
+  GstAdapter *adapter; /**< adapt incoming media stream */
+
+  media_type in_media_type; /**< incoming media type */
   union
   {
     GstVideoInfo video; /**< video-info of the input media stream */
     GstAudioInfo audio; /**< audio-info of the input media stream */
-    /** @todo: Add other media types */
   } in_info; /**< media input stream info union. will support audio/text later */
-  gboolean removePadding; /**< If TRUE, zero-padding must be removed during transform */
-  gboolean disableInPlace; /**< If TRUE, In place mode is disabled */
-  gboolean silent; /**< True if logging is minimized */
-  guint frames_per_buffer; /**< frame count per buffer */
 
-  /** For Tensor */
+  gboolean remove_padding; /**< If true, zero-padding must be removed */
   gboolean tensor_configured; /**< True if already successfully configured tensor metadata */
-  GstTensorConfig tensor_config; /**< configured tensor info */
+  GstTensorConfig tensor_config; /**< output tensor info */
 };
 
 /**
- * @brief GstTensorConverterClass inherits GstBaseTransformClass.
- *
- * Referring another child (sibiling), GstVideoFilter (abstract class) and
- * its child (concrete class) GstVideoConverter.
- * Note that GstTensorConverterClass is a concrete class; thus we need to look at both.
+ * @brief GstTensorConverterClass data structure.
  */
 struct _GstTensorConverterClass
 {
-  GstBaseTransformClass parent_class; /**< Inherits GstBaseTransformClass */
+  GstElementClass parent_class; /**< parent class */
 };
 
 /**
@@ -103,4 +98,4 @@ GType gst_tensor_converter_get_type (void);
 
 G_END_DECLS
 
-#endif /* __GST_TENSOR_CONVERTER_H__ */
+#endif /** __GST_TENSOR_CONVERTER_H__ */

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -25,11 +25,6 @@ function do_test {
 
 	compareAllSizeLimit testcase02_${1}_${2}x${3}.golden testcase02_${1}_${2}x${3}.log ${4}
 }
-function do_test_nonip {
-	gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase02_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! tensor_converter silent=TRUE force-memcpy=TRUE ! filesink location=\"testcase02_${1}_${2}x${3}.nonip.log\" sync=true" ${4}
-
-	compareAllSizeLimit testcase02_${1}_${2}x${3}.golden testcase02_${1}_${2}x${3}.nonip.log ${4}
-}
 
 do_test BGRx 640 480 2-1
 do_test RGB 640 480 2-2
@@ -37,13 +32,6 @@ do_test GRAY8 640 480 2-3
 do_test BGRx 642 480 2-4
 do_test RGB 642 480 2-5
 do_test GRAY8 642 480 2-6
-
-do_test_nonip BGRx 640 480 3-1
-do_test_nonip RGB 640 480 3-2
-do_test_nonip GRAY8 640 480 3-3
-do_test_nonip BGRx 642 480 3-4
-do_test_nonip RGB 642 480 3-5
-do_test_nonip GRAY8 642 480 3-6
 
 # @TODO Change this when YUV becomes supported by tensor_converter
 # Fail Test: YUV is given
@@ -53,20 +41,20 @@ gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! vi
 gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter silent=TRUE whatthehell=isthis ! filesink location=\"test.yuv.fail.log\" sync=true" 6-F
 
 # audio format S16LE, 8k sample rate, samples per buffer 8000
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! tee name=t ! queue ! audioconvert ! tensor_converter ! filesink location=\"test.audio8k.s16le.log\" sync=true t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 7-1
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000 ! tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! filesink location=\"test.audio8k.s16le.log\" sync=true t. ! queue ! filesink location=\"test.audio8k.s16le.origin.log\" sync=true" 7-1
 compareAll test.audio8k.s16le.origin.log test.audio8k.s16le.log 7-2
 
 # audio format U8, 16k sample rate, samples per buffer 8000
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U8,rate=16000 ! tee name=t ! queue ! audioconvert ! tensor_converter frames-per-buffer=8000 ! filesink location=\"test.audio16k.u8.log\" sync=true t. ! queue ! filesink location=\"test.audio16k.u8.origin.log\" sync=true" 7-3
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U8,rate=16000 ! tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! filesink location=\"test.audio16k.u8.log\" sync=true t. ! queue ! filesink location=\"test.audio16k.u8.origin.log\" sync=true" 7-3
 compareAll test.audio16k.u8.origin.log test.audio16k.u8.log 7-4
 
 # audio format U16LE, 16k sample rate, 2 channels, samples per buffer 8000
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U16LE,rate=16000,channels=2 ! tee name=t ! queue ! audioconvert ! tensor_converter frames-per-buffer=8000 ! filesink location=\"test.audio16k2c.u16le.log\" sync=true t. ! queue ! filesink location=\"test.audio16k2c.u16le.origin.log\" sync=true" 7-5
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=U16LE,rate=16000,channels=2 ! tee name=t ! queue ! audioconvert ! tensor_converter frames-per-tensor=8000 ! filesink location=\"test.audio16k2c.u16le.log\" sync=true t. ! queue ! filesink location=\"test.audio16k2c.u16le.origin.log\" sync=true" 7-5
 compareAll test.audio16k2c.u16le.origin.log test.audio16k2c.u16le.log 7-6
 
 # @TODO Change this when audio format S32LE becomes supported by tensor_converter
 # Fail Test: S32LE is given
-gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S32LE,rate=8000 ! tensor_converter ! filesink location=\"test.audio8k.s32le.fail.log\" sync=true" 7-F
+gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S32LE,rate=8000 ! tensor_converter frames-per-tensor=8000 ! filesink location=\"test.audio8k.s32le.fail.log\" sync=true" 7-F
 
 # Stream test case (genCase08 in generateGoldenTestResult.py)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! tensor_converter ! filesink location=\"testcase08.log\"" 8

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <gst/gst.h>
 #include <gst/app/gstappsrc.h>
+#include <tensor_common.h>
 
 /**
  * @brief Macro for debug mode.
@@ -51,11 +52,27 @@ typedef enum
  */
 typedef enum
 {
-  TEST_TYPE_VIDEO, /**< pipeline for video */
-  TEST_TYPE_AUDIO, /**< pipeline for audio */
+  TEST_TYPE_VIDEO_RGB, /**< pipeline for video (RGB) */
+  TEST_TYPE_VIDEO_RGB_PADDING, /**< pipeline for video (RGB), remove padding */
+  TEST_TYPE_VIDEO_RGB_3F, /**< pipeline for video (RGB) 3 frames */
+  TEST_TYPE_VIDEO_BGRx, /**< pipeline for video (BGRx) */
+  TEST_TYPE_VIDEO_BGRx_2F, /**< pipeline for video (BGRx) 2 frames */
+  TEST_TYPE_VIDEO_GRAY8, /**< pipeline for video (GRAY8) */
+  TEST_TYPE_VIDEO_GRAY8_PADDING, /**< pipeline for video (GRAY8), remove padding */
+  TEST_TYPE_VIDEO_GRAY8_3F_PADDING, /**< pipeline for video (GRAY8) 3 frames, remove padding */
+  TEST_TYPE_AUDIO_S8, /**< pipeline for audio (S8) */
+  TEST_TYPE_AUDIO_U8_100F, /**< pipeline for audio (U8) 100 frames */
+  TEST_TYPE_AUDIO_S16, /**< pipeline for audio (S16) */
+  TEST_TYPE_AUDIO_U16_1000F, /**< pipeline for audio (U16) 1000 frames */
   TEST_TYPE_TEXT, /**< pipeline for text */
+  TEST_TYPE_TEXT_3F, /**< pipeline for text 3 frames */
   TEST_TYPE_TENSORS, /**< pipeline for tensors with tensormux */
   TEST_TYPE_NEGO_FAILED, /**< pipeline to test caps negotiation */
+  TEST_TYPE_VIDEO_RGB_AGGR, /**< pipeline to test tensor-aggregator */
+  TEST_TYPE_AUDIO_S16_AGGR, /**< pipeline to test tensor-aggregator */
+  TEST_TYPE_AUDIO_U16_AGGR, /**< pipeline to test tensor-aggregator */
+  TEST_TYPE_TYPECAST, /**< pipeline for typecast with tensor-transform */
+  TEST_TYPE_UNKNOWN /**< unknonwn */
 } TestType;
 
 /**
@@ -65,6 +82,7 @@ typedef struct
 {
   guint num_buffers; /**< count of buffers */
   TestType test_type; /**< test pipeline */
+  tensor_type t_type; /**< tensor type */
 } TestOption;
 
 /**
@@ -77,10 +95,14 @@ typedef struct
   GstBus *bus; /**< gst bus for test */
   GstElement *sink; /**< tensor sink element */
   TestStatus status; /**< current status */
+  TestType tc_type; /**< pipeline for testcase type */
+  tensor_type t_type; /**< tensor type */
   guint received; /**< received buffer count */
+  gsize received_size; /**< received buffer size */
   gboolean start; /**< stream started */
   gboolean end; /**< eos reached */
   gchar *caps_name; /**< negotiated caps name */
+  GstTensorConfig config; /**< tensor config from negotiated caps */
 } TestData;
 
 /**
@@ -153,7 +175,20 @@ static void
 _new_data_cb (GstElement * element, GstBuffer * buffer, gpointer user_data)
 {
   g_test_data.received++;
-  _print_log ("new data callback [%d]", g_test_data.received);
+  g_test_data.received_size = gst_buffer_get_size (buffer);
+
+  _print_log ("new data callback [%d] size [%zd]",
+      g_test_data.received, g_test_data.received_size);
+
+  if (DBG) {
+    GstClockTime pts, dts;
+
+    pts = GST_BUFFER_PTS (buffer);
+    dts = GST_BUFFER_DTS (buffer);
+
+    _print_log ("pts %" GST_TIME_FORMAT, GST_TIME_ARGS (pts));
+    _print_log ("dts %" GST_TIME_FORMAT, GST_TIME_ARGS (dts));
+  }
 
   if (g_test_data.caps_name == NULL) {
     GstPad *sink_pad;
@@ -167,6 +202,12 @@ _new_data_cb (GstElement * element, GstBuffer * buffer, gpointer user_data)
 
     g_test_data.caps_name = (gchar *) gst_structure_get_name (structure);
     _print_log ("caps name [%s]", g_test_data.caps_name);
+
+    if (g_str_equal (g_test_data.caps_name, "other/tensor")) {
+      if (!gst_tensor_config_from_structure (&g_test_data.config, structure)) {
+        _print_log ("failed to get config from caps");
+      }
+    }
 
     gst_caps_unref (caps);
   }
@@ -193,6 +234,47 @@ _eos_cb (GstElement * element, GstBuffer * buffer, gpointer user_data)
 }
 
 /**
+ * @brief Push text data to appsrc for text utf8 type.
+ */
+static gboolean
+_push_text_data (const guint num_buffers)
+{
+  GstElement *appsrc;
+  gboolean failed = FALSE;
+  guint i;
+
+  appsrc = gst_bin_get_by_name (GST_BIN (g_test_data.pipeline), "appsrc");
+
+  for (i = 0; i < num_buffers; i++) {
+    GstBuffer *buf = gst_buffer_new_allocate (NULL, 10, NULL);
+    GstMapInfo info;
+
+    gst_buffer_map (buf, &info, GST_MAP_WRITE);
+    sprintf ((char *) info.data, "%d", i);
+    gst_buffer_unmap (buf, &info);
+
+    GST_BUFFER_PTS (buf) = (i + 1) * 10 * GST_MSECOND;
+    GST_BUFFER_DTS (buf) = GST_BUFFER_PTS (buf);
+
+    if (gst_app_src_push_buffer (GST_APP_SRC (appsrc), buf) != GST_FLOW_OK) {
+      _print_log ("failed to push buffer [%d]", i);
+      failed = TRUE;
+      goto error;
+    }
+  }
+
+  if (gst_app_src_end_of_stream (GST_APP_SRC (appsrc)) != GST_FLOW_OK) {
+    _print_log ("failed to set eos");
+    failed = TRUE;
+    goto error;
+  }
+
+error:
+  gst_object_unref (appsrc);
+  return !failed;
+}
+
+/**
  * @brief Prepare test pipeline.
  */
 static gboolean
@@ -203,9 +285,13 @@ _setup_pipeline (TestOption & option)
 
   g_test_data.status = TEST_START;
   g_test_data.received = 0;
+  g_test_data.received_size = 0;
   g_test_data.start = FALSE;
   g_test_data.end = FALSE;
   g_test_data.caps_name = NULL;
+  g_test_data.tc_type = option.test_type;
+  g_test_data.t_type = option.t_type;
+  gst_tensor_config_init (&g_test_data.config);
 
   _print_log ("option num_buffers[%d] test_type[%d]",
       option.num_buffers, option.test_type);
@@ -214,25 +300,111 @@ _setup_pipeline (TestOption & option)
   _check_cond_err (g_test_data.loop != NULL);
 
   switch (option.test_type) {
-    case TEST_TYPE_VIDEO:
-      /** video 160x120 */
+    case TEST_TYPE_VIDEO_RGB:
+      /** video 160x120 RGB */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
           "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
       break;
-    case TEST_TYPE_AUDIO:
+    case TEST_TYPE_VIDEO_RGB_PADDING:
+      /** video 162x120 RGB, remove padding */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_RGB_3F:
+      /** video 160x120 RGB, 3 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_BGRx:
+      /** video 160x120 BGRx */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGRx,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_BGRx_2F:
+      /** video 160x120 BGRx, 2 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGRx,framerate=(fraction)30/1 ! "
+          "tensor_converter frames-per-tensor=2 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_GRAY8:
+      /** video 160x120 GRAY8 */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_GRAY8_PADDING:
+      /** video 162x120 GRAY8, remove padding */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_GRAY8_3F_PADDING:
+      /** video 162x120 GRAY8, 3 frames, remove padding */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
+          "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_S8:
+      /** audio sample rate 16000 (8 bits, signed, little endian) */
+      str_pipeline =
+          g_strdup_printf
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=S8,rate=16000 ! "
+          "tensor_converter frames-per-tensor=500 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_U8_100F:
+      /** audio sample rate 16000 (8 bits, unsigned, little endian), 100 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=U8,rate=16000 ! "
+          "tensor_converter frames-per-tensor=100 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_S16:
       /** audio sample rate 16000 (16 bits, signed, little endian) */
       str_pipeline =
           g_strdup_printf
-          ("audiotestsrc num-buffers=%d ! audio/x-raw,format=S16LE,rate=16000 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=S16LE,rate=16000 ! "
+          "tensor_converter frames-per-tensor=500 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_U16_1000F:
+      /** audio sample rate 16000 (16 bits, unsigned, little endian), 1000 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=U16LE,rate=16000 ! "
+          "tensor_converter frames-per-tensor=1000 ! tensor_sink name=test_sink",
+          option.num_buffers);
       break;
     case TEST_TYPE_TEXT:
+      /** text stream */
       str_pipeline =
           g_strdup_printf
           ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
           "tensor_converter ! tensor_sink name=test_sink");
+      break;
+    case TEST_TYPE_TEXT_3F:
+      /** text stream 3 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
+          "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink");
+      break;
       break;
     case TEST_TYPE_TENSORS:
       /** other/tensors with tensormux */
@@ -247,8 +419,40 @@ _setup_pipeline (TestOption & option)
       /** caps negotiation failed */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
           "videoconvert ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_RGB_AGGR:
+      /** video stream with tensor_aggregator */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_aggregator frames-out=10 frames-flush=5 frames-dim=3 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_S16_AGGR:
+      /** audio stream with tensor_aggregator, 4 buffers with 2000 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=S16LE,rate=16000,channels=1 ! "
+          "tensor_converter frames-per-tensor=500 ! tensor_aggregator frames-in=500 frames-out=2000 frames-dim=1 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_AUDIO_U16_AGGR:
+      /** audio stream with tensor_aggregator, divided into 5 buffers with 100 frames */
+      str_pipeline =
+          g_strdup_printf
+          ("audiotestsrc num-buffers=%d samplesperbuffer=500 ! audioconvert ! audio/x-raw,format=U16LE,rate=16000,channels=1 ! "
+          "tensor_converter frames-per-tensor=500 ! tensor_aggregator frames-in=500 frames-out=100 frames-dim=1 ! tensor_sink name=test_sink",
+          option.num_buffers);
+      break;
+    case TEST_TYPE_TYPECAST:
+      /** text stream to test typecast */
+      str_pipeline =
+          g_strdup_printf
+          ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
+          "tensor_converter ! tensor_transform mode=typecast option=%s ! tensor_sink name=test_sink",
+          tensor_element_typename[option.t_type]);
       break;
     default:
       goto error;
@@ -275,6 +479,11 @@ _setup_pipeline (TestOption & option)
     g_object_set (g_test_data.sink, "silent", (gboolean) FALSE, NULL);
   }
 
+  /** signal for new data */
+  handle_id = g_signal_connect (g_test_data.sink, "new-data",
+      (GCallback) _new_data_cb, NULL);
+  _check_cond_err (handle_id > 0);
+
   g_test_data.status = TEST_INIT;
   return TRUE;
 
@@ -294,7 +503,7 @@ TEST (tensor_sink_test, properties)
   gboolean emit, res_emit;
   gboolean sync, res_sync;
   gboolean qos, res_qos;
-  TestOption option = { 1, TEST_TYPE_VIDEO };
+  TestOption option = { 1, TEST_TYPE_VIDEO_RGB };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
@@ -302,9 +511,10 @@ TEST (tensor_sink_test, properties)
   g_object_get (g_test_data.sink, "signal-rate", &rate, NULL);
   EXPECT_EQ (rate, 0);
 
-  g_object_set (g_test_data.sink, "signal-rate", (rate + 10), NULL);
+  rate += 10;
+  g_object_set (g_test_data.sink, "signal-rate", rate, NULL);
   g_object_get (g_test_data.sink, "signal-rate", &res_rate, NULL);
-  EXPECT_EQ (res_rate, (rate + 10));
+  EXPECT_EQ (res_rate, rate);
 
   /** default emit-signal is TRUE */
   g_object_get (g_test_data.sink, "emit-signal", &emit, NULL);
@@ -355,17 +565,13 @@ TEST (tensor_sink_test, properties)
  */
 TEST (tensor_sink_test, signals)
 {
-  const guint num_buffers = 10;
+  const guint num_buffers = 5;
   gulong handle_id;
-  TestOption option = { num_buffers, TEST_TYPE_VIDEO };
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
   /** tensor sink signals */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
   handle_id = g_signal_connect (g_test_data.sink, "stream-start",
       (GCallback) _stream_start_cb, NULL);
   EXPECT_TRUE (handle_id > 0);
@@ -374,7 +580,6 @@ TEST (tensor_sink_test, signals)
       (GCallback) _eos_cb, NULL);
   EXPECT_TRUE (handle_id > 0);
 
-  _print_log ("start pipeline for signals test");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -398,21 +603,14 @@ TEST (tensor_sink_test, signals)
  */
 TEST (tensor_sink_test, signal_rate)
 {
-  const guint num_buffers = 10;
-  gulong handle_id;
-  TestOption option = { num_buffers, TEST_TYPE_VIDEO };
+  const guint num_buffers = 6;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
   /** set signal-rate */
   g_object_set (g_test_data.sink, "signal-rate", (guint) 15, NULL);
 
-  /** signal for new data */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
-  _print_log ("start pipeline for signal-rate test");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -430,59 +628,16 @@ TEST (tensor_sink_test, signal_rate)
 }
 
 /**
- * @brief Test for unknown property and signal.
- */
-TEST (tensor_sink_test, unknown_case)
-{
-  const guint num_buffers = 5;
-  gulong handle_id;
-  gint unknown = -1;
-  TestOption option = { num_buffers, TEST_TYPE_VIDEO };
-
-  ASSERT_TRUE (_setup_pipeline (option));
-
-  /** try to set/get unknown property */
-  g_object_set (g_test_data.sink, "unknown-prop", 1, NULL);
-  g_object_get (g_test_data.sink, "unknown-prop", &unknown, NULL);
-  EXPECT_EQ (unknown, -1);
-
-  /** unknown signal */
-  handle_id = g_signal_connect (g_test_data.sink, "unknown-sig",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_EQ (handle_id, 0);
-
-  _print_log ("start pipeline for unknown case test");
-  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
-  g_main_loop_run (g_test_data.loop);
-  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
-
-  /** check eos message */
-  EXPECT_EQ (g_test_data.status, TEST_EOS);
-
-  /** check received buffers */
-  EXPECT_EQ (g_test_data.received, 0);
-
-  _free_test_data ();
-}
-
-/**
  * @brief Test for caps negotiation failed.
  */
 TEST (tensor_sink_test, caps_error)
 {
   const guint num_buffers = 5;
-  gulong handle_id;
   TestOption option = { num_buffers, TEST_TYPE_NEGO_FAILED };
 
   /** failed : cannot link videoconvert and tensor_sink */
   ASSERT_TRUE (_setup_pipeline (option));
 
-  /** signal for new data */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
-  _print_log ("start pipeline for caps error test");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -502,17 +657,10 @@ TEST (tensor_sink_test, caps_error)
 TEST (tensor_sink_test, caps_tensors)
 {
   const guint num_buffers = 5;
-  gulong handle_id;
   TestOption option = { num_buffers, TEST_TYPE_TENSORS };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
-  /** signal for new data */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
-  _print_log ("start pipeline to test caps other/tensors");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -522,6 +670,7 @@ TEST (tensor_sink_test, caps_tensors)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 115200);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
@@ -530,22 +679,15 @@ TEST (tensor_sink_test, caps_tensors)
 }
 
 /**
- * @brief Test for audio stream.
+ * @brief Test for video format RGB.
  */
-TEST (tensor_sink_test, audio_stream)
+TEST (tensor_stream_test, video_rgb)
 {
-  const guint num_buffers = 10;
-  gulong handle_id;
-  TestOption option = { num_buffers, TEST_TYPE_AUDIO };
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
-  /** signal for new data */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
-  _print_log ("start pipeline to test audio stream");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -553,54 +695,446 @@ TEST (tensor_sink_test, audio_stream)
   /** check eos message */
   EXPECT_EQ (g_test_data.status, TEST_EOS);
 
-  /** check received buffers */
+  /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 57600);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
 
   _free_test_data ();
 }
 
 /**
- * @brief Test for text stream.
+ * @brief Test for video format RGB, remove padding.
  */
-TEST (tensor_sink_test, text_stream)
+TEST (tensor_stream_test, video_rgb_padding)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_PADDING };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 58320);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format RGB, 3 frames from tensor_converter.
+ */
+TEST (tensor_stream_test, video_rgb_3f)
+{
+  const guint num_buffers = 7;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_3F };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers / 3);
+  EXPECT_EQ (g_test_data.received_size, 57600 * 3);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 3);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format BGRx.
+ */
+TEST (tensor_stream_test, video_bgrx)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRx };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 76800);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 4);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format BGRx, 2 frames from tensor_converter.
+ */
+TEST (tensor_stream_test, video_bgrx_2f)
+{
+  const guint num_buffers = 6;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRx_2F };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers / 2);
+  EXPECT_EQ (g_test_data.received_size, 76800 * 2);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 4);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 2);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format GRAY8.
+ */
+TEST (tensor_stream_test, video_gray8)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8 };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 19200);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format GRAY8, remove padding.
+ */
+TEST (tensor_stream_test, video_gray8_padding)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8_PADDING };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 19440);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format GRAY8, 3 frames from tensor_converter, remove padding.
+ */
+TEST (tensor_stream_test, video_gray8_3f_padding)
+{
+  const guint num_buffers = 6;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_GRAY8_3F_PADDING };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers / 3);
+  EXPECT_EQ (g_test_data.received_size, 19440 * 3);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 3);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio format S8.
+ */
+TEST (tensor_stream_test, audio_s8)
+{
+  const guint num_buffers = 5; /** 5 * 500 frames */
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_S8 };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 500);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 500);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio format U8, 100 frames from tensor_converter.
+ */
+TEST (tensor_stream_test, audio_u8_100F)
+{
+  const guint num_buffers = 5; /** 5 * 500 frames */
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_U8_100F };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers * 5);
+  EXPECT_EQ (g_test_data.received_size, 100);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 100);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio format S16.
+ */
+TEST (tensor_stream_test, audio_s16)
+{
+  const guint num_buffers = 5; /** 5 * 500 frames */
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_S16 };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, 500 * 2);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_INT16);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 500);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio format U16, 1000 frames from tensor_converter.
+ */
+TEST (tensor_stream_test, audio_u16_1000f)
+{
+  const guint num_buffers = 5; /** 5 * 500 frames */
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_U16_1000F };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers / 2);
+  EXPECT_EQ (g_test_data.received_size, 500 * 2 * 2);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT16);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1000);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for text format utf8.
+ */
+TEST (tensor_stream_test, text_utf8)
 {
   const guint num_buffers = 10;
-  gulong handle_id;
-  guint i;
-  GstElement *appsrc;
   TestOption option = { num_buffers, TEST_TYPE_TEXT };
 
   ASSERT_TRUE (_setup_pipeline (option));
 
-  appsrc = gst_bin_get_by_name (GST_BIN (g_test_data.pipeline), "appsrc");
-
-  /** signal for new data */
-  handle_id = g_signal_connect (g_test_data.sink, "new-data",
-      (GCallback) _new_data_cb, NULL);
-  EXPECT_TRUE (handle_id > 0);
-
-  _print_log ("start pipeline to test text stream");
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
 
-  for (i = 0; i < num_buffers; i++) {
-    GstBuffer *buf = gst_buffer_new_allocate (NULL, 5, NULL);
-    GstMapInfo info;
-
-    gst_buffer_map (buf, &info, GST_MAP_WRITE);
-    strcpy ((gchar *) info.data, "test");
-    gst_buffer_unmap (buf, &info);
-
-    GST_BUFFER_PTS (buf) = (i + 1) * 20 * GST_MSECOND;
-    GST_BUFFER_DTS (buf) = GST_BUFFER_PTS (buf);
-
-    EXPECT_EQ (gst_app_src_push_buffer (GST_APP_SRC (appsrc), buf),
-        GST_FLOW_OK);
-  }
-
-  EXPECT_EQ (gst_app_src_end_of_stream (GST_APP_SRC (appsrc)), GST_FLOW_OK);
+  _push_text_data (num_buffers);
 
   g_main_loop_run (g_test_data.loop);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
@@ -610,9 +1144,507 @@ TEST (tensor_sink_test, text_stream)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for text format utf8, 3 frames from tensor_converter.
+ */
+TEST (tensor_stream_test, text_utf8_3f)
+{
+  const guint num_buffers = 10;
+  TestOption option = { num_buffers, TEST_TYPE_TEXT_3F };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers / 3);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * 3);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 3);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to int32 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_int32)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_INT32;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to uint32 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_uint32)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_UINT32;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to int16 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_int16)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_INT16;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to uint16 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_uint16)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_UINT16;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to float64 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_float64)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_FLOAT64;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to float32 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_float32)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_FLOAT32;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to int64 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_int64)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_INT64;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for typecast to uint64 using tensor_transform.
+ */
+TEST (tensor_stream_test, typecast_uint64)
+{
+  const guint num_buffers = 2;
+  const tensor_type t_type = _NNS_UINT64;
+  TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
+  unsigned int t_size = tensor_element_size[t_type];
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+
+  _push_text_data (num_buffers);
+
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for text */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, t_type);
+  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 0);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video stream with tensor_aggregator.
+ */
+TEST (tensor_stream_test, video_aggregate)
+{
+  const guint num_buffers = 35;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGB_AGGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, (num_buffers - 10) / 5 + 1);
+  EXPECT_EQ (g_test_data.received_size, 57600 * 10);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.dimension[3], 10);
+  EXPECT_EQ (g_test_data.config.rate_n, 30);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio stream with tensor_aggregator.
+ */
+TEST (tensor_stream_test, audio_aggregate_s16)
+{
+  const guint num_buffers = 21;
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_S16_AGGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers / 4);
+  EXPECT_EQ (g_test_data.received_size, 500 * 2 * 4);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_INT16);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 2000);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
+
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for audio stream with tensor_aggregator.
+ */
+TEST (tensor_stream_test, audio_aggregate_u16)
+{
+  const guint num_buffers = 10;
+  TestOption option = { num_buffers, TEST_TYPE_AUDIO_U16_AGGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers */
+  EXPECT_EQ (g_test_data.received, num_buffers * 5);
+  EXPECT_EQ (g_test_data.received_size, 500 * 2 / 5);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check tensor config for audio */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
+  EXPECT_EQ (g_test_data.config.type, _NNS_UINT16);
+  EXPECT_EQ (g_test_data.config.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.dimension[1], 100);
+  EXPECT_EQ (g_test_data.config.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.rate_n, 16000);
+  EXPECT_EQ (g_test_data.config.rate_d, 1);
 
   _free_test_data ();
 }


### PR DESCRIPTION
refactor tensor-converter with gst-adapter, so that this plugin can aggregate the frames.

1. change properties
- add frames-per-tensor to set the number of frames in output tensor
- remove force-memcpy, frames-per-buffer
2. fixed size of string type (GST_TENSOR_STRING_SIZE)
3. remove media format and type in GstTensorConfig
4. add simple testcases to test media stream and data aggregation using tensor-sink

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
