### PR TITLE
[CODEOWNERS] Update for github.com migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,13 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 # For more details, visit https://help.github.com/articles/about-codeowners/
+# The lists of people and groups are for github.com
 
-# Note that the current version of github.sec.samsung.net does not translate
-# @org/team-name (e.g., @STAR/taos-team), even though
-# https://help.github.com/articles/about-codeowners/ depicts @org/team-name
-# as well as @username format.
-# So, We must write all IDs of @STAR/taos-team manually.
-
-# Note that when we migrate this to github.com, we need to rewrite the whole
-# entries.
-
-# All members of taos-team are supposed to review each other
-*                                             @myungjoo-ham @wook16-song @jinhyuck83-park @jy1210-jung @sewon-oh @hello-ahn @jijoong-moon @geunsik-lim @sangjung-woo
+# All members of nnstreamer-team are supposed to review each other
+*                                             @nnsuite/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @ohsewon @jinhyuck-park @helloahn
 
 # For /packaging/, reviewers are limited to those who have some RPM packaging experiences
-/packaging/                                   @geunsik-lim @sangjung-woo @wook16-song @myungjoo-ham
+/packaging/                                   @leemgs @again4you @wooksong @myungjoo
+
+# For /debian/, reviewers are limited to those who have some DEB packaging experiences
+/debian/                                      @leemgs @myungjoo


### PR DESCRIPTION
The usernames at github.com are different from our internal github repo.
Update CODEOWNERS accordingly.

Fixes #497

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

ps. This does not touch source code.