### PR TITLE
[Transform] Add Arithmetic Mode - @open sesame 09/07 15:07

### DIFF
--- a/gst/tensor_transform/tensor_transform.h
+++ b/gst/tensor_transform/tensor_transform.h
@@ -66,22 +66,45 @@ typedef struct _GstTensor_Transform GstTensor_Transform;
 
 typedef struct _GstTensor_TransformClass GstTensor_TransformClass;
 
-typedef enum {
-  GTT_DIMCHG = 0, /* Dimension Change. "dimchg" */
-  GTT_TYPECAST = 1, /* Type change. "typecast" */
-
+typedef enum
+{
+  GTT_DIMCHG = 0,               /* Dimension Change. "dimchg" */
+  GTT_TYPECAST = 1,             /* Type change. "typecast" */
+  GTT_ARITHMETIC = 2,           /* Type change. "typecast" */
 
   GTT_END,
 } tensor_transform_mode;
 
+typedef enum
+{
+  ARITH_ADD = 0,
+  ARITH_MUL = 1,
+  ARITH_END,
+} tensor_transform_arith_mode;
+
+/**
+ * @brief Internal data structure for dimchg mode.
+ */
 typedef struct _tensor_transform_dimchg {
   int from;
   int to;
 } tensor_transform_dimchg;
 
+/**
+ * @brief Internal data structure for typecast mode.
+ */
 typedef struct _tensor_transform_typecast {
   tensor_type to; /**< tensor_type after cast. _NNS_END if unknown */
 } tensor_transform_typecast;
+
+/**
+ * @brief Internal data structure for arithmetic mode.
+ */
+typedef struct _tensor_transform_arithmetic {
+  tensor_transform_arith_mode mode;
+  /* TODO : Better to use union for various type*/
+  int64_t value;
+} tensor_transform_arithmetic;
 
 /**
  * @brief Internal data structure for tensor_transform instances.
@@ -96,6 +119,7 @@ struct _GstTensor_Transform
   union {
     tensor_transform_dimchg data_dimchg; /**< Parsed option value for "dimchg" mode */
     tensor_transform_typecast data_typecast; /**< Parsed option value for "typecast" mode. */
+    tensor_transform_arithmetic data_arithmetic; /**< Parsed option value for "arithmetic" mode. */
   };
   gboolean loaded; /**< TRUE if mode & option are loaded */
 
@@ -104,7 +128,7 @@ struct _GstTensor_Transform
   tensor_type type; /**< tensor_type of input. Most transform share the same type for both input and output. However, this does not hold for typecast. */
 };
 
-/*
+/**
  * @brief GstTensor_TransformClass inherits GstBaseTransformClass.
  *
  * Referring another child (sibiling), GstVideoFilter (abstract class) and
@@ -116,7 +140,7 @@ struct _GstTensor_TransformClass
   GstBaseTransformClass parent_class;	/**< Inherits GstBaseTransformClass */
 };
 
-/*
+/**
  * @brief Get Type function required for gst elements
  */
 GType gst_tensor_transform_get_type (void);

--- a/tests/transform_arithmetic/checkResult.py
+++ b/tests/transform_arithmetic/checkResult.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file checkResult.py
+# @brief Check if the tranform results are correct with typecast
+# @author Jijoong Moon <jijoong.moo@samsung.com>
+# @date 20 Jul 2018
+# @bug No known bugs
+
+import sys
+import struct
+
+##
+# @brief Check typecast from typea to typeb with file fna/fnb
+#
+def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, value):
+  lena = len(fna)
+  lenb = len(fnb)
+
+  if (0 < (lena % typeasize)) or (0 < (lenb % typebsize)):
+    return 10
+  num = lena / typeasize
+  if num != (lenb / typebsize):
+    return 11
+  limitb = 2 ** (8 * typebsize)
+  maskb = limitb - 1
+  for x in range(0, num):
+    vala = struct.unpack(typeapack, fna[x * typeasize: x * typeasize + typeasize])[0]
+    valb = struct.unpack(typebpack, fnb[x * typebsize: x * typebsize + typebsize])[0]
+    if (mode[0:3] == 'add'):
+      diff = vala + float(value) - valb
+      if diff > 0.01 or diff < -0.01:
+        return 20
+    elif (mode[0:3] == 'mul'):
+      diff = vala * float(value) - valb
+      if diff > 0.01 or diff < -0.01:
+        return 20
+    else:
+      return 21
+  return 0
+
+def readfile (filename):
+  F = open(filename, 'r')
+  readfile = F.read()
+  F.close
+  return readfile
+
+if len(sys.argv) < 2:
+  exit(5)
+
+if (sys.argv[1] == 'arithmetic'):
+  if len(sys.argv) < 10:
+    exit(5)
+  fna = readfile(sys.argv[2])
+  fnb = readfile(sys.argv[3])
+  typeasize = int(sys.argv[4])
+  typebsize = int(sys.argv[5])
+  typeapack = (sys.argv[6])
+  typebpack = (sys.argv[7])
+  mode = sys.argv[8]
+  value = sys.argv[9]
+
+  exit(testArithmetic(fna, fnb, typeasize, typebsize, typeapack, typebpack, mode, value))
+
+exit(5)

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+source ../testAPI.sh
+
+if [ "$SKIPGEN" == "YES" ]
+then
+  echo "Test Case Generation Skipped"
+  sopath=$2
+else
+  echo "Test Case Generation Started"
+  python ../nnstreamer_converter/generateGoldenTestResult.py 8
+  sopath=$1
+fi
+convertBMP2PNG
+
+# Test gst availability. (0)
+gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! filesink location=\"testcase.apitest.log\" sync=true" 0
+
+# Test with small stream (1, 2)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:-10 ! filesink location=\"testcase01.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase01.direct.log\" sync=true" 1
+
+python checkResult.py arithmetic testcase01.direct.log testcase01.arithmetic.log 4 4 f f add -10
+casereport 1 $? "Golden test comparison"
+
+# Test with small stream (1, 2)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:2.0 ! filesink location=\"testcase02.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase02.direct.log\" sync=true" 2
+
+python checkResult.py arithmetic testcase02.direct.log testcase02.arithmetic.log 4 4 f f mul 2.0
+casereport 2 $? "Golden test comparison"
+
+report


### PR DESCRIPTION
# PR Description
In addition to typecast and dimchg, we may need simple arithmetic for
element by element in tensor. For example, we need to add or
multiplicate a centain constant to element by element to scale. In
order to cover the requirement another mode called "arithmetic" is
added. The option for the this arithmetic mode is
"(operation):(constnat number)" such as "mul:2.0, add:-128".

"mode=arithmetic, option=add:-128"

One thing we should aware is that we do not gurantee the type of
tensor after the arithmetic operation. For the case of multiplication
with float type to the uint8_t type tensor, the output type should be
float. But in the mode, uint8_t is the type from this mode. That
means the type of output from this mode is always same with input type
of tensor. The user should aware of this and use this mode with
caution.

**Changes proposed in this PR:**
- arithmetic mode is added

Resolves:

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>