### PR TITLE
[Common/Refactor] Remove rank from pad cap

### DIFF
--- a/gst/tensor_demux/gsttensordemux.c
+++ b/gst/tensor_demux/gsttensordemux.c
@@ -353,7 +353,6 @@ gst_get_tensor_pad (GstTensorDemux * tensor_demux, GstBuffer * inbuf,
   gst_event_unref (event);
 
   caps_string = g_strdup_printf ("other/tensor, "
-      "rank = (int)4, "
       "type = (string)%s,"
       "framerate = (fraction) %d/%d, "
       "dim1 = (int) %d, "

--- a/gst/tensor_mux/gsttensormux.c
+++ b/gst/tensor_mux/gsttensormux.c
@@ -453,8 +453,8 @@ gst_tensor_mux_collected (GstCollectPads * pads, GstTensorMux * tensor_mux)
   if (!tensor_mux->negotiated) {
     GstCaps *newcaps;
     newcaps =
-        gst_caps_new_simple ("other/tensors", "rank", G_TYPE_INT,
-        tensor_mux->rank, "num_tensors", G_TYPE_INT,
+        gst_caps_new_simple ("other/tensors",
+        "num_tensors", G_TYPE_INT,
         tensor_mux->num_tensors, "types", G_TYPE_STRING,
         types->str, "framerate", GST_TYPE_FRACTION,
         tensor_mux->framerate_numerator, tensor_mux->framerate_denominator,

--- a/gst/tensor_transform/tensor_transform.c
+++ b/gst/tensor_transform/tensor_transform.c
@@ -594,27 +594,6 @@ gst_tensor_read_cap (GstCaps * caps, tensor_dim dim, tensor_type * type,
 }
 
 /**
- * @brief Calculate the rank of a tensor
- * @param dimension The dimension vector (tensor_dim = uint32_t[NNS_TENSOR_RANK_LIMIT]) of tensor.
- * @return the rank value
- */
-static int
-get_rank (const tensor_dim dimension)
-{
-  int i = 0;
-  int rank = 0;
-  g_assert (dimension);
-  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
-    g_assert (dimension[i] > 0);
-    if (dimension[i] > 1)
-      rank = i + 1;
-  }
-  if (rank == 0)                /* a scalar (assume it is 1-dim vector) */
-    return 1;
-  return rank;
-}
-
-/**
  * @brief Write cap from the given dim/type. You need to free the returned value
  * @param[in] dim The given tensor dimension
  * @param[in] type The given tensor element type
@@ -625,7 +604,6 @@ get_rank (const tensor_dim dimension)
 static GstCaps *
 gst_tensor_write_cap (const tensor_dim dim, tensor_type type, gint fn, gint fd)
 {
-  int rank = get_rank (dim);
   GstStaticCaps rawcap = GST_STATIC_CAPS (GST_TENSOR_CAP_DEFAULT);
   GstCaps *tmp, *tmp2;
   GstCaps *staticcap = gst_static_caps_get (&rawcap);
@@ -634,13 +612,13 @@ gst_tensor_write_cap (const tensor_dim dim, tensor_type type, gint fn, gint fd)
     /* type: certain. dim: uncertain */
     if (fn != -1 && fd != -1) {
       tmp2 =
-          gst_caps_new_simple ("other/tensor", "rank", G_TYPE_INT, rank,
+          gst_caps_new_simple ("other/tensor",
           "dim1", G_TYPE_INT, dim[0], "dim2", G_TYPE_INT, dim[1],
           "dim3", G_TYPE_INT, dim[2], "dim4", G_TYPE_INT, dim[3],
           "framerate", GST_TYPE_FRACTION, fn, fd, NULL);
     } else {
       tmp2 =
-          gst_caps_new_simple ("other/tensor", "rank", G_TYPE_INT, rank,
+          gst_caps_new_simple ("other/tensor",
           "dim1", G_TYPE_INT, dim[0], "dim2", G_TYPE_INT, dim[1],
           "dim3", G_TYPE_INT, dim[2], "dim4", G_TYPE_INT, dim[3], NULL);
     }
@@ -648,14 +626,14 @@ gst_tensor_write_cap (const tensor_dim dim, tensor_type type, gint fn, gint fd)
     /* type: certain. dim: certain */
     if (fn != -1 && fd != -1) {
       tmp2 =
-          gst_caps_new_simple ("other/tensor", "rank", G_TYPE_INT, rank, "type",
+          gst_caps_new_simple ("other/tensor", "type",
           G_TYPE_STRING, tensor_element_typename[type], "dim1", G_TYPE_INT,
           dim[0], "dim2", G_TYPE_INT, dim[1], "dim3", G_TYPE_INT,
           dim[2], "dim4", G_TYPE_INT, dim[3],
           "framerate", GST_TYPE_FRACTION, fn, fd, NULL);
     } else {
       tmp2 =
-          gst_caps_new_simple ("other/tensor", "rank", G_TYPE_INT, rank, "type",
+          gst_caps_new_simple ("other/tensor", "type",
           G_TYPE_STRING, tensor_element_typename[type], "dim1", G_TYPE_INT,
           dim[0], "dim2", G_TYPE_INT, dim[1], "dim3", G_TYPE_INT,
           dim[2], "dim4", G_TYPE_INT, dim[3], NULL);

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -63,14 +63,12 @@ G_BEGIN_DECLS
     GST_TENSOR_TEXT_CAPS_STR
 
 /** @todo I'm not sure if the range is to be 1, 65535 or larger */
-#define GST_TENSOR_RANK_RANGE "(int) [ 1, 4 ]"
 #define GST_TENSOR_DIM_RANGE "(int) [ 1, 65535 ]"
 #define GST_TENSOR_RATE_RANGE "(fraction) [ 0/1, 2147483647/1 ]"
 #define GST_TENSOR_TYPE_ALL "{ float32, float64, int64, uint64, int32, uint32, int16, uint16, int8, uint8 }"
 
 #define GST_TENSOR_CAP_DEFAULT \
     "other/tensor, " \
-    "rank = " GST_TENSOR_RANK_RANGE ", " \
     "dim1 = " GST_TENSOR_DIM_RANGE ", " \
     "dim2 = " GST_TENSOR_DIM_RANGE ", " \
     "dim3 = " GST_TENSOR_DIM_RANGE ", " \
@@ -97,7 +95,6 @@ G_BEGIN_DECLS
  */
 #define GST_TENSORS_CAP_DEFAULT \
     "other/tensors, " \
-    "rank = " GST_TENSOR_RANK_RANGE ", " \
     "num_tensors = " GST_TENSOR_NUM_TENSORS_RANGE ", "\
     "framerate = " GST_TENSOR_RATE_RANGE
     /**
@@ -163,10 +160,6 @@ typedef struct
  */
 typedef struct
 {
-  /**
-   * @todo remove rank.
-   */
-  gint rank; /**< Tensor Rank (# dimensions) */
   tensor_type type; /**< Type of each element in the tensor. User must designate this. Otherwise, this is UINT8 for video/x-raw byte stream */
   tensor_dim dimension; /**< Dimensions. We support up to 4th ranks.  */
   gint rate_n; /**< framerate is in fraction, which is numerator/denominator */


### PR DESCRIPTION
- Remove rank from pad cap of other/tensor and other/tensors
- Remove dependencies on rank info from plugins

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

Fixes #515

CC: It appears that this PR requires attention from @helloahn @jaeyun-jung .