### PR TITLE
[Common] common functions to prepare multi-tensors

### DIFF
--- a/gst/tensor_aggregator/tensor_aggregator.c
+++ b/gst/tensor_aggregator/tensor_aggregator.c
@@ -661,7 +661,7 @@ gst_tensor_aggregator_parse_caps (GstTensorAggregator * self,
 
   /** update dimension in output tensor */
   if (self->frames_dim >= 0) {
-    config.dimension[self->frames_dim] = self->frames_out;
+    config.info.dimension[self->frames_dim] = self->frames_out;
   }
 
   self->out_config = config;

--- a/gst/tensor_converter/tensor_converter.c
+++ b/gst/tensor_converter/tensor_converter.c
@@ -53,7 +53,7 @@
  * <refsect2>
  * <title>Example launch line</title>
  * |[
- * gst-launch-1.0 videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_convert ! tensor_sink
+ * gst-launch-1.0 videotestsrc ! video/x-raw,format=RGB,width=640,height=480 ! tensor_converter ! tensor_sink
  * ]|
  * </refsect2>
  */
@@ -472,8 +472,8 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   switch (self->in_media_type) {
     case _NNS_VIDEO:
       frame_size =
-          config->dimension[0] * config->dimension[1] * config->dimension[2] *
-          tensor_element_size[config->type];
+          config->info.dimension[0] * config->info.dimension[1] *
+          config->info.dimension[2] * tensor_element_size[config->info.type];
       frames_in = 1; /** supposed 1 frame in buffer */
 
       if (self->remove_padding) {
@@ -495,7 +495,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         /**
          * Refer: https://gstreamer.freedesktop.org/documentation/design/mediatype-video-raw.html
          */
-        size = offset = config->dimension[0] * config->dimension[1];
+        size = offset = config->info.dimension[0] * config->info.dimension[1];
 
         g_assert (offset % 4);
         if (offset % 4) {
@@ -505,7 +505,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         for (d0 = 0; d0 < frames_in; d0++) {
           /** Supposed to be 0 only, 1 frame in buffer. */
           g_assert (d0 == 0);
-          for (d1 = 0; d1 < config->dimension[2]; d1++) { /** Height */
+          for (d1 = 0; d1 < config->info.dimension[2]; d1++) { /** Height */
             memcpy (destptr + dest_idx, srcptr + src_idx, size);
             dest_idx += size;
             src_idx += offset;
@@ -747,7 +747,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
   }
 
   /** set the number of frames in dimension */
-  config.dimension[frames_dim] = self->frames_per_tensor;
+  config.info.dimension[frames_dim] = self->frames_per_tensor;
 
   self->in_media_type = in_type;
   self->tensor_configured = TRUE;

--- a/gst/tensor_filter/tensor_filter.c
+++ b/gst/tensor_filter/tensor_filter.c
@@ -531,10 +531,8 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
         int i;
         prop->inputMeta.num_tensors =
             get_tensor_dimension (g_value_get_string (value),
-            prop->inputMeta.dims, prop->inputMeta.ranks);
+            prop->inputMeta.dims);
         for (i = 0; i < prop->inputMeta.num_tensors; i++) {
-          g_assert (prop->inputMeta.ranks[i] > 0
-              && prop->inputMeta.ranks[i] <= NNS_TENSOR_RANK_LIMIT);
           silent_debug ("Input Prop: %d:%d:%d:%d Rank %d\n",
               prop->inputMeta.dims[i][0], prop->inputMeta.dims[i][1],
               prop->inputMeta.dims[i][2], prop->inputMeta.dims[i][3],
@@ -550,10 +548,8 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
         int i;
         prop->outputMeta.num_tensors =
             get_tensor_dimension (g_value_get_string (value),
-            prop->outputMeta.dims, prop->outputMeta.ranks);
+            prop->outputMeta.dims);
         for (i = 0; i < prop->outputMeta.num_tensors; i++) {
-          g_assert (prop->outputMeta.ranks[i] > 0
-              && prop->outputMeta.ranks[i] <= NNS_TENSOR_RANK_LIMIT);
           silent_debug ("Output Prop: %d:%d:%d:%d Rank %d\n",
               prop->outputMeta.dims[i][0], prop->outputMeta.dims[i][1],
               prop->outputMeta.dims[i][2], prop->outputMeta.dims[i][3],

--- a/gst/tensor_split/gsttensorsplit.c
+++ b/gst/tensor_split/gsttensorsplit.c
@@ -316,7 +316,7 @@ gst_get_tensor_pad (GstTensorSplit * tensor_split, GstBuffer * inbuf,
   dim =
       g_array_index (tensor_split->tensorseg, tensor_dim *,
       tensor_split->num_srcpads);
-  type = tensor_split->sink_tensor_conf.type;
+  type = tensor_split->sink_tensor_conf.info.type;
 
   tensor_split->num_srcpads++;
 
@@ -434,7 +434,7 @@ gst_get_splited_tensor (GstTensorSplit * split, GstBuffer * buffer, gint nth)
   dim = g_array_index (split->tensorseg, tensor_dim *, nth);
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
     temp *= (*dim)[i];
-  size += temp * tensor_element_size[split->sink_tensor_conf.type];
+  size += temp * tensor_element_size[split->sink_tensor_conf.info.type];
   mem = gst_allocator_alloc (NULL, size, NULL);
   gst_memory_map (mem, &dest_info, GST_MAP_WRITE);
   gst_buffer_map (buffer, &src_info, GST_MAP_READ);

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -98,8 +98,7 @@ G_BEGIN_DECLS
     "num_tensors = " GST_TENSOR_NUM_TENSORS_RANGE ", "\
     "framerate = " GST_TENSOR_RATE_RANGE
     /**
-     * type should be one of
-     * { float32, float64, int32, uint32, int16, uint16, int8, uint8 }
+     * type should be one of types in GST_TENSOR_TYPE_ALL
      * "types = (string) uint8, uint8, uint8"
      * Dimensions of Tensors for negotiation. It's comment out here,
        but when we call gst_structure_get_string, it actually is working well
@@ -122,49 +121,24 @@ typedef enum _nns_media_type
 } media_type;
 
 /**
- * @brief Internal data structure for video info to configure tensor.
+ * @brief Internal data structure for configured tensor info (for other/tensor).
  */
 typedef struct
 {
-  GstVideoFormat format; /**< video format */
-  gint w; /**< width */
-  gint h; /**< height */
-  gint fn; /**< framerate numerator */
-  gint fd; /**< framerate denominator */
-  gint frames; /**< number of frames per tensor */
-} GstTensorVideoInfo;
-
-/**
- * @brief Internal data structure for audio info to configure tensor.
- */
-typedef struct
-{
-  GstAudioFormat format; /**< audio format */
-  gint ch; /**< channels */
-  gint rate; /**< rate */
-  gint frames; /**< samples per tensor */
-} GstTensorAudioInfo;
-
-/**
- * @brief Internal data structure for text info to configure tensor.
- */
-typedef struct
-{
-  gint format; /**< text format (0:unknown, 1:utf8) */
-  gint size; /**< string length (now it is fixed size GST_TENSOR_STRING_SIZE) */
-  gint frames; /**< number of frames per tensor */
-} GstTensorTextInfo;
-
-/**
- * @brief Internal data structure for configured tensor info.
- */
-typedef struct
-{
-  tensor_type type; /**< Type of each element in the tensor. User must designate this. Otherwise, this is UINT8 for video/x-raw byte stream */
-  tensor_dim dimension; /**< Dimensions. We support up to 4th ranks.  */
+  GstTensorInfo info; /**< tensor info*/
   gint rate_n; /**< framerate is in fraction, which is numerator/denominator */
   gint rate_d; /**< framerate is in fraction, which is numerator/denominator */
 } GstTensorConfig;
+
+/**
+ * @brief Internal data structure for configured tensors info (for other/tensors).
+ */
+typedef struct
+{
+  GstTensorsInfo info; /**< tensor info*/
+  gint rate_n; /**< framerate is in fraction, which is numerator/denominator */
+  gint rate_d; /**< framerate is in fraction, which is numerator/denominator */
+} GstTensorsConfig;
 
 /**
  * @brief String representations for each tensor element type.
@@ -188,88 +162,48 @@ extern media_type
 gst_tensor_media_type_from_structure (const GstStructure * structure);
 
 /**
- * @brief Initialize the video info structure
- * @param v_info video info structure to be initialized
+ * @brief Initialize the tensor info structure
+ * @param info tensor info structure to be initialized
  */
 extern void
-gst_tensor_video_info_init (GstTensorVideoInfo * v_info);
+gst_tensor_info_init (GstTensorInfo * info);
 
 /**
- * @brief Initialize the audio info structure
- * @param a_info audio info structure to be initialized
- */
-extern void
-gst_tensor_audio_info_init (GstTensorAudioInfo * a_info);
-
-/**
- * @brief Initialize the text info structure
- * @param t_info text info structure to be initialized
- */
-extern void
-gst_tensor_text_info_init (GstTensorTextInfo * t_info);
-
-/**
- * @brief Set video info to configure tensor
- * @param v_info video info structure to be filled
- * @param structure caps structure
- * @note Fill frames in GstTensorVideoInfo after calling this function.
- */
-extern void
-gst_tensor_video_info_from_structure (GstTensorVideoInfo * v_info,
-    const GstStructure * structure);
-
-/**
- * @brief Set audio info to configure tensor
- * @param a_info audio info structure to be filled
- * @param structure caps structure
- * @note Fill frames in GstTensorAudioInfo after calling this function.
- */
-extern void
-gst_tensor_audio_info_from_structure (GstTensorAudioInfo * a_info,
-    const GstStructure * structure);
-
-/**
- * @brief Set text info to configure tensor
- * @param t_info text info structure to be filled
- * @param structure caps structure
- * @note Fill size and frames in GstTensorTextInfo after calling this function.
- */
-extern void
-gst_tensor_text_info_from_structure (GstTensorTextInfo * t_info,
-    const GstStructure * structure);
-
-/**
- * @brief Set the video info structure from tensor config
- * @param v_info video info structure to be filled
- * @param config tensor config structure to be interpreted
- * @note We cannot get the exact media info from tensor config, you have to check media info after calling this function.
- * @return TRUE if no error
+ * @brief Check the tensor info is valid
+ * @param info tensor info structure
+ * @return TRUE if info is valid
  */
 extern gboolean
-gst_tensor_video_info_from_config (GstTensorVideoInfo * v_info,
-    const GstTensorConfig * config);
+gst_tensor_info_validate (const GstTensorInfo * info);
 
 /**
- * @brief Set the audio info structure from tensor config
- * @param a_info audio info structure to be filled
- * @param config tensor config structure to be interpreted
- * @note We cannot get the exact media info from tensor config, you have to check media info after calling this function.
- * @return TRUE if no error
+ * @brief Compare tensor info
+ * @param TRUE if equal
  */
 extern gboolean
-gst_tensor_audio_info_from_config (GstTensorAudioInfo * a_info,
-    const GstTensorConfig * config);
+gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2);
 
 /**
- * @brief Set the text info structure from tensor config
- * @param t_info text info structure to be filled
- * @param config tensor config structure to be interpreted
- * @note We cannot get the exact media info from tensor config, you have to check media info after calling this function.
- * @return TRUE if no error
+ * @brief Initialize the tensors info structure
+ * @param info tensors info structure to be initialized
+ */
+extern void
+gst_tensors_info_init (GstTensorsInfo * info);
+
+/**
+ * @brief Check the tensors info is valid
+ * @param info tensors info structure
+ * @return TRUE if info is valid
  */
 extern gboolean
-gst_tensor_text_info_from_config (GstTensorTextInfo * t_info,
-    const GstTensorConfig * config);
+gst_tensors_info_validate (const GstTensorsInfo * info);
+
+/**
+ * @brief Compare tensors info
+ * @param TRUE if equal
+ */
+extern gboolean
+gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2);
 
 /**
  * @brief Initialize the tensor config info structure
@@ -288,14 +222,14 @@ gst_tensor_config_validate (const GstTensorConfig * config);
 
 /**
  * @brief Compare tensor config info
- * @param TRUE if same
+ * @param TRUE if equal
  */
 extern gboolean
-gst_tensor_config_is_same (const GstTensorConfig * c1,
+gst_tensor_config_is_equal (const GstTensorConfig * c1,
     const GstTensorConfig * c2);
 
 /**
- * @brief Parse structure and set tensor config info
+ * @brief Parse structure and set tensor config info (for other/tensor)
  * @param config tensor config structure to be filled
  * @param structure structure to be interpreted
  * @note Change dimention if tensor contains N frames.
@@ -306,45 +240,53 @@ gst_tensor_config_from_structure (GstTensorConfig * config,
     const GstStructure * structure);
 
 /**
- * @brief Set the tensor config structure from video info
- * @param config tensor config structure to be filled
- * @param v_info video info structure to be interpreted
- * @note Change dimention if tensor contains N frames.
- * @return TRUE if supported type
- */
-extern gboolean
-gst_tensor_config_from_video_info (GstTensorConfig * config,
-    const GstTensorVideoInfo * v_info);
-
-/**
- * @brief Set the tensor config structure from audio info
- * @param config tensor config structure to be filled
- * @param a_info audio info structure to be interpreted
- * @note Change dimention if tensor contains N frames.
- * @return TRUE if supported type
- */
-extern gboolean
-gst_tensor_config_from_audio_info (GstTensorConfig * config,
-    const GstTensorAudioInfo * a_info);
-
-/**
- * @brief Set the tensor config structure from text info
- * @param config tensor config structure to be filled
- * @param t_info text info structure to be interpreted
- * @note Change dimention if tensor contains N frames.
- * @return TRUE if supported type
- */
-extern gboolean
-gst_tensor_config_from_text_info (GstTensorConfig * config,
-    const GstTensorTextInfo * t_info);
-
-/**
- * @brief Get tensor caps from tensor config
+ * @brief Get tensor caps from tensor config (for other/tensor)
  * @param config tensor config info
  * @return caps for given config
  */
 extern GstCaps *
 gst_tensor_caps_from_config (const GstTensorConfig * config);
+
+/**
+ * @brief Initialize the tensors config info structure (for other/tensors)
+ * @param config tensors config structure to be initialized
+ */
+extern void
+gst_tensors_config_init (GstTensorsConfig * config);
+
+/**
+ * @brief Check the tensors are all configured (for other/tensors)
+ * @param config tensor config structure
+ * @return TRUE if configured
+ */
+extern gboolean
+gst_tensors_config_validate (const GstTensorsConfig * config);
+
+/**
+ * @brief Compare tensor config info (for other/tensors)
+ * @param TRUE if equal
+ */
+extern gboolean
+gst_tensors_config_is_equal (const GstTensorsConfig * c1,
+    const GstTensorsConfig * c2);
+
+/**
+ * @brief Parse structure and set tensors config (for other/tensors)
+ * @param config tensors config structure to be filled
+ * @param structure structure to be interpreted
+ * @return TRUE if no error
+ */
+extern gboolean
+gst_tensors_config_from_structure (GstTensorsConfig * config,
+    const GstStructure * structure);
+
+/**
+ * @brief Get caps from tensors config (for other/tensors)
+ * @param config tensors config info
+ * @return caps for given config
+ */
+extern GstCaps *
+gst_tensors_caps_from_config (const GstTensorsConfig * config);
 
 /**
  * @brief Determine if we need zero-padding
@@ -374,8 +316,7 @@ extern int find_key_strv (const gchar ** strv, const gchar * key);
  * @param param The parameter string in the format of d1:d2:d3:d4, d1:d2:d3, d1:d2, or d1, where dN is a positive integer and d1 is the innermost dimension; i.e., dim[d4][d3][d2][d1];
  */
 extern int get_tensor_dimension (const gchar * param,
-    uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT],
-    int rank[NNS_TENSOR_SIZE_LIMIT]);
+    uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT]);
 
 /**
  * @brief Count the number of elemnts of a tensor

--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -103,6 +103,7 @@ typedef uint8_t *tensors[NNS_TENSOR_SIZE_LIMIT];     /**< Array of tensors */
 
 /**
  * @brief Internal meta data exchange format for a other/tensors instance
+ * @todo replace this to GstTensorsInfo
  */
 typedef struct
 {
@@ -111,6 +112,24 @@ typedef struct
   tensor_type types[NNS_TENSOR_SIZE_LIMIT];   /**< The list of types for each tensors */
   int ranks[NNS_TENSOR_SIZE_LIMIT];          /**< The list of types for each tensors */
 } GstTensor_TensorsMeta;
+
+/**
+ * @brief Internal data structure for tensor info.
+ */
+typedef struct
+{
+  tensor_type type; /**< Type of each element in the tensor. User must designate this. */
+  tensor_dim dimension; /**< Dimension. We support up to 4th ranks.  */
+} GstTensorInfo;
+
+/**
+ * @brief Internal meta data exchange format for a other/tensors instance
+ */
+typedef struct
+{
+  unsigned int num_tensors; /**< The number of tensors */
+  GstTensorInfo info[NNS_TENSOR_SIZE_LIMIT]; /**< The list of tensor info */
+} GstTensorsInfo;
 
 /**
  * @brief Tensor_Filter's properties (internal data structure)

--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -175,10 +175,8 @@ TEST (common_find_key_strv, key_index)
 TEST (common_get_tensor_dimension, case1)
 {
   uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int rank[NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123:433:177", dim, rank);
+  int num_tensors = get_tensor_dimension ("345:123:433:177", dim);
   EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (rank[0], 4);
   EXPECT_EQ (dim[0][0], 345);
   EXPECT_EQ (dim[0][1], 123);
   EXPECT_EQ (dim[0][2], 433);
@@ -191,10 +189,8 @@ TEST (common_get_tensor_dimension, case1)
 TEST (common_get_tensor_dimension, case2)
 {
   uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int rank[NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123:433", dim, rank);
+  int num_tensors = get_tensor_dimension ("345:123:433", dim);
   EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (rank[0], 3);
   EXPECT_EQ (dim[0][0], 345);
   EXPECT_EQ (dim[0][1], 123);
   EXPECT_EQ (dim[0][2], 433);
@@ -207,10 +203,8 @@ TEST (common_get_tensor_dimension, case2)
 TEST (common_get_tensor_dimension, case3)
 {
   uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int rank[NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123", dim, rank);
+  int num_tensors = get_tensor_dimension ("345:123", dim);
   EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (rank[0], 2);
   EXPECT_EQ (dim[0][0], 345);
   EXPECT_EQ (dim[0][1], 123);
   EXPECT_EQ (dim[0][2], 1);
@@ -223,10 +217,8 @@ TEST (common_get_tensor_dimension, case3)
 TEST (common_get_tensor_dimension, case4)
 {
   uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int rank[NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345", dim, rank);
+  int num_tensors = get_tensor_dimension ("345", dim);
   EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (rank[0], 1);
   EXPECT_EQ (dim[0][0], 345);
   EXPECT_EQ (dim[0][1], 1);
   EXPECT_EQ (dim[0][2], 1);

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -704,11 +704,11 @@ TEST (tensor_stream_test, video_rgb)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 3);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -741,11 +741,11 @@ TEST (tensor_stream_test, video_rgb_padding)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 3);
-  EXPECT_EQ (g_test_data.config.dimension[1], 162);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -778,11 +778,11 @@ TEST (tensor_stream_test, video_rgb_3f)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 3);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 3);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 3);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -815,11 +815,11 @@ TEST (tensor_stream_test, video_bgrx)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 4);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -852,11 +852,11 @@ TEST (tensor_stream_test, video_bgrx_2f)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 4);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 2);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 2);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -889,11 +889,11 @@ TEST (tensor_stream_test, video_gray8)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -926,11 +926,11 @@ TEST (tensor_stream_test, video_gray8_padding)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 162);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -963,11 +963,11 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 162);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 3);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 3);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1000,11 +1000,11 @@ TEST (tensor_stream_test, audio_s8)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 500);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 500);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1037,11 +1037,11 @@ TEST (tensor_stream_test, audio_u8_100F)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 100);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 100);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1074,11 +1074,11 @@ TEST (tensor_stream_test, audio_s16)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 500);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_INT16);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 500);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1111,11 +1111,11 @@ TEST (tensor_stream_test, audio_u16_1000f)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT16);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1000);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT16);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1000);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1151,11 +1151,11 @@ TEST (tensor_stream_test, text_utf8)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1191,11 +1191,11 @@ TEST (tensor_stream_test, text_utf8_3f)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_INT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 3);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_INT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 3);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1233,11 +1233,11 @@ TEST (tensor_stream_test, typecast_int32)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1275,11 +1275,11 @@ TEST (tensor_stream_test, typecast_uint32)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1317,11 +1317,11 @@ TEST (tensor_stream_test, typecast_int16)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1359,11 +1359,11 @@ TEST (tensor_stream_test, typecast_uint16)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1401,11 +1401,11 @@ TEST (tensor_stream_test, typecast_float64)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1443,11 +1443,11 @@ TEST (tensor_stream_test, typecast_float32)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1485,11 +1485,11 @@ TEST (tensor_stream_test, typecast_int64)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1527,11 +1527,11 @@ TEST (tensor_stream_test, typecast_uint64)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, t_type);
-  EXPECT_EQ (g_test_data.config.dimension[0], GST_TENSOR_STRING_SIZE);
-  EXPECT_EQ (g_test_data.config.dimension[1], 1);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, t_type);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 0);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1564,11 +1564,11 @@ TEST (tensor_stream_test, video_aggregate)
 
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.config.dimension[0], 3);
-  EXPECT_EQ (g_test_data.config.dimension[1], 160);
-  EXPECT_EQ (g_test_data.config.dimension[2], 120);
-  EXPECT_EQ (g_test_data.config.dimension[3], 10);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 10);
   EXPECT_EQ (g_test_data.config.rate_n, 30);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1601,11 +1601,11 @@ TEST (tensor_stream_test, audio_aggregate_s16)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 2000);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_INT16);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 2000);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 
@@ -1638,11 +1638,11 @@ TEST (tensor_stream_test, audio_aggregate_u16)
 
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.config));
-  EXPECT_EQ (g_test_data.config.type, _NNS_UINT16);
-  EXPECT_EQ (g_test_data.config.dimension[0], 1);
-  EXPECT_EQ (g_test_data.config.dimension[1], 100);
-  EXPECT_EQ (g_test_data.config.dimension[2], 1);
-  EXPECT_EQ (g_test_data.config.dimension[3], 1);
+  EXPECT_EQ (g_test_data.config.info.type, _NNS_UINT16);
+  EXPECT_EQ (g_test_data.config.info.dimension[0], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[1], 100);
+  EXPECT_EQ (g_test_data.config.info.dimension[2], 1);
+  EXPECT_EQ (g_test_data.config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.config.rate_n, 16000);
   EXPECT_EQ (g_test_data.config.rate_d, 1);
 


### PR DESCRIPTION
prepare multi-tensors (other/tensors)

1. add new structure and functions for tensor info
2. remove dependency of media info
3. remove the rank of tensor dimension

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
