### PR TITLE
[Decoder] Minor style fix (variable types) - @open sesame 09/13 18:10

### DIFF
--- a/gst/tensor_decoder/tensordec.h
+++ b/gst/tensor_decoder/tensordec.h
@@ -61,7 +61,7 @@ struct _GstTensorDec
   gboolean add_padding; /**< If TRUE, zero-padding must be added during transform */
   gboolean silent; /**< True if logging is minimized */
   guint output_type; /**< Denotes the output type */
-  gchar *mode; /** Mode for tensor decoder "direct_video" or "image_labeling" */
+  const gchar *mode; /** Mode for tensor decoder "direct_video" or "image_labeling" */
 
   /** For Tensor */
   gboolean configured; /**< TRUE if already successfully configured tensor metadata */
@@ -83,7 +83,7 @@ struct _GstTensorDecClass
 /**
  * @brief Tensor decoder modes
  */
-gchar *Mode[] = {
+static const gchar *Mode[] = {
   "direct_video",
   "image_labeling"
 };


### PR DESCRIPTION
Let's constify mode names as they are not going to be edited in runtime, but switched between predefined strings only.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
