### PR TITLE
[Filter/Custom] Ensure the loaded private data is stored at the desired position

### DIFF
--- a/gst/tensor_filter/tensor_filter_custom.c
+++ b/gst/tensor_filter/tensor_filter_custom.c
@@ -63,6 +63,7 @@ custom_loadlib (const GstTensor_Filter * filter, void **private_data)
 
   ptr = g_new0 (internal_data, 1);      /* Fill Zero! */
   *private_data = ptr;
+  g_assert (*private_data == filter->privateData);
   ptr->parent = GstTensor_Filter_of_privateData (private_data);
 
   /* Load .so if this is the first time for this instance. */


### PR DESCRIPTION

We check filter->privateData to see if the custom filter (.so) is already loaded or not.
Thus, in order to prevent duplicated filter loading, we need to ensure that
the created private data (*private_data) is stored at the desired location (filter->privateData).

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped
