### PR TITLE
[Filter/Common] prepare multi-tensors

### DIFF
--- a/gst/tensor_filter/tensor_filter.h
+++ b/gst/tensor_filter/tensor_filter.h
@@ -36,52 +36,58 @@
 #include <tensor_common.h>
 
 G_BEGIN_DECLS
-/* #defines don't like whitespacey bits */
+
 #define GST_TYPE_TENSOR_FILTER \
   (gst_tensor_filter_get_type())
 #define GST_TENSOR_FILTER(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_FILTER,GstTensor_Filter))
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_FILTER,GstTensorFilter))
 #define GST_TENSOR_FILTER_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_FILTER,GstTensor_FilterClass))
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_FILTER,GstTensorFilterClass))
 #define GST_IS_TENSOR_FILTER(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_FILTER))
 #define GST_IS_TENSOR_FILTER_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_FILTER))
-#define GST_TENSOR_FILTER_CAST(obj)  ((GstTensor_Filter *)(obj))
-typedef struct _GstTensor_Filter GstTensor_Filter;
+#define GST_TENSOR_FILTER_CAST(obj)  ((GstTensorFilter *)(obj))
 
-typedef struct _GstTensor_FilterClass GstTensor_FilterClass;
+typedef struct _GstTensorFilter GstTensorFilter;
+typedef struct _GstTensorFilterClass GstTensorFilterClass;
 
 extern const char *nnfw_names[];
 
 /**
  * @brief Internal data structure for tensor_filter instances.
  */
-struct _GstTensor_Filter
+struct _GstTensorFilter
 {
   GstBaseTransform element;     /**< This is the parent object */
 
   void *privateData; /**< NNFW plugin's private data is stored here */
+  GstTensorFilterProperties prop; /**< NNFW plugin's properties */
 
-  GstTensor_Filter_Properties prop;
+  /** internal properties for tensor-filter */
+  int silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
+  gboolean configured; /**< True if already successfully configured tensor metadata */
+  GstTensorsConfig in_config; /**< input tensor info */
+  GstTensorsConfig out_config; /**< output tensor info */
 };
 
-/** @brief Location of GstTensor_Filter from privateData
- *  @param p the "privateData" pointer of GstTensor_Filter
- *  @return the pointer to GstTensor_Filter containing p as privateData
+/**
+ * @brief Location of GstTensorFilter from privateData
+ * @param p the "privateData" pointer of GstTensorFilter
+ * @return the pointer to GstTensorFilter containing p as privateData
  */
-#define GstTensor_Filter_of_privateData(p) ({ \
+#define GstTensorFilter_of_privateData(p) ({ \
     const void **__mptr = (const void **)(p); \
-    (GstTensor_Filter *)( (char *)__mptr - offsetof(GstTensor_Filter, privateData) );})
+    (GstTensorFilter *)( (char *)__mptr - offsetof(GstTensorFilter, privateData) );})
 
 /**
- * @brief GstTensor_FilterClass inherits GstBaseTransformClass.
+ * @brief GstTensorFilterClass inherits GstBaseTransformClass.
  *
  * Referring another child (sibiling), GstVideoFilter (abstract class) and
  * its child (concrete class) GstVideoConverter.
- * Note that GstTensor_FilterClass is a concrete class; thus we need to look at both.
+ * Note that GstTensorFilterClass is a concrete class; thus we need to look at both.
  */
-struct _GstTensor_FilterClass
+struct _GstTensorFilterClass
 {
   GstBaseTransformClass parent_class;   /**< Inherits GstBaseTransformClass */
 };
@@ -98,13 +104,13 @@ GType gst_tensor_filter_get_type (void);
  * filter Filter properties. Read Only
  * private_data Subplugin's private data. Set this (*private_data = XXX) if you want to change filter->private_data
  */
-struct _GstTensor_Filter_Framework
+struct _GstTensorFilterFramework
 {
   gchar *name; /**< Name of the neural network framework, searchable by FRAMEWORK property */
   gboolean allow_in_place; /**< TRUE if InPlace transfer of input-to-output is allowed. Not supported in main, yet */
   gboolean allocate_in_invoke; /**< TRUE if invoke_NN is going to allocate outputptr by itself and return the address via outputptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
 
-  uint8_t *(*invoke_NN) (const GstTensor_Filter * filter, void **private_data,
+  uint8_t *(*invoke_NN) (const GstTensorFilter * filter, void **private_data,
       const uint8_t * inputptr, uint8_t * outputptr);
       /**< Mandatory callback. Invoke the given network model.
        *
@@ -115,34 +121,33 @@ struct _GstTensor_Filter_Framework
        * @return outputptr if allocate_in_invoke = 00 if OK. non-zero if error.
        */
 
-  int (*getInputDimension) (const GstTensor_Filter * filter,
-      void **private_data, GstTensor_TensorsMeta * meta);
+  int (*getInputDimension) (const GstTensorFilter * filter,
+      void **private_data, GstTensorsInfo * info);
       /**< Optional. Set NULL if not supported. Get dimension of input tensor
        * If getInputDimension is NULL, setInputDimension must be defined.
        * If getInputDimension is defined, it is recommended to define getOutputDimension
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer.
-       * @param[out] inputDimension dimension of input tensor (return value)
-       * @param[out] type type of input tensor element (return value)
+       * @param[out] info structure of tensor info (return value)
        * @return the size of input tensors
        */
-  int (*getOutputDimension) (const GstTensor_Filter * filter,
-      void **private_data, GstTensor_TensorsMeta * meta);
+
+  int (*getOutputDimension) (const GstTensorFilter * filter,
+      void **private_data, GstTensorsInfo * info);
       /**< Optional. Set NULL if not supported. Get dimension of output tensor
        * If getInputDimension is NULL, setInputDimension must be defined.
        * If getInputDimension is defined, it is recommended to define getOutputDimension
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer.
-       * @param[out] outputDimension dimension of output tensor (return value)
-       * @param[out] type type of output tensor element (return value)
+       * @param[out] info structure of tensor info (return value)
        * @return the size of output tensors
        */
-  int (*setInputDimension) (const GstTensor_Filter * filter,
-      void **private_data, const tensor_dim inputDimension,
-      const tensor_type inputType, tensor_dim outputDimension,
-      tensor_type * outputType);
+
+  int (*setInputDimension) (const GstTensorFilter * filter,
+      void **private_data, const GstTensorsInfo * in_info,
+      GstTensorsInfo * out_info);
       /**< Optional. Set Null if not supported. Tensor_filter::main will
        * configure input dimension from pad-cap in run-time for the sub-plugin.
        * Then, the sub-plugin is required to return corresponding output dimension
@@ -154,20 +159,19 @@ struct _GstTensor_Filter_Framework
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer.
-       * @param[in] inputDimension dimension of input tensor
-       * @param[in] inputType type of input tensor element
-       * @param[out] outputDimension dimension of output tensor (return value)
-       * @param[out] outputType type of output tensor element (return value)
+       * @param[in] in_info structure of input tensor info
+       * @param[out] out_info structure of output tensor info (return value)
        * @return 0 if OK. non-zero if error.
        */
 
-  void (*open) (const GstTensor_Filter * filter, void **private_data);
+  void (*open) (const GstTensorFilter * filter, void **private_data);
       /**< Optional. tensor_filter.c will call this before any of other callbacks and will call once before calling close
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, open() allocates memory for private_data.
        */
-  void (*close) (const GstTensor_Filter * filter, void **private_data);
+
+  void (*close) (const GstTensorFilter * filter, void **private_data);
       /**< Optional. tensor_filter.c will not call other callbacks after calling close. Free-ing private_data is this function's responsibility. Set NULL after that.
        *
        * @param[in] filter "this" pointer. Use this to read property values
@@ -175,11 +179,12 @@ struct _GstTensor_Filter_Framework
        */
 };
 
-extern GstTensor_Filter_Framework NNS_support_tensorflow_lite;
-extern GstTensor_Filter_Framework NNS_support_tensorflow;
-extern GstTensor_Filter_Framework NNS_support_custom;
+extern GstTensorFilterFramework NNS_support_tensorflow_lite;
+extern GstTensorFilterFramework NNS_support_tensorflow;
+extern GstTensorFilterFramework NNS_support_custom;
 
-extern GstTensor_Filter_Framework *tensor_filter_supported[];
+extern GstTensorFilterFramework *tensor_filter_supported[];
 
 G_END_DECLS
+
 #endif /* __GST_TENSOR_FILTER_H__ */

--- a/gst/tensor_filter/tensor_filter_tensorflow.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow.c
@@ -23,7 +23,7 @@
  * @bug		No known bugs except for NYI items
  *
  * This is the per-NN-framework plugin (tensorflow) for tensor_filter.
- * Fill in "GstTensor_Filter_Framework" for tensor_filter.h/c
+ * Fill in "GstTensorFilterFramework" for tensor_filter.h/c
  *
  */
 
@@ -47,16 +47,16 @@ typedef struct _Tf_data tf_data;
  * @return 0 if successfully loaded. 1 if skipped (already loaded). -1 if error
  */
 static int
-tf_loadModelFile (const GstTensor_Filter * filter, void **private_data)
+tf_loadModelFile (const GstTensorFilter * filter, void **private_data)
 {
   tf_data *tf;
   if (filter->privateData != NULL) {
-    /** @todo : Check the integrity of filter->data and filter->modelFilename, nnfw */
+    /** @todo : Check the integrity of filter->data and filter->model_file, nnfw */
     return 1;
   }
   tf = g_new0 (tf_data, 1); /** initialize tf Fill Zero! */
   *private_data = tf;
-  tf->tf_private_data = tf_core_new (filter->prop.modelFilename);
+  tf->tf_private_data = tf_core_new (filter->prop.model_file);
   if (tf->tf_private_data) {
     return 0;
   } else {
@@ -65,24 +65,24 @@ tf_loadModelFile (const GstTensor_Filter * filter, void **private_data)
 }
 
 /**
- * @brief The open callback for GstTensor_Filter_Framework. Called before anything else
+ * @brief The open callback for GstTensorFilterFramework. Called before anything else
  * @param filter : tensor_filter instance
  * @param private_data : tensorflow lite plugin's private data
  */
 static void
-tf_open (const GstTensor_Filter * filter, void **private_data)
+tf_open (const GstTensorFilter * filter, void **private_data)
 {
   int retval = tf_loadModelFile (filter, private_data);
   g_assert (retval == 0);       /** This must be called only once */
 }
 
 /**
- * @brief The mandatory callback for GstTensor_Filter_Framework
+ * @brief The mandatory callback for GstTensorFilterFramework
  * @param[in] inptr The input tensor
  * @param[out] outptr The output tensor
  */
 static uint8_t *
-tf_invoke (const GstTensor_Filter * filter, void **private_data,
+tf_invoke (const GstTensorFilter * filter, void **private_data,
     const uint8_t * inptr, uint8_t * outptr)
 {
   int retval;
@@ -98,11 +98,11 @@ tf_invoke (const GstTensor_Filter * filter, void **private_data,
 }
 
 /**
- * @brief The optional callback for GstTensor_Filter_Framework
+ * @brief The optional callback for GstTensorFilterFramework
  */
 static int
-tf_getInputDim (const GstTensor_Filter * filter, void **private_data,
-    GstTensor_TensorsMeta * meta)
+tf_getInputDim (const GstTensorFilter * filter, void **private_data,
+    GstTensorsInfo * info)
 {
   int temp_idx = 0;
   tf_data *tf;
@@ -113,16 +113,15 @@ tf_getInputDim (const GstTensor_Filter * filter, void **private_data,
   else
     temp_idx = 0;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  return tf_core_getInputDim (tf->tf_private_data, meta->dims[0],
-      &meta->types[0], &meta->num_tensors);
+  return tf_core_getInputDim (tf->tf_private_data, info);
 }
 
 /**
- * @brief The optional callback for GstTensor_Filter_Framework
+ * @brief The optional callback for GstTensorFilterFramework
  */
 static int
-tf_getOutputDim (const GstTensor_Filter * filter, void **private_data,
-    GstTensor_TensorsMeta * meta)
+tf_getOutputDim (const GstTensorFilter * filter, void **private_data,
+    GstTensorsInfo * info)
 {
   int temp_idx = 0;
   tf_data *tf;
@@ -133,17 +132,15 @@ tf_getOutputDim (const GstTensor_Filter * filter, void **private_data,
   else
     temp_idx = 0;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  return tf_core_getOutputDim (tf->tf_private_data, meta->dims[0],
-      &meta->types[0], &meta->num_tensors);
+  return tf_core_getOutputDim (tf->tf_private_data, info);
 }
 
 /**
- * @brief The set-input-dim callback for GstTensor_Filter_Framework
+ * @brief The set-input-dim callback for GstTensorFilterFramework
  */
 static int
-tf_setInputDim (const GstTensor_Filter * filter, void **private_data,
-    const tensor_dim iDimension, const tensor_type iType,
-    tensor_dim oDimension, tensor_type * oType)
+tf_setInputDim (const GstTensorFilter * filter, void **private_data,
+    const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   /** @todo call tflite core apis */
   return 0;                     /** NYI */
@@ -153,7 +150,7 @@ tf_setInputDim (const GstTensor_Filter * filter, void **private_data,
  * @brief Free privateData and move on.
  */
 static void
-tf_close (const GstTensor_Filter * filter, void **private_data)
+tf_close (const GstTensorFilter * filter, void **private_data)
 {
   tf_data *tf;
   tf = *private_data;
@@ -163,7 +160,7 @@ tf_close (const GstTensor_Filter * filter, void **private_data)
   g_assert (filter->privateData == NULL);
 }
 
-GstTensor_Filter_Framework NNS_support_tensorflow = {
+GstTensorFilterFramework NNS_support_tensorflow = {
   .name = "tensorflow",
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = TRUE,

--- a/gst/tensor_filter/tensor_filter_tensorflow_core.cc
+++ b/gst/tensor_filter/tensor_filter_tensorflow_core.cc
@@ -102,32 +102,30 @@ TFCore::getTensorType (int tensor_idx, tensor_type * type)
 
 /**
  * @brief	return the Dimension of Input Tensor.
- * @param idx	: the index of the input tensor
- * @param[out] dim	: the array of the input tensor
- * @param[out] type	: the data type of the input tensor
+ * @param[out] info Structure for tensor info.
  * @return 0 if OK. non-zero if error.
  */
 int
-TFCore::getInputTensorDim (tensor_dim dim, tensor_type * type,
-    unsigned int *num_tensors)
+TFCore::getInputTensorDim (GstTensorsInfo * info)
 {
-  int ret = getTensorDim (dim, type);
-  return ret;
+  /**
+   * @todo fill here
+   */
+  return 0;
 }
 
 /**
  * @brief	return the Dimension of Output Tensor.
- * @param idx	: the index of the output tensor
- * @param[out] dim	: the array of the output tensor
- * @param[out] type	: the data type of the output tensor
+ * @param[out] info Structure for tensor info.
  * @return 0 if OK. non-zero if error.
  */
 int
-TFCore::getOutputTensorDim (tensor_dim dim, tensor_type * type,
-    unsigned int *num_tensors)
+TFCore::getOutputTensorDim (GstTensorsInfo * info)
 {
-  int ret = getTensorDim (dim, type);
-  return ret;
+  /**
+   * @todo fill here
+   */
+  return 0;
 }
 
 /**
@@ -208,34 +206,28 @@ tf_core_getModelPath (void *tf)
 
 /**
  * @brief	get the Dimension of Input Tensor of model
- * @param	tf	: the class object
- * @param idx	: the index of the input tensor
- * @param[out] dim	: the array of the input tensor
- * @param[out] type	: the data type of the input tensor
+ * @param	tf	the class object
+ * @param[out] info Structure for tensor info.
  * @return 0 if OK. non-zero if error.
  */
 int
-tf_core_getInputDim (void *tf, tensor_dim dim, tensor_type * type,
-    unsigned int *num_tensors)
+tf_core_getInputDim (void *tf, GstTensorsInfo * info)
 {
   TFCore *c = (TFCore *) tf;
-  return c->getInputTensorDim (dim, type, num_tensors);
+  return c->getInputTensorDim (info);
 }
 
 /**
  * @brief	get the Dimension of Output Tensor of model
- * @param	tf	: the class object
- * @param idx	: the index of the output tensor
- * @param[out] dim	: the array of the output tensor
- * @param[out] type	: the data type of the output tensor
+ * @param	tf	the class object
+ * @param[out] info Structure for tensor info.
  * @return 0 if OK. non-zero if error.
  */
 int
-tf_core_getOutputDim (void *tf, tensor_dim dim, tensor_type * type,
-    unsigned int *num_tensors)
+tf_core_getOutputDim (void *tf, GstTensorsInfo * info)
 {
   TFCore *c = (TFCore *) tf;
-  return c->getOutputTensorDim (dim, type, num_tensors);
+  return c->getOutputTensorDim (info);
 }
 
 /**

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -23,7 +23,7 @@
  * @bug		No known bugs except for NYI items
  *
  * This is the per-NN-framework plugin (tensorflow-lite) for tensor_filter.
- * Fill in "GstTensor_Filter_Framework" for tensor_filter.h/c
+ * Fill in "GstTensorFilterFramework" for tensor_filter.h/c
  *
  */
 
@@ -47,16 +47,16 @@ typedef struct _Tflite_data tflite_data;
  * @return 0 if successfully loaded. 1 if skipped (already loaded). -1 if error
  */
 static int
-tflite_loadModelFile (const GstTensor_Filter * filter, void **private_data)
+tflite_loadModelFile (const GstTensorFilter * filter, void **private_data)
 {
   tflite_data *tf;
   if (filter->privateData != NULL) {
-    /** @todo : Check the integrity of filter->data and filter->modelFilename, nnfw */
+    /** @todo : Check the integrity of filter->data and filter->model_file, nnfw */
     return 1;
   }
   tf = g_new0 (tflite_data, 1); /** initialize tf Fill Zero! */
   *private_data = tf;
-  tf->tflite_private_data = tflite_core_new (filter->prop.modelFilename);
+  tf->tflite_private_data = tflite_core_new (filter->prop.model_file);
   if (tf->tflite_private_data) {
     return 0;
   } else {
@@ -65,24 +65,24 @@ tflite_loadModelFile (const GstTensor_Filter * filter, void **private_data)
 }
 
 /**
- * @brief The open callback for GstTensor_Filter_Framework. Called before anything else
+ * @brief The open callback for GstTensorFilterFramework. Called before anything else
  * @param filter : tensor_filter instance
  * @param private_data : tensorflow lite plugin's private data
  */
 static void
-tflite_open (const GstTensor_Filter * filter, void **private_data)
+tflite_open (const GstTensorFilter * filter, void **private_data)
 {
   int retval = tflite_loadModelFile (filter, private_data);
   g_assert (retval == 0);       /** This must be called only once */
 }
 
 /**
- * @brief The mandatory callback for GstTensor_Filter_Framework
+ * @brief The mandatory callback for GstTensorFilterFramework
  * @param[in] inptr The input tensor
  * @param[out] outptr The output tensor
  */
 static uint8_t *
-tflite_invoke (const GstTensor_Filter * filter, void **private_data,
+tflite_invoke (const GstTensorFilter * filter, void **private_data,
     const uint8_t * inptr, uint8_t * outptr)
 {
   int retval;
@@ -98,40 +98,39 @@ tflite_invoke (const GstTensor_Filter * filter, void **private_data,
 }
 
 /**
- * @brief The optional callback for GstTensor_Filter_Framework
+ * @brief The optional callback for GstTensorFilterFramework
  */
 static int
-tflite_getInputDim (const GstTensor_Filter * filter, void **private_data,
-    GstTensor_TensorsMeta * meta)
+tflite_getInputDim (const GstTensorFilter * filter, void **private_data,
+    GstTensorsInfo * info)
 {
   tflite_data *tf;
   tf = *private_data;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  int ret = tflite_core_getInputDim (tf->tflite_private_data, meta);
+  int ret = tflite_core_getInputDim (tf->tflite_private_data, info);
   return ret;
 }
 
 /**
- * @brief The optional callback for GstTensor_Filter_Framework
+ * @brief The optional callback for GstTensorFilterFramework
  */
 static int
-tflite_getOutputDim (const GstTensor_Filter * filter, void **private_data,
-    GstTensor_TensorsMeta * meta)
+tflite_getOutputDim (const GstTensorFilter * filter, void **private_data,
+    GstTensorsInfo * info)
 {
   tflite_data *tf;
   tf = *private_data;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  int ret = tflite_core_getOutputDim (tf->tflite_private_data, meta);
+  int ret = tflite_core_getOutputDim (tf->tflite_private_data, info);
   return ret;
 }
 
 /**
- * @brief The set-input-dim callback for GstTensor_Filter_Framework
+ * @brief The set-input-dim callback for GstTensorFilterFramework
  */
 static int
-tflite_setInputDim (const GstTensor_Filter * filter, void **private_data,
-    const tensor_dim iDimension, const tensor_type iType,
-    tensor_dim oDimension, tensor_type * oType)
+tflite_setInputDim (const GstTensorFilter * filter, void **private_data,
+    const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   /** @todo call tflite core apis */
   return 0;                     /** NYI */
@@ -141,7 +140,7 @@ tflite_setInputDim (const GstTensor_Filter * filter, void **private_data,
  * @brief Free privateData and move on.
  */
 static void
-tflite_close (const GstTensor_Filter * filter, void **private_data)
+tflite_close (const GstTensorFilter * filter, void **private_data)
 {
   tflite_data *tf;
   tf = *private_data;
@@ -151,7 +150,7 @@ tflite_close (const GstTensor_Filter * filter, void **private_data)
   g_assert (filter->privateData == NULL);
 }
 
-GstTensor_Filter_Framework NNS_support_tensorflow_lite = {
+GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .name = "tensorflow-lite",
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = TRUE,

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -312,11 +312,19 @@ extern int find_key_strv (const gchar ** strv, const gchar * key);
 
 /**
  * @brief Parse tensor dimension parameter string
- * @return The Rank.
- * @param param The parameter string in the format of d1:d2:d3:d4, d1:d2:d3, d1:d2, or d1, where dN is a positive integer and d1 is the innermost dimension; i.e., dim[d4][d3][d2][d1];
+ * @return The Rank. 0 if error.
+ * @param dimstr The dimension string in the format of d1:d2:d3:d4, d1:d2:d3, d1:d2, or d1, where dN is a positive integer and d1 is the innermost dimension; i.e., dim[d4][d3][d2][d1];
+ * @param dim dimension to be filled.
  */
-extern int get_tensor_dimension (const gchar * param,
-    uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT]);
+extern int get_tensor_dimension (const gchar * dimstr, tensor_dim dim);
+
+/**
+ * @brief Get dimension string from given tensor dimension.
+ * @param dim tensor dimension
+ * @return Formatted string of given dimension (d1:d2:d3:d4).
+ * @note The returned value should be freed with g_free()
+ */
+extern gchar *get_tensor_dimension_string (const tensor_dim dim);
 
 /**
  * @brief Count the number of elemnts of a tensor
@@ -350,18 +358,6 @@ get_tensor_from_structure (const GstStructure * str, tensor_dim dim,
 extern GstTensor_Filter_CheckStatus
 get_tensor_from_padcap (const GstCaps * caps, tensor_dim dim,
     tensor_type * type, int *framerate_num, int *framerate_denum);
-
-/**
- * @brief Read GstStructure, return corresponding tensor-dim/type. (other/tensor)
- * @return The number of tensors.
- * @param[in] str the GstStructure to be interpreted.
- * @param[out] meta An allocated but filled with Null meta, to be used as output.
- * @param[out] framerate_num Numerator of framerate. Set null to not use this.
- * @param[out] framerate_denum Denumerator of framerate. Set null to not use this.
- */
-extern int
-get_tensors_from_structure (const GstStructure * str,
-    GstTensor_TensorsMeta * meta, int *framerate_num, int *framerate_denum);
 
 /**
  * @brief Make str(xyz) ==> "xyz" with macro expansion

--- a/include/tensor_filter_custom.h
+++ b/include/tensor_filter_custom.h
@@ -43,80 +43,77 @@
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
  * @return The returned pointer will be passed to other functions as "private_data".
  */
-typedef void *(*NNS_custom_init_func)(const GstTensor_Filter_Properties *prop);
+typedef void *(*NNS_custom_init_func) (const GstTensorFilterProperties * prop);
 
 /**
  * @brief A function that is called after calling other functions, when it's ready to close.
  * @param[in] private_data If you have allocated *private_data at init, free it here.
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
  */
-typedef void (*NNS_custom_exit_func)(void *private_data, const GstTensor_Filter_Properties *prop);
+typedef void (*NNS_custom_exit_func) (void *private_data,
+    const GstTensorFilterProperties * prop);
 
 /**
  * @brief Get input tensor type.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[out] inputDimension uint32_t[NNS_TENSOR_RANK_LIMIT] (tensor_dim)
- * @param[out] type Type of each element in the input tensor
+ * @param[out] info Structure for tensor info.
  */
 typedef int (*NNS_custom_get_input_dimension) (void *private_data,
-    const GstTensor_Filter_Properties * prop, GstTensor_TensorsMeta * meta);
+    const GstTensorFilterProperties * prop, GstTensorsInfo * info);
 
 /**
  * @brief Get output tensor type.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[out] outputDimension uint32_t[NNS_TENSOR_RANK_LIMIT] (tensor_dim)
- * @param[out] type Type of each element in the output tensor
+ * @param[out] info Structure for tensor info.
  */
 typedef int (*NNS_custom_get_output_dimension) (void *private_data,
-    const GstTensor_Filter_Properties * prop, GstTensor_TensorsMeta * meta);
+    const GstTensorFilterProperties * prop, GstTensorsInfo * info);
 
 /**
  * @brief Set input dim by framework. Let custom plutin set output dim accordingly.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[in] inputDimension Input dimension designated by the gstreamer framework. Note that this is not a fixed value and gstreamer may try different values during pad-cap negotiations.
- * @param[in] inputType Input element type designated by the gstreamer framework.
- * @param[out] outputDimension Output dimension according to the inputDimension/type.
- * @param[out] outputType Output element type according to the inputDimension/type.
+ * @param[in] in_info Input tensor info designated by the gstreamer framework. Note that this is not a fixed value and gstreamer may try different values during pad-cap negotiations.
+ * @param[out] out_info Output tensor info according to the input tensor info.
  *
  * @caution Do not fix internal values based on this call. Gstreamer may call
  * this function repeatedly with different values during pad-cap negotiations.
  * Fix values when invoke is finally called.
  */
-typedef int (*NNS_custom_set_input_dimension)(void *private_data, const GstTensor_Filter_Properties *prop,
-    const tensor_dim inputDimension, const tensor_type inputType,
-    tensor_dim outputDimension, tensor_type *outputType);
+typedef int (*NNS_custom_set_input_dimension) (void *private_data,
+    const GstTensorFilterProperties * prop, const GstTensorsInfo * in_info, GstTensorsInfo * out_info);
 
 /**
  * @brief Invoke the "main function". Without allocating output buffer. (fill in the given output buffer)
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[in] inputPtr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
- * @param[out] outputPtr pointer to output tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[in] inptr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[out] outptr pointer to output tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
  * @return 0 if success
  */
-typedef int (*NNS_custom_invoke)(void *private_data, const GstTensor_Filter_Properties *prop,
-    const uint8_t *inputPtr, uint8_t *outputPtr);
+typedef int (*NNS_custom_invoke) (void *private_data,
+    const GstTensorFilterProperties * prop, const uint8_t * inptr, uint8_t * outptr);
 
 /**
  * @brief Invoke the "main function". Without allocating output buffer. (fill in the given output buffer)
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
  * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[in] inputPtr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[in] inptr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
  * @param[out] size The allocated size.
  * @return The output buffer allocated in the invoke function
  */
-typedef uint8_t * (*NNS_custom_allocate_invoke)(void *private_data, const GstTensor_Filter_Properties *prop,
-    const uint8_t *inputPtr, size_t *size);
+typedef uint8_t *(*NNS_custom_allocate_invoke) (void *private_data,
+    const GstTensorFilterProperties * prop, const uint8_t * inptr, size_t * size);
 
 /**
  * @brief Custom Filter Class
  *
  * Note that exery function pointer is MANDATORY!
  */
-struct _NNStreamer_custom_class {
+struct _NNStreamer_custom_class
+{
   int allocate_outbuf_in_invoke; /**< Set non-zero if invoke function is to allocate output buffer. Note that the allocated outbuf size MUST be consistent with output tensor dimension & type */
   NNS_custom_init_func initfunc; /**< called before any other callbacks from tensor_filter_custom.c */
   NNS_custom_exit_func exitfunc; /**< will not call other callbacks after this call */

--- a/include/tensor_filter_tensorflow_core.h
+++ b/include/tensor_filter_tensorflow_core.h
@@ -64,10 +64,8 @@ public:
   double get_ms (struct timeval t);
   int getInputTensorSize ();
   int getOutputTensorSize ();
-  int getInputTensorDim (tensor_dim dim, tensor_type * type,
-      unsigned int *num_tensors);
-  int getOutputTensorDim (tensor_dim dim, tensor_type * type,
-      unsigned int *num_tensors);
+  int getInputTensorDim (GstTensorsInfo * info);
+  int getOutputTensorDim (GstTensorsInfo * info);
   int getInputTensorDimSize ();
   int getOutputTensorDimSize ();
   int invoke (uint8_t * inptr, uint8_t ** outptr);
@@ -95,10 +93,8 @@ extern "C"
   extern void *tf_core_new (const char *_model_path);
   extern void tf_core_delete (void *tf);
   extern const char *tf_core_getModelPath (void *tf);
-  extern int tf_core_getInputDim (void *tf, tensor_dim dim,
-      tensor_type * type, unsigned int *num_tensors);
-  extern int tf_core_getOutputDim (void *tf, tensor_dim dim,
-      tensor_type * type, unsigned int *num_tensors);
+  extern int tf_core_getInputDim (void *tf, GstTensorsInfo * info);
+  extern int tf_core_getOutputDim (void *tf, GstTensorsInfo * info);
   extern int tf_core_getInputSize (void *tf);
   extern int tf_core_getOutputSize (void *tf);
   extern int tf_core_invoke (void *tf, uint8_t * inptr, uint8_t ** outptr);

--- a/include/tensor_filter_tensorflow_lite_core.h
+++ b/include/tensor_filter_tensorflow_lite_core.h
@@ -49,8 +49,8 @@ public:
   int setOutputTensorProp ();
   int getInputTensorSize ();
   int getOutputTensorSize ();
-  int getInputTensorDim (GstTensor_TensorsMeta * meta);
-  int getOutputTensorDim (GstTensor_TensorsMeta * meta);
+  int getInputTensorDim (GstTensorsInfo * info);
+  int getOutputTensorDim (GstTensorsInfo * info);
   int invoke (uint8_t * inptr, uint8_t ** outptr);
 
 private:
@@ -60,15 +60,15 @@ private:
   tensors inputTensors; /**< The list of input tensors */
   tensors outputTensors; /**< The list of output tensors */
 
-  GstTensor_TensorsMeta inputTensorMeta;  /**< The meta of input tensors */
-  GstTensor_TensorsMeta outputTensorMeta;  /**< The meta of input tensors */
+  GstTensorsInfo inputTensorMeta;  /**< The meta of input tensors */
+  GstTensorsInfo outputTensorMeta;  /**< The meta of input tensors */
 
   std::unique_ptr < tflite::Interpreter > interpreter;
   std::unique_ptr < tflite::FlatBufferModel > model;
 
   double get_ms (struct timeval t);
   _nns_tensor_type getTensorType (TfLiteType tfType);
-  int getTensorDim (int tensor_idx, tensor_dim dim, int *rank);
+  int getTensorDim (int tensor_idx, tensor_dim dim);
 };
 
 /**
@@ -82,9 +82,9 @@ extern "C"
   extern void tflite_core_delete (void *tflite);
   extern const char *tflite_core_getModelPath (void *tflite);
   extern int tflite_core_getInputDim (void *tflite,
-      GstTensor_TensorsMeta * meta);
+      GstTensorsInfo * info);
   extern int tflite_core_getOutputDim (void *tflite,
-      GstTensor_TensorsMeta * meta);
+      GstTensorsInfo * info);
   extern int tflite_core_getOutputSize (void *tflite);
   extern int tflite_core_getInputSize (void *tflite);
   extern int tflite_core_invoke (void *tflite, uint8_t * inptr,

--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -84,8 +84,8 @@ typedef enum _nnfw_type {
   _T_F_NNFW_END,
 } nnfw_type;
 
-struct _GstTensor_Filter_Framework;
-typedef struct _GstTensor_Filter_Framework GstTensor_Filter_Framework;
+struct _GstTensorFilterFramework;
+typedef struct _GstTensorFilterFramework GstTensorFilterFramework;
 
 typedef enum {
   _TFC_INIT = 0,
@@ -100,18 +100,6 @@ typedef enum {
 
 typedef uint32_t tensor_dim[NNS_TENSOR_RANK_LIMIT];
 typedef uint8_t *tensors[NNS_TENSOR_SIZE_LIMIT];     /**< Array of tensors */
-
-/**
- * @brief Internal meta data exchange format for a other/tensors instance
- * @todo replace this to GstTensorsInfo
- */
-typedef struct
-{
-  unsigned int num_tensors;    /**< The number of tensors */
-  tensor_dim dims[NNS_TENSOR_SIZE_LIMIT];     /**< The list of dimensions of each tensors */
-  tensor_type types[NNS_TENSOR_SIZE_LIMIT];   /**< The list of types for each tensors */
-  int ranks[NNS_TENSOR_SIZE_LIMIT];          /**< The list of types for each tensors */
-} GstTensor_TensorsMeta;
 
 /**
  * @brief Internal data structure for tensor info.
@@ -132,29 +120,25 @@ typedef struct
 } GstTensorsInfo;
 
 /**
- * @brief Tensor_Filter's properties (internal data structure)
+ * @brief Tensor_Filter's properties for NN framework (internal data structure)
  *
  * Because custom filters of tensor_filter may need to access internal data
  * of Tensor_Filter, we define this data structure here.
  */
-typedef struct _GstTensor_Filter_Properties
+typedef struct _GstTensorFilterProperties
 {
-  int silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
-  GstTensor_Filter_CheckStatus inputConfigured; /**< input dimension status */
-  GstTensor_Filter_CheckStatus outputConfigured; /**< output dimension status */
   nnfw_type nnfw; /**< The enum value of corresponding NNFW. _T_F_UNDEFINED if not configured */
-  GstTensor_Filter_Framework *fw; /**< The implementation core of the NNFW. NULL if not configured */
-  int fwOpened; /**< true IF open() is called or tried. Use int instead of gboolean because this is refered by custom plugins. */
-  int fwClosed; /**< true IF close() is called or tried. Use int instead of gboolean because this is refered by custom plugins. */
-  const char *modelFilename; /**< Filepath to the model file (as an argument for NNFW). char instead of gchar for non-glib custom plugins */
+  GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
+  int fw_opened; /**< TRUE IF open() is called or tried. Use int instead of gboolean because this is refered by custom plugins. */
+  const char *model_file; /**< Filepath to the model file (as an argument for NNFW). char instead of gchar for non-glib custom plugins */
 
-  int inputCapNegotiated; /**< @todo check if this is really needed */
-  GstTensor_TensorsMeta inputMeta;
+  int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
+  GstTensorsInfo input_meta; /**< configured input tensor info */
 
-  int outputCapNegotiated; /**< @todo check if this is really needed */
-  GstTensor_TensorsMeta outputMeta;
+  int output_configured; /**< TRUE if output tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
+  GstTensorsInfo output_meta; /**< configured output tensor info */
 
-  const char *customProperties; /**< sub-plugin specific custom property values in string */
-} GstTensor_Filter_Properties;
+  const char *custom_properties; /**< sub-plugin specific custom property values in string */
+} GstTensorFilterProperties;
 
 #endif /*__GST_TENSOR_TYPEDEF_H__*/

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
@@ -37,7 +37,7 @@ typedef struct _pt_data
  * @brief _pt_data
  */
 static void *
-pt_init (const GstTensor_Filter_Properties * prop)
+pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
   int i;
@@ -57,7 +57,7 @@ pt_init (const GstTensor_Filter_Properties * prop)
  * @brief _pt_data
  */
 static void
-pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
+pt_exit (void *private_data, const GstTensorFilterProperties * prop)
 {
   pt_data *data = private_data;
   g_assert (data);
@@ -68,21 +68,22 @@ pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
  * @brief _pt_data
  */
 static int
-get_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
-    GstTensor_TensorsMeta * meta)
+get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
+    GstTensorsInfo * info)
 {
   pt_data *data = private_data;
   int i;
 
   g_assert (data);
   g_assert (NNS_TENSOR_RANK_LIMIT >= 3);
-  meta->dims[0][0] = D1;
-  meta->dims[0][1] = D2;
-  meta->dims[0][2] = D3;
+
+  info->info[0].dimension[0] = D1;
+  info->info[0].dimension[1] = D2;
+  info->info[0].dimension[2] = D3;
   for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-    meta->dims[0][i] = 1;
-  meta->types[0] = _NNS_UINT8;
-  meta->num_tensors = 1;
+    info->info[0].dimension[i] = 1;
+  info->info[0].type = _NNS_UINT8;
+  info->num_tensors = 1;
   return 0;
 }
 
@@ -90,21 +91,22 @@ get_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
  * @brief _pt_data
  */
 static int
-get_outputDim (void *private_data, const GstTensor_Filter_Properties * prop,
-    GstTensor_TensorsMeta * meta)
+get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
+    GstTensorsInfo * info)
 {
   pt_data *data = private_data;
   int i;
 
   g_assert (data);
   g_assert (NNS_TENSOR_RANK_LIMIT >= 3);
-  meta->dims[0][0] = D1;
-  meta->dims[0][1] = D2;
-  meta->dims[0][2] = D3;
+
+  info->info[0].dimension[0] = D1;
+  info->info[0].dimension[1] = D2;
+  info->info[0].dimension[2] = D3;
   for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
-    meta->dims[0][i] = 1;
-  meta->types[0] = _NNS_UINT8;
-  meta->num_tensors = 1;
+    info->info[0].dimension[i] = 1;
+  info->info[0].type = _NNS_UINT8;
+  info->num_tensors = 1;
   return 0;
 }
 
@@ -112,7 +114,7 @@ get_outputDim (void *private_data, const GstTensor_Filter_Properties * prop,
  * @brief _pt_data
  */
 static int
-pt_invoke (void *private_data, const GstTensor_Filter_Properties * prop,
+pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
     const uint8_t * inptr, uint8_t * outptr)
 {
   pt_data *data = private_data;

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
@@ -29,7 +29,7 @@ typedef struct _pt_data
  * @brief pt_init
  */
 static void *
-pt_init (const GstTensor_Filter_Properties * prop)
+pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
 
@@ -41,7 +41,7 @@ pt_init (const GstTensor_Filter_Properties * prop)
  * @brief pt_exit
  */
 static void
-pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
+pt_exit (void *private_data, const GstTensorFilterProperties * prop)
 {
   pt_data *data = private_data;
   g_assert (data);
@@ -52,15 +52,20 @@ pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
  * @brief set_inputDim
  */
 static int
-set_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
-    const tensor_dim iDim, const tensor_type iType,
-    tensor_dim oDim, tensor_type * oType)
+set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
+    const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   int i;
 
+  g_assert (in_info);
+  g_assert (out_info);
+
+  out_info->num_tensors = 1;
+
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    oDim[i] = iDim[i];
-  *oType = iType;
+    out_info->info[0].dimension[i] = in_info->info[0].dimension[i];
+
+  out_info->info[0].type = in_info->info[0].type;
 
   return 0;
 }
@@ -69,7 +74,7 @@ set_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
  * @brief pt_invoke
  */
 static int
-pt_invoke (void *private_data, const GstTensor_Filter_Properties * prop,
+pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
     const uint8_t * inptr, uint8_t * outptr)
 {
   pt_data *data = private_data;
@@ -79,8 +84,8 @@ pt_invoke (void *private_data, const GstTensor_Filter_Properties * prop,
   g_assert (inptr);
   g_assert (outptr);
 
-  size = get_tensor_element_count (prop->outputMeta.dims[0]) *
-      tensor_element_size[prop->outputMeta.types[0]];
+  size = get_tensor_element_count (prop->output_meta.info[0].dimension) *
+      tensor_element_size[prop->output_meta.info[0].type];
 
   g_assert (inptr != outptr);
   memcpy (outptr, inptr, size);

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -53,12 +53,12 @@ _strdup (const char *src)
  * @brief tensor_filter_custom::NNS_custom_init_func
  */
 static void *
-pt_init (const GstTensor_Filter_Properties * prop)
+pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
 
-  if (prop->customProperties && strlen (prop->customProperties) > 0)
-    data->property = _strdup (prop->customProperties);
+  if (prop->custom_properties && strlen (prop->custom_properties) > 0)
+    data->property = _strdup (prop->custom_properties);
   else
     data->property = NULL;
   data->new_x = 0;
@@ -93,7 +93,7 @@ pt_init (const GstTensor_Filter_Properties * prop)
  * @brief tensor_filter_custom::NNS_custom_exit_func
  */
 static void
-pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
+pt_exit (void *private_data, const GstTensorFilterProperties * prop)
 {
   pt_data *data = private_data;
   assert (data);
@@ -106,24 +106,28 @@ pt_exit (void *private_data, const GstTensor_Filter_Properties * prop)
  * @brief tensor_filter_custom::NNS_custom_set_input_dimension
  */
 static int
-set_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
-    const tensor_dim iDim, const tensor_type iType,
-    tensor_dim oDim, tensor_type * oType)
+set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
+    const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   int i;
   pt_data *data = private_data;
+
   assert (data);
+  assert (in_info);
+  assert (out_info);
+
+  out_info->num_tensors = 1;
 
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
-    oDim[i] = iDim[i];
+    out_info->info[0].dimension[i] = in_info->info[0].dimension[i];
 
   /* Update [1] and [2] oDim with new-x, new-y */
   if (data->new_x > 0)
-    oDim[1] = data->new_x;
+    out_info->info[0].dimension[1] = data->new_x;
   if (data->new_y > 0)
-    oDim[2] = data->new_y;
+    out_info->info[0].dimension[2] = data->new_y;
 
-  *oType = iType;
+  out_info->info[0].type = in_info->info[0].type;
   return 0;
 }
 
@@ -131,7 +135,7 @@ set_inputDim (void *private_data, const GstTensor_Filter_Properties * prop,
  * @brief tensor_filter_custom::NNS_custom_invoke
  */
 static int
-pt_invoke (void *private_data, const GstTensor_Filter_Properties * prop,
+pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
     const uint8_t * inptr, uint8_t * outptr)
 {
   pt_data *data = private_data;
@@ -146,37 +150,40 @@ pt_invoke (void *private_data, const GstTensor_Filter_Properties * prop,
   /* This assumes the limit is 4 */
   assert (NNS_TENSOR_RANK_LIMIT == 4);
 
-  assert (prop->inputMeta.dims[0][0] == prop->outputMeta.dims[0][0]);
-  assert (prop->inputMeta.dims[0][3] == prop->outputMeta.dims[0][3]);
-  assert (prop->inputMeta.types[0] == prop->outputMeta.types[0]);
+  assert (prop->input_meta.info[0].dimension[0] ==
+      prop->output_meta.info[0].dimension[0]);
+  assert (prop->input_meta.info[0].dimension[3] ==
+      prop->output_meta.info[0].dimension[3]);
+  assert (prop->input_meta.info[0].type == prop->output_meta.info[0].type);
 
-  elementsize = tensor_element_size[prop->inputMeta.types[0]];
+  elementsize = tensor_element_size[prop->input_meta.info[0].type];
 
-  ox = (data->new_x > 0) ? data->new_x : prop->outputMeta.dims[0][1];
-  oy = (data->new_y > 0) ? data->new_y : prop->outputMeta.dims[0][2];
+  ox = (data->new_x > 0) ? data->new_x : prop->output_meta.info[0].dimension[1];
+  oy = (data->new_y > 0) ? data->new_y : prop->output_meta.info[0].dimension[2];
 
-  oidx0 = prop->outputMeta.dims[0][0];
-  oidx1 = oidx0 * prop->outputMeta.dims[0][1];
-  oidx2 = oidx1 * prop->outputMeta.dims[0][2];
+  oidx0 = prop->output_meta.info[0].dimension[0];
+  oidx1 = oidx0 * prop->output_meta.info[0].dimension[1];
+  oidx2 = oidx1 * prop->output_meta.info[0].dimension[2];
 
-  iidx0 = prop->inputMeta.dims[0][0];
-  iidx1 = iidx0 * prop->inputMeta.dims[0][1];
-  iidx2 = iidx1 * prop->inputMeta.dims[0][2];
+  iidx0 = prop->input_meta.info[0].dimension[0];
+  iidx1 = iidx0 * prop->input_meta.info[0].dimension[1];
+  iidx2 = iidx1 * prop->input_meta.info[0].dimension[2];
 
-  for (z = 0; z < prop->inputMeta.dims[0][3]; z++) {
+  for (z = 0; z < prop->input_meta.info[0].dimension[3]; z++) {
     for (y = 0; y < oy; y++) {
       for (x = 0; x < ox; x++) {
         unsigned int c;
-        for (c = 0; c < prop->inputMeta.dims[0][0]; c++) {
+        for (c = 0; c < prop->input_meta.info[0].dimension[0]; c++) {
           int sz;
           /* Output[y'][x'] = Input[ y' * y / new-y ][ x' * x / new-x ]. Yeah This is Way too Simple. But this is just an example :D */
           unsigned ix, iy;
 
-          ix = x * prop->inputMeta.dims[0][1] / ox;
-          iy = y * prop->inputMeta.dims[0][2] / oy;
+          ix = x * prop->input_meta.info[0].dimension[1] / ox;
+          iy = y * prop->input_meta.info[0].dimension[2] / oy;
 
-          assert (ix >= 0 && iy >= 0 && ix < prop->inputMeta.dims[0][1]
-              && iy < prop->inputMeta.dims[0][2]);
+          assert (ix >= 0 && iy >= 0
+              && ix < prop->input_meta.info[0].dimension[1]
+              && iy < prop->input_meta.info[0].dimension[2]);
 
           /* outptr[z][y][x][c] = inptr[z][iy][ix][c]; */
           for (sz = 0; sz < elementsize; sz++)

--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -174,13 +174,13 @@ TEST (common_find_key_strv, key_index)
  */
 TEST (common_get_tensor_dimension, case1)
 {
-  uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123:433:177", dim);
-  EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (dim[0][0], 345);
-  EXPECT_EQ (dim[0][1], 123);
-  EXPECT_EQ (dim[0][2], 433);
-  EXPECT_EQ (dim[0][3], 177);
+  tensor_dim dim;
+  int rank = get_tensor_dimension ("345:123:433:177", dim);
+  EXPECT_EQ (rank, 4);
+  EXPECT_EQ (dim[0], 345);
+  EXPECT_EQ (dim[1], 123);
+  EXPECT_EQ (dim[2], 433);
+  EXPECT_EQ (dim[3], 177);
 }
 
 /**
@@ -188,13 +188,13 @@ TEST (common_get_tensor_dimension, case1)
  */
 TEST (common_get_tensor_dimension, case2)
 {
-  uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123:433", dim);
-  EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (dim[0][0], 345);
-  EXPECT_EQ (dim[0][1], 123);
-  EXPECT_EQ (dim[0][2], 433);
-  EXPECT_EQ (dim[0][3], 1);
+  tensor_dim dim;
+  int rank = get_tensor_dimension ("345:123:433", dim);
+  EXPECT_EQ (rank, 3);
+  EXPECT_EQ (dim[0], 345);
+  EXPECT_EQ (dim[1], 123);
+  EXPECT_EQ (dim[2], 433);
+  EXPECT_EQ (dim[3], 1);
 }
 
 /**
@@ -202,13 +202,13 @@ TEST (common_get_tensor_dimension, case2)
  */
 TEST (common_get_tensor_dimension, case3)
 {
-  uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345:123", dim);
-  EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (dim[0][0], 345);
-  EXPECT_EQ (dim[0][1], 123);
-  EXPECT_EQ (dim[0][2], 1);
-  EXPECT_EQ (dim[0][3], 1);
+  tensor_dim dim;
+  int rank = get_tensor_dimension ("345:123", dim);
+  EXPECT_EQ (rank, 2);
+  EXPECT_EQ (dim[0], 345);
+  EXPECT_EQ (dim[1], 123);
+  EXPECT_EQ (dim[2], 1);
+  EXPECT_EQ (dim[3], 1);
 }
 
 /**
@@ -216,13 +216,13 @@ TEST (common_get_tensor_dimension, case3)
  */
 TEST (common_get_tensor_dimension, case4)
 {
-  uint32_t dim[NNS_TENSOR_SIZE_LIMIT][NNS_TENSOR_RANK_LIMIT];
-  int num_tensors = get_tensor_dimension ("345", dim);
-  EXPECT_EQ (num_tensors, 1);
-  EXPECT_EQ (dim[0][0], 345);
-  EXPECT_EQ (dim[0][1], 1);
-  EXPECT_EQ (dim[0][2], 1);
-  EXPECT_EQ (dim[0][3], 1);
+  tensor_dim dim;
+  int rank = get_tensor_dimension ("345", dim);
+  EXPECT_EQ (rank, 1);
+  EXPECT_EQ (dim[0], 345);
+  EXPECT_EQ (dim[1], 1);
+  EXPECT_EQ (dim[2], 1);
+  EXPECT_EQ (dim[3], 1);
 }
 
 /**


### PR DESCRIPTION
refactor tensor-filter to support multi-tensors (other/tensors).
tf and tf-lte should be updated later for multi-tensors.

1. add common GstTensorsInfo in tensor-filter and parse from NN model
2. change NN framework properties
3. fix the bug in common functions for multi-tensors
4. remove space to get tensor dim and type in common function

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
