### PR TITLE
[Filter] change filter-framework callbacks

### DIFF
--- a/gst/tensor_filter/tensor_filter.h
+++ b/gst/tensor_filter/tensor_filter.h
@@ -110,15 +110,15 @@ struct _GstTensorFilterFramework
   gboolean allow_in_place; /**< TRUE if InPlace transfer of input-to-output is allowed. Not supported in main, yet */
   gboolean allocate_in_invoke; /**< TRUE if invoke_NN is going to allocate outputptr by itself and return the address via outputptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
 
-  uint8_t *(*invoke_NN) (const GstTensorFilter * filter, void **private_data,
-      const uint8_t * inputptr, uint8_t * outputptr);
+  int (*invoke_NN) (const GstTensorFilter * filter, void **private_data,
+      const GstTensorMemory * input, GstTensorMemory * output);
       /**< Mandatory callback. Invoke the given network model.
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer.
-       * @param[in] inputptr Input tensor. Allocated and filled by tensor_filter/main
-       * @param[out] outputptr Output tensor. Allocated by tensor_filter/main and to be filled by invoke_NN. N/C if allocate_in_invoke is TRUE.
-       * @return outputptr if allocate_in_invoke = 00 if OK. non-zero if error.
+       * @param[in] input The array of input tensors. Allocated and filled by tensor_filter/main
+       * @param[out] output The array of output tensors. Allocated by tensor_filter/main and to be filled by invoke_NN. If allocate_in_invoke is TRUE, sub-plugin should allocate the memory block for output tensor. (data in GstTensorMemory)
+       * @return 0 if OK. non-zero if error.
        */
 
   int (*getInputDimension) (const GstTensorFilter * filter,

--- a/gst/tensor_filter/tensor_filter_tensorflow.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow.c
@@ -78,23 +78,20 @@ tf_open (const GstTensorFilter * filter, void **private_data)
 
 /**
  * @brief The mandatory callback for GstTensorFilterFramework
- * @param[in] inptr The input tensor
- * @param[out] outptr The output tensor
+ * @param[in] input The array of input tensors
+ * @param[out] output The array of output tensors
  */
-static uint8_t *
+static int
 tf_invoke (const GstTensorFilter * filter, void **private_data,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   int retval;
-  uint8_t *allocated_outptr;
   tf_data *tf;
   tf = *private_data;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  retval =
-      tf_core_invoke (tf->tf_private_data, (uint8_t *) inptr,
-      &allocated_outptr);
+  retval = tf_core_invoke (tf->tf_private_data, input, output);
   g_assert (retval == 0);
-  return allocated_outptr;
+  return retval;
 }
 
 /**

--- a/gst/tensor_filter/tensor_filter_tensorflow_core.cc
+++ b/gst/tensor_filter/tensor_filter_tensorflow_core.cc
@@ -164,12 +164,12 @@ TFCore::getOutputTensorSize ()
 
 /**
  * @brief	run the model with the input.
- * @param[in] inptr : The input tensor
- * @param[out]  outptr : The output tensor
+ * @param[in] input : The array of input tensors
+ * @param[out]  output : The array of output tensors
  * @return 0 if OK. non-zero if error.
  */
 int
-TFCore::invoke (uint8_t * inptr, uint8_t ** outptr)
+TFCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
 {
   return 0;
 }
@@ -257,13 +257,14 @@ tf_core_getOutputSize (void *tf)
 /**
  * @brief	invoke the model
  * @param	tf	: the class object
- * @param[in] inptr : The input tensor
- * @param[out]  outptr : The output tensor
+ * @param[in] input : The array of input tensors
+ * @param[out]  output : The array of output tensors
  * @return 0 if OK. non-zero if error.
  */
 int
-tf_core_invoke (void *tf, uint8_t * inptr, uint8_t ** outptr)
+tf_core_invoke (void *tf, const GstTensorMemory * input,
+    GstTensorMemory * output)
 {
   TFCore *c = (TFCore *) tf;
-  return c->invoke (inptr, outptr);
+  return c->invoke (input, output);
 }

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -78,23 +78,21 @@ tflite_open (const GstTensorFilter * filter, void **private_data)
 
 /**
  * @brief The mandatory callback for GstTensorFilterFramework
- * @param[in] inptr The input tensor
- * @param[out] outptr The output tensor
+ * @param[in] input The array of input tensors
+ * @param[out] output The array of output tensors
+ * @return 0 if OK. non-zero if error.
  */
-static uint8_t *
+static int
 tflite_invoke (const GstTensorFilter * filter, void **private_data,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   int retval;
-  uint8_t *allocated_outptr;
   tflite_data *tf;
   tf = *private_data;
   g_assert (filter->privateData && *private_data == filter->privateData);
-  retval =
-      tflite_core_invoke (tf->tflite_private_data, (uint8_t *) inptr,
-      &allocated_outptr);
+  retval = tflite_core_invoke (tf->tflite_private_data, input, output);
   g_assert (retval == 0);
-  return allocated_outptr;
+  return retval;
 }
 
 /**

--- a/include/tensor_filter_custom.h
+++ b/include/tensor_filter_custom.h
@@ -40,7 +40,7 @@
 
 /**
  * @brief A function that is called before calling other functions.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
  * @return The returned pointer will be passed to other functions as "private_data".
  */
 typedef void *(*NNS_custom_init_func) (const GstTensorFilterProperties * prop);
@@ -48,7 +48,7 @@ typedef void *(*NNS_custom_init_func) (const GstTensorFilterProperties * prop);
 /**
  * @brief A function that is called after calling other functions, when it's ready to close.
  * @param[in] private_data If you have allocated *private_data at init, free it here.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
  */
 typedef void (*NNS_custom_exit_func) (void *private_data,
     const GstTensorFilterProperties * prop);
@@ -56,7 +56,7 @@ typedef void (*NNS_custom_exit_func) (void *private_data,
 /**
  * @brief Get input tensor type.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
  * @param[out] info Structure for tensor info.
  */
 typedef int (*NNS_custom_get_input_dimension) (void *private_data,
@@ -65,7 +65,7 @@ typedef int (*NNS_custom_get_input_dimension) (void *private_data,
 /**
  * @brief Get output tensor type.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
  * @param[out] info Structure for tensor info.
  */
 typedef int (*NNS_custom_get_output_dimension) (void *private_data,
@@ -74,7 +74,7 @@ typedef int (*NNS_custom_get_output_dimension) (void *private_data,
 /**
  * @brief Set input dim by framework. Let custom plutin set output dim accordingly.
  * @param[in] private_data The pointer returned by NNStreamer_custom_init
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
  * @param[in] in_info Input tensor info designated by the gstreamer framework. Note that this is not a fixed value and gstreamer may try different values during pad-cap negotiations.
  * @param[out] out_info Output tensor info according to the input tensor info.
  *
@@ -88,24 +88,25 @@ typedef int (*NNS_custom_set_input_dimension) (void *private_data,
 /**
  * @brief Invoke the "main function". Without allocating output buffer. (fill in the given output buffer)
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[in] inptr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
- * @param[out] outptr pointer to output tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
+ * @param[in] input The array of input tensors, each tensor size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[out] output The array of output tensors, each tensor size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
  * @return 0 if success
  */
 typedef int (*NNS_custom_invoke) (void *private_data,
-    const GstTensorFilterProperties * prop, const uint8_t * inptr, uint8_t * outptr);
+    const GstTensorFilterProperties * prop, const GstTensorMemory * input, GstTensorMemory * output);
 
 /**
  * @brief Invoke the "main function". Without allocating output buffer. (fill in the given output buffer)
  * @param[in] private_data The pointer returned by NNStreamer_custom_init.
- * @param[in] prop Tensor_Filter's property values. Do not change its values.
- * @param[in] inptr pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[in] prop GstTensorFilter's property values. Do not change its values.
+ * @param[in] input pointer to input tensor, size = dim1 x dim2 x dim3 x dim4 x typesize, allocated by caller
+ * @param[out] output The array of output tensors, each tensor size = dim1 x dim2 x dim3 x dim4 x typesize, the memory block for output tensor should be allocated. (data in GstTensorMemory)
  * @param[out] size The allocated size.
  * @return The output buffer allocated in the invoke function
  */
-typedef uint8_t *(*NNS_custom_allocate_invoke) (void *private_data,
-    const GstTensorFilterProperties * prop, const uint8_t * inptr, size_t * size);
+typedef int (*NNS_custom_allocate_invoke) (void *private_data,
+    const GstTensorFilterProperties * prop, const GstTensorMemory * input, GstTensorMemory * output);
 
 /**
  * @brief Custom Filter Class

--- a/include/tensor_filter_tensorflow_core.h
+++ b/include/tensor_filter_tensorflow_core.h
@@ -68,7 +68,7 @@ public:
   int getOutputTensorDim (GstTensorsInfo * info);
   int getInputTensorDimSize ();
   int getOutputTensorDimSize ();
-  int invoke (uint8_t * inptr, uint8_t ** outptr);
+  int invoke (const GstTensorMemory * input, GstTensorMemory * output);
 
 private:
   /**
@@ -97,7 +97,7 @@ extern "C"
   extern int tf_core_getOutputDim (void *tf, GstTensorsInfo * info);
   extern int tf_core_getInputSize (void *tf);
   extern int tf_core_getOutputSize (void *tf);
-  extern int tf_core_invoke (void *tf, uint8_t * inptr, uint8_t ** outptr);
+  extern int tf_core_invoke (void *tf, const GstTensorMemory * input, GstTensorMemory * output);
 
 #ifdef __cplusplus
 }

--- a/include/tensor_filter_tensorflow_lite_core.h
+++ b/include/tensor_filter_tensorflow_lite_core.h
@@ -51,23 +51,20 @@ public:
   int getOutputTensorSize ();
   int getInputTensorDim (GstTensorsInfo * info);
   int getOutputTensorDim (GstTensorsInfo * info);
-  int invoke (uint8_t * inptr, uint8_t ** outptr);
+  int invoke (const GstTensorMemory * input, GstTensorMemory * output);
 
 private:
 
   const char *model_path;
 
-  tensors inputTensors; /**< The list of input tensors */
-  tensors outputTensors; /**< The list of output tensors */
-
-  GstTensorsInfo inputTensorMeta;  /**< The meta of input tensors */
-  GstTensorsInfo outputTensorMeta;  /**< The meta of input tensors */
+  GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
+  GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
 
   std::unique_ptr < tflite::Interpreter > interpreter;
   std::unique_ptr < tflite::FlatBufferModel > model;
 
   double get_ms (struct timeval t);
-  _nns_tensor_type getTensorType (TfLiteType tfType);
+  tensor_type getTensorType (TfLiteType tfType);
   int getTensorDim (int tensor_idx, tensor_dim dim);
 };
 
@@ -81,14 +78,12 @@ extern "C"
   extern void *tflite_core_new (const char *_model_path);
   extern void tflite_core_delete (void *tflite);
   extern const char *tflite_core_getModelPath (void *tflite);
-  extern int tflite_core_getInputDim (void *tflite,
-      GstTensorsInfo * info);
-  extern int tflite_core_getOutputDim (void *tflite,
-      GstTensorsInfo * info);
+  extern int tflite_core_getInputDim (void *tflite, GstTensorsInfo * info);
+  extern int tflite_core_getOutputDim (void *tflite, GstTensorsInfo * info);
   extern int tflite_core_getOutputSize (void *tflite);
   extern int tflite_core_getInputSize (void *tflite);
-  extern int tflite_core_invoke (void *tflite, uint8_t * inptr,
-      uint8_t ** outptr);
+  extern int tflite_core_invoke (void *tflite, const GstTensorMemory * input,
+      GstTensorMemory * output);
 
 #ifdef __cplusplus
 }

--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -102,7 +102,6 @@ typedef enum
 } GstTensor_Filter_CheckStatus;
 
 typedef uint32_t tensor_dim[NNS_TENSOR_RANK_LIMIT];
-typedef uint8_t *tensors[NNS_TENSOR_SIZE_LIMIT];     /**< Array of tensors */
 
 /**
  * @brief The unit of each data tensors. It will be used as an input/output tensor of other/tensors.
@@ -133,10 +132,10 @@ typedef struct
 } GstTensorsInfo;
 
 /**
- * @brief Tensor_Filter's properties for NN framework (internal data structure)
+ * @brief GstTensorFilter's properties for NN framework (internal data structure)
  *
  * Because custom filters of tensor_filter may need to access internal data
- * of Tensor_Filter, we define this data structure here.
+ * of GstTensorFilter, we define this data structure here.
  */
 typedef struct _GstTensorFilterProperties
 {

--- a/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
+++ b/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
@@ -83,10 +83,10 @@ set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
 /**
  * @brief do_avg
  */
-#define do_avg(type, sumtype) do {\
+#define do_avg(type,sumtype) do {\
       sumtype *avg = (sumtype *) malloc(sizeof(sumtype) * prop->input_meta.info[0].dimension[0]); \
-      type *iptr = (type *) inptr; \
-      type *optr = (type *) outptr; \
+      type *iptr = (type *) input[0].data; \
+      type *optr = (type *) output[0].data; \
       for (z = 0; z < prop->input_meta.info[0].dimension[3]; z++) { \
         for (y = 0; y < prop->input_meta.info[0].dimension[0]; y++) \
           avg[y] = 0; \
@@ -109,7 +109,7 @@ set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
  */
 static int
 pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   pt_data *data = private_data;
   uint32_t c, x, y, z;
@@ -127,8 +127,8 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
       prop->input_meta.info[0].dimension[2];
 
   assert (data);
-  assert (inptr);
-  assert (outptr);
+  assert (input);
+  assert (output);
 
   /* This assumes the limit is 4 */
   assert (NNS_TENSOR_RANK_LIMIT == 4);
@@ -173,7 +173,7 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
     default:
       assert (0);               /* Type Mismatch */
   }
-  assert (inptr != outptr);
+  assert (input[0].data != output[0].data);
 
   return 0;
 }

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
@@ -115,19 +115,19 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
  */
 static int
 pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   pt_data *data = private_data;
   size_t size;
 
   g_assert (data);
-  g_assert (inptr);
-  g_assert (outptr);
+  g_assert (input);
+  g_assert (output);
 
   size = get_tensor_element_count (data->dim) * tensor_element_size[data->type];
 
-  g_assert (inptr != outptr);
-  memcpy (outptr, inptr, size);
+  g_assert (input[0].data != output[0].data);
+  memcpy (output[0].data, input[0].data, size);
 
   return 0;
 }

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
@@ -75,20 +75,20 @@ set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
  */
 static int
 pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   pt_data *data = private_data;
   size_t size;
 
   g_assert (data);
-  g_assert (inptr);
-  g_assert (outptr);
+  g_assert (input);
+  g_assert (output);
 
   size = get_tensor_element_count (prop->output_meta.info[0].dimension) *
       tensor_element_size[prop->output_meta.info[0].type];
 
-  g_assert (inptr != outptr);
-  memcpy (outptr, inptr, size);
+  g_assert (input[0].data != output[0].data);
+  memcpy (output[0].data, input[0].data, size);
 
   return 0;
 }

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -136,7 +136,7 @@ set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
  */
 static int
 pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
-    const uint8_t * inptr, uint8_t * outptr)
+    const GstTensorMemory * input, GstTensorMemory * output)
 {
   pt_data *data = private_data;
   uint32_t ox, oy, x, y, z, elementsize;
@@ -144,8 +144,8 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
   uint32_t iidx0, iidx1, iidx2;
 
   assert (data);
-  assert (inptr);
-  assert (outptr);
+  assert (input);
+  assert (output);
 
   /* This assumes the limit is 4 */
   assert (NNS_TENSOR_RANK_LIMIT == 4);
@@ -185,18 +185,18 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
               && ix < prop->input_meta.info[0].dimension[1]
               && iy < prop->input_meta.info[0].dimension[2]);
 
-          /* outptr[z][y][x][c] = inptr[z][iy][ix][c]; */
+          /* output[z][y][x][c] = input[z][iy][ix][c]; */
           for (sz = 0; sz < elementsize; sz++)
-            *(outptr + elementsize * (c + x * oidx0 + y * oidx1 + z * oidx2) +
-                sz) =
-                *(inptr + elementsize * (c + ix * iidx0 + iy * iidx1 +
-                    z * iidx2) + sz);
+            *((uint8_t *) output[0].data + elementsize * (c + x * oidx0 +
+                    y * oidx1 + z * oidx2) + sz) =
+                *((uint8_t *) input[0].data + elementsize * (c + ix * iidx0 +
+                    iy * iidx1 + z * iidx2) + sz);
         }
       }
     }
   }
 
-  assert (inptr != outptr);
+  assert (input[0].data != output[0].data);
 
   return 0;
 }


### PR DESCRIPTION
Change framework callbacks to support multi-tensors.

To support multi tensors,
1. GstTensorFilter allocates the memory block for each output tensor.
2. Fill input and output tensor info (GstTensorMemory)
3. GstTensorFilter calls 'invoke' with the structure GstTensorMemory.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
