### PR TITLE
[Example/CustomFilterScaler] Fix coverity analysis error 1029511

### DIFF
--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -70,15 +70,11 @@ pt_init (const GstTensorFilterProperties * prop)
     gchar **strv = g_strsplit_set (data->property, s, 3);
     if (strv[0] != NULL) {
       data->new_x = (uint32_t) g_ascii_strtoll (strv[0], NULL, 10);
-      if (data->new_x < 0)
-        data->new_x = 0;
     } else {
       data->new_x = 0;
     }
     if (strv[1] != NULL) {
       data->new_y = (uint32_t) g_ascii_strtoll (strv[1], NULL, 10);
-      if (data->new_y < 0)
-        data->new_y = 0;
     } else {
       data->new_y = 0;
     }


### PR DESCRIPTION
Unsigned variables cannot be less than 0.
Do not check if they are less than 0.

Addresses one item of #558.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
