### PR TITLE
[Filter/TF-Lite] fix bug about nomalization

### DIFF
--- a/gst/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -306,7 +306,7 @@ TFLiteCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
     for (int j = 0; j < num_of_input[i]; j++) {
       if (inputTensorMeta.info[i].type == _NNS_FLOAT32) {
         (interpreter->typed_tensor < float >(in_tensor))[j] =
-            (((float *) input[i].data)[j] - 127.5f) / 127.5f;
+            ((float *) input[i].data)[j];
       } else if (inputTensorMeta.info[i].type == _NNS_UINT8) {
         (interpreter->typed_tensor < uint8_t > (in_tensor))[j] =
             ((uint8_t *) input[i].data)[j];


### PR DESCRIPTION
Since tensor_transform will do typecast and data nomalization, temporal nomalization code is useless.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: HyoungjooAhn <hello.ahnn@gmail.com>
