### PR TITLE
[TensorSplit] Fix Tensor dimension type assign

### DIFF
--- a/gst/tensor_split/gsttensorsplit.c
+++ b/gst/tensor_split/gsttensorsplit.c
@@ -38,7 +38,7 @@
  * <title>Example launch line</title>
  * |[
  * gst-launch -v -m filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1 ! tensor_converter
- * ! tensor_split name=split tensorseg=1:100:100:2,1:100:100:1 split.src_0 ! queue ! filesink location=src0.log
+ * ! tensor_split name=split tensorseg=2:100:100,1:100:100 split.src_0 ! queue ! filesink location=src0.log
  * split.src_1 ! queue ! filesink location=src1.log
  * ]|
  *
@@ -607,6 +607,9 @@ gst_tensor_split_set_property (GObject * object, guint prop_id,
         for (k = 0; k < num; k++) {
           (*d)[k] = g_ascii_strtod (p[k], NULL);
         }
+        for (k = num; k < NNS_TENSOR_RANK_LIMIT; k++)
+          (*d)[k] = 1;
+
         g_array_append_val (self->tensorseg, d);
         g_strfreev (p);
       }

--- a/tests/nnstreamer_split/runTest.sh
+++ b/tests/nnstreamer_split/runTest.sh
@@ -12,31 +12,31 @@ else
 fi
 convertBMP2PNG
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=1:100:100:3 split. ! queue ! filesink location=split00.log" 1
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=3:100:100 split. ! queue ! filesink location=split00.log" 1
 
 compareAllSizeLimit testcase_0_0.golden split00.log 1
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=1:100:100:1,1:100:100:2 split. ! queue ! filesink location=split01_0.log split. ! queue ! filesink location=split01_1.log" 2
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=1:100:100,2:100:100 split. ! queue ! filesink location=split01_0.log split. ! queue ! filesink location=split01_1.log" 2
 
 compareAllSizeLimit testcase_1_0.golden split01_0.log 2_0
 compareAllSizeLimit testcase_1_1.golden split01_1.log 2_1
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=1:100:100:1,1:100:100:1,1:100:100:1 split. ! queue ! filesink location=split02_0.log split. ! queue ! filesink location=split02_1.log split. ! queue ! filesink location=split02_2.log" 3
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 filesrc location=testcase_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw, format = RGB, width=100, height=100, framerate=0/1 ! tensor_converter ! tensor_split name=split tensorseg=1:100:100,1:100:100,1:100:100 split. ! queue ! filesink location=split02_0.log split. ! queue ! filesink location=split02_1.log split. ! queue ! filesink location=split02_2.log" 3
 
 compareAllSizeLimit testcase_2_0.golden split02_0.log 3_0
 compareAllSizeLimit testcase_2_1.golden split02_1.log 3_1
 compareAllSizeLimit testcase_2_2.golden split02_2.log 3_2
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=1:16:16:3 split. ! queue ! filesink location=split03.log" 4
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=3:16:16 split. ! queue ! filesink location=split03.log" 4
 
 compareAllSizeLimit testcase_stream.golden split03.log 4
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=1:16:16:1,1:16:16:2 split. ! queue ! filesink location=split04_0.log split. ! queue ! filesink location=split04_1.log" 5
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=1:16:16,2:16:16 split. ! queue ! filesink location=split04_0.log split. ! queue ! filesink location=split04_1.log" 5
 
 compareAllSizeLimit testcase_stream_1_0.golden split04_0.log 5_0
 compareAllSizeLimit testcase_stream_1_1.golden split04_1.log 5_1
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=1:16:16:1,1:16:16:1,1:16:16:1 split. ! queue ! filesink location=split05_0.log split. ! queue ! filesink location=split05_1.log split. ! queue ! filesink location=split05_2.log" 6
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_split:5 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! tensor_split name=split tensorseg=1:16:16,1:16:16,1:16:16 split. ! queue ! filesink location=split05_0.log split. ! queue ! filesink location=split05_1.log split. ! queue ! filesink location=split05_2.log" 6
 
 compareAllSizeLimit testcase_stream_2_0.golden split05_0.log 6_0
 compareAllSizeLimit testcase_stream_2_1.golden split05_1.log 6_1


### PR DESCRIPTION
# PR Description
When we write tensor dimension, it should be [C][W][H][B].
But before this PR, it considered C array type [B][H][W][C].

Resolves: #538

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
