### PR TITLE
[Example/FilterPerformanceProfile] Fix coverity analysis errors 1029505 and 1029509

### DIFF
--- a/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
+++ b/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
@@ -2,7 +2,7 @@
  * @file	nnstreamer_example_filter_performance_profile.c
  * @date	27 August 2018
  * @brief	A NNStreamer Example of tensor_filter using TensorFlow Lite:
- *          Perfromance Profiling (i.e., FPS)
+ * 		Perfromance Profiling (i.e., FPS)
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
  * @author	Wook Song <wook16.song@samsung.com>
  * @bug		No known bugs.
@@ -20,9 +20,7 @@
  * https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/lite/g3doc/models.md#image-classification-quantized-models
  * By using the 'new-data' signal of tensor_sink, Frames per Second (FPS) is measured
  * as well as the clasification result is fed to 'textoverlay'.
- *_filterS for the frames from v4l2src,
- *_filterthe frames from the tensor_convert filter.
- *_filter
+ *
  * How to run this application: Before running this example,
  * GST_PLUGIN_PATH should be updated for the path where the nnstreamer plug-ins are placed.
  * $ export GST_PLUGIN_PATH=/where/NNSTreamer/plugins/located:$GST_PLUGIN_PATH

--- a/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
+++ b/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
@@ -963,7 +963,7 @@ _unregister_signals (nnstrmr_app_context_t * ctx)
 int
 main (int argc, char *argv[])
 {
-  nnstrmr_app_context_t app_ctx;
+  nnstrmr_app_context_t app_ctx = {};
   gboolean ret;
   GstBus *bus;
   guint bus_watch_id;

--- a/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
+++ b/nnstreamer_example/example_filter_performance_profile/nnstreamer_example_filter_performance_profile.c
@@ -412,11 +412,6 @@ _set_and_parse_option_info (int argc, char *argv[], nnstrmr_app_context_t * ctx)
   }
   ctx->input_src_height = height;
 
-  if (width == -1) {
-    width = DEFAULT_WIDTH_INPUT_SRC;
-  }
-  ctx->input_src_width = width;
-
   if (framerates == NULL) {
     framerates = g_strndup (DEFAULT_FRAME_RATES_INPUT_SRC,
         strlen (DEFAULT_FRAME_RATES_INPUT_SRC));


### PR DESCRIPTION
This PR addresses #558.

In this PR, coverity analysis errors 1029505 and 1029509.
- Removing logically dead code, which is duplicated by mistake (1029505)
- Adding an initialization of a structure variable to fix the "Uninitialized scalar variable" issue (1029509)

In addition, the file header comment is slightly revised.

Signed-off-by: Wook Song <wook16.song@samsung.com>