### PR TITLE
Security: fix buffer overflow issue in gst_tensor_dimension_conversion

### DIFF
--- a/gst/tensor_transform/tensor_transform.c
+++ b/gst/tensor_transform/tensor_transform.c
@@ -994,7 +994,8 @@ gst_tensor_transform_transform_caps (GstBaseTransform * trans,
     GstPadDirection direction, GstCaps * caps, GstCaps * filtercap)
 {
   /** @todo NYI: framerate configuration! */
-  tensor_dim in, out;
+  tensor_dim in = { 0, };
+  tensor_dim out = { 0, };
   tensor_type itype, otype;
   gboolean ret;
   GstTensor_Transform *filter = GST_TENSOR_TRANSFORM_CAST (trans);


### PR DESCRIPTION
Fixed issue https://github.com/nnsuite/nnstreamer/issues/552.

This commit is to fix a security issue that is reported by CPPCheck and SVACE tool.

**Changes proposed in this PR:**
1. Initialized in and out variable to avoid a buffer overflow issue.

* SVACE Checker:
```bash
BUFFER_OVERFLOW.PROC
Warning Message
Array 'in' of size 16 bytes passed to function 'gst_tensor_dimension_conversion' at tensor_transform.c:968
by passing as 5th parameter to function 'gst_tensor_dimension_conversion' at tensor_transform.c:1016,
where it is accessed by unacceptable index. This may lead to buffer overflow.
Trace Message
buffer overflow
┗ Shift at tensor_transform.c:968
┗ Variable '↦in[0]' is passed to function 'gst_tensor_dimension_conversion' as 5th parameter
at tensor_transform.c:1016 at tensor_transform.c:1016
```

* CPPChecker:
```bash
[gst/tensor_transform/tensor_transform.c:1007]: (error) Uninitialized variable: in
[gst/tensor_transform/tensor_transform.c:1010]: (error) Uninitialized variable: in
[gst/tensor_transform/tensor_transform.c:1018]: (error) Uninitialized variable: in
[gst/tensor_transform/tensor_transform.c:1021]: (error) Uninitialized variable: in
[gst/tensor_transform/tensor_transform.c:1010]: (error) Uninitialized variable: out
[gst/tensor_transform/tensor_transform.c:1013]: (error) Uninitialized variable: out
[gst/tensor_transform/tensor_transform.c:1015]: (error) Uninitialized variable: out
[gst/tensor_transform/tensor_transform.c:1018]: (error) Uninitialized variable: out
```

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

