### PR TITLE
[Test/Meta] remove dependency of tensor-meta

### DIFF
--- a/gst/tensor_saveload/tensor_load.c
+++ b/gst/tensor_saveload/tensor_load.c
@@ -50,7 +50,6 @@
 #include <glib.h>
 
 #include "tensor_load.h"
-#include <tensor_meta.h>
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensor_load_debug);
 #define GST_CAT_DEFAULT gst_tensor_load_debug

--- a/tests/nnstreamer_tensors/tensors_test/gsttensorscheck.c
+++ b/tests/nnstreamer_tensors/tensors_test/gsttensorscheck.c
@@ -3,29 +3,6 @@
  * Copyright (C) 2005 Thomas Vander Stichele <thomas@apestaart.org>
  * Copyright (C) 2005 Ronald S. Bultje <rbultje@ronald.bitfreak.net>
  * Copyright (C) 2018 Jijoong Moon <jijoong.moon@samsung.com>
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *
- * Alternatively, the contents of this file may be used under the
- * GNU Lesser General Public License Version 2.1 (the "LGPL"), in
- * which case the following provisions apply instead of the ones
- * mentioned above:
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,21 +13,16 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
  */
+
 /**
  * @file	gsttensorscheck.c
  * @date	26 June 2018
  * @brief	test element to check tensors
- * @see		http://github.com/TO-BE-DETERMINED-SOON
+ * @see		https://github.com/nnsuite/nnstreamer
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
- * @bug         no known bugs
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
- *
+ * @bug		No known bugs except for NYI items
  */
 
 /**
@@ -70,28 +42,21 @@
 #include <config.h>
 #endif
 
-#include <gst/gst.h>
-
 #include "gsttensorscheck.h"
 
 GST_DEBUG_CATEGORY_STATIC (gst_tensorscheck_debug);
 #define GST_CAT_DEFAULT gst_tensorscheck_debug
 
-/** Filter signals and args */
-enum
-{
-  /** FILL ME */
-  LAST_SIGNAL
-};
-
+/** Properties */
 enum
 {
   PROP_0,
+  PROP_PASSTHROUGH,
   PROP_SILENT
 };
 
-/** the capabilities of the inputs and outputs.
- *
+/**
+ * the capabilities of the inputs and outputs.
  * describe the real formats here.
  */
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
@@ -109,6 +74,7 @@ static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
 #define gst_tensorscheck_parent_class parent_class
 G_DEFINE_TYPE (Gsttensorscheck, gst_tensorscheck, GST_TYPE_ELEMENT);
 
+/** GObject vmethod implementations */
 static void gst_tensorscheck_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec);
 static void gst_tensorscheck_get_property (GObject * object, guint prop_id,
@@ -118,8 +84,6 @@ static gboolean gst_tensorscheck_sink_event (GstPad * pad, GstObject * parent,
     GstEvent * event);
 static GstFlowReturn gst_tensorscheck_chain (GstPad * pad, GstObject * parent,
     GstBuffer * buf);
-
-/** GObject vmethod implementations */
 
 /**
  * @brief initialize the tensorscheck's class
@@ -136,13 +100,17 @@ gst_tensorscheck_class_init (GsttensorscheckClass * klass)
   gobject_class->set_property = gst_tensorscheck_set_property;
   gobject_class->get_property = gst_tensorscheck_get_property;
 
+  g_object_class_install_property (gobject_class, PROP_PASSTHROUGH,
+      g_param_spec_boolean ("passthrough", "Passthrough",
+          "Flag to pass incoming buufer", FALSE, G_PARAM_READWRITE));
+
   g_object_class_install_property (gobject_class, PROP_SILENT,
       g_param_spec_boolean ("silent", "Silent", "Produce verbose output ?",
-          FALSE, G_PARAM_READWRITE));
+          TRUE, G_PARAM_READWRITE));
 
   gst_element_class_set_details_simple (gstelement_class,
       "tensorscheck",
-      "Test Tensors",
+      "Test/Tensor",
       "Get Tensors and Re-construct tensor to check",
       "Jijoong Moon <jijoong.moon@samsung.com>");
 
@@ -171,7 +139,8 @@ gst_tensorscheck_init (Gsttensorscheck * filter)
   filter->srcpad = gst_pad_new_from_static_template (&src_factory, "src");
   gst_element_add_pad (GST_ELEMENT (filter), filter->srcpad);
 
-  filter->silent = FALSE;
+  filter->silent = TRUE;
+  filter->passthrough = FALSE;
 }
 
 /**
@@ -184,6 +153,9 @@ gst_tensorscheck_set_property (GObject * object, guint prop_id,
   Gsttensorscheck *filter = GST_TENSORSCHECK (object);
 
   switch (prop_id) {
+    case PROP_PASSTHROUGH:
+      filter->passthrough = g_value_get_boolean (value);
+      break;
     case PROP_SILENT:
       filter->silent = g_value_get_boolean (value);
       break;
@@ -203,6 +175,9 @@ gst_tensorscheck_get_property (GObject * object, guint prop_id,
   Gsttensorscheck *filter = GST_TENSORSCHECK (object);
 
   switch (prop_id) {
+    case PROP_PASSTHROUGH:
+      g_value_set_boolean (value, filter->passthrough);
+      break;
     case PROP_SILENT:
       g_value_set_boolean (value, filter->silent);
       break;
@@ -212,106 +187,45 @@ gst_tensorscheck_get_property (GObject * object, guint prop_id,
   }
 }
 
-
-/**
- * @brief entry point to initialize the plug-in
- * initialize the plug-in itself
- * register the element factories and other features
- */
-static gboolean
-tensorscheck_init (GstPlugin * tensorscheck)
-{
-  /** debug category for fltering log messages
-   *
-   * exchange the string 'Template tensorscheck' with your description
-   */
-  GST_DEBUG_CATEGORY_INIT (gst_tensorscheck_debug, "tensorscheck",
-      0, "Template tensorscheck");
-
-  return gst_element_register (tensorscheck, "tensorscheck", GST_RANK_NONE,
-      GST_TYPE_TENSORSCHECK);
-}
-
-/** PACKAGE: this is usually set by autotools depending on some _INIT macro
- * in configure.ac and then written into and defined in config.h, but we can
- * just set it ourselves here in case someone doesn't use autotools to
- * compile this code. GST_PLUGIN_DEFINE needs PACKAGE to be defined.
- */
-#ifndef PACKAGE
-#define PACKAGE "tensorscheck"
-#endif
-
-/** gstreamer looks for this structure to register tensorschecks
- *
- * exchange the string 'Template tensorscheck' with your tensorscheck description
- */
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
-    GST_VERSION_MINOR,
-    tensorscheck,
-    "Template tensorscheck",
-    tensorscheck_init, VERSION, "LGPL", "GStreamer", "http://gstreamer.net/")
-
 /**
  * @brief Set Caps in pad.
  * @param filter Gsttensorscheck instance
  * @param caps incomming capablity
  * @return TRUE/FALSE (if successfully generate & set cap, return TRUE)
  */
-     static gboolean
-         gst_tensors_check_setcaps (Gsttensorscheck * filter, GstCaps * caps)
+static gboolean
+gst_tensors_check_setcaps (Gsttensorscheck * filter, const GstCaps * caps)
 {
-  gboolean ret;
-  gint dim;
   GstCaps *othercaps;
-  const gchar *dim_string;
-  const gchar *types;
-  int i;
-
+  gboolean ret;
+  guint num_tensors;
+  GstTensorConfig config;
+  GstTensorsConfig tensors_config;
   GstStructure *s = gst_caps_get_structure (caps, 0);
-  gst_structure_get_int (s, "rank", &filter->rank);
-  gst_structure_get_int (s, "num_tensors", &dim);
-  filter->num_tensors = dim;
 
-  dim_string = gst_structure_get_string (s, "dimensions");
-  if (dim_string) {
-    debug_print (!filter->silent, "dimension sting : %s\n", dim_string);
-    filter->dimensions = parse_dimensions (dim_string);
-    for (i = 0; i < filter->num_tensors; i++) {
-      tensor_dim *d = g_array_index (filter->dimensions, tensor_dim *, i);
-      debug_print (!filter->silent, "dimensions[%d] %d %d %d %d\n", i, (*d)[0],
-          (*d)[1], (*d)[2], (*d)[3]);
-    }
-  } else {
-    err_print ("Cannot get dimensions for negotiation!\n");
-  }
-  gst_structure_get_fraction (s, "framerate", &filter->framerate_numerator,
-      &filter->framerate_denominator);
-  types = gst_structure_get_string (s, "types");
-  if (types) {
-    debug_print (!filter->silent, "types string : %s\n", types);
-    filter->types = parse_types (types);
-    for (i = 0; i < filter->num_tensors; i++) {
-      tensor_type *t = g_array_index (filter->types, tensor_type *, i);
-      debug_print (!filter->silent, "types[%d] %s\n", i,
-          tensor_element_typename[(*t)]);
-    }
-  } else {
-    err_print ("Cannot get types for negotiation!\n");
-  }
+  g_assert (gst_tensors_config_from_structure (&tensors_config, s));
+  g_assert (gst_tensors_config_validate (&tensors_config));
 
-  tensor_dim *d = g_array_index (filter->dimensions, tensor_dim *, 0);
-  tensor_type *t = g_array_index (filter->types, tensor_type *, 0);
-  othercaps = gst_caps_new_simple ("other/tensor",
-      "rank", G_TYPE_INT, filter->rank,
-      "dim1", G_TYPE_INT, (*d)[0],
-      "dim2", G_TYPE_INT, (*d)[1],
-      "dim3", G_TYPE_INT, (*d)[2],
-      "dim4", G_TYPE_INT, (*d)[3],
-      "type", G_TYPE_STRING, tensor_element_typename[*t],
-      "framerate", GST_TYPE_FRACTION, filter->framerate_numerator,
-      filter->framerate_denominator, NULL);
+  filter->in_config = tensors_config;
+
+  /* parse config to test tensors */
+  gst_tensor_config_init (&config);
+
+  num_tensors = tensors_config.info.num_tensors;
+
+  config.info = tensors_config.info.info[0];
+  config.info.dimension[0] = num_tensors;
+
+  config.rate_n = tensors_config.rate_n;
+  config.rate_d = tensors_config.rate_d;
+  g_assert (gst_tensor_config_validate (&config));
+
+  filter->out_config = config;
+
+  othercaps = gst_tensor_caps_from_config (&config);
   ret = gst_pad_set_caps (filter->srcpad, othercaps);
   gst_caps_unref (othercaps);
+
   return ret;
 }
 
@@ -325,48 +239,36 @@ static GstBuffer *
 gst_tensors_check (Gsttensorscheck * filter, GstBuffer * inbuf)
 {
   GstBuffer *outbuf;
-  gint num_tensors;
+  gsize out_size;
+  guint i, num_tensors;
   GstMapInfo info, src_info, dest_info;
-  GstMemory *buffer_mem;
-  tensor_dim *dim;
-  unsigned int d0, d1, d2, i;
-  gboolean ret;
+  guint d0, d1, d2;
+  size_t span, span1;
 
   /** Mapping input buffer (tensors) into src_info */
   gst_buffer_map (inbuf, &src_info, GST_MAP_READ);
 
-  /** Making output GstBuffer */
-  outbuf = gst_buffer_new ();
-
   /** Making output buffer (one big buffer for check tensors) */
-  buffer_mem = gst_allocator_alloc (NULL,
-      /** filter->dimension[0] * filter->dimension[1] * filter->dimension[2] * */
-      /** filter->dimension[3], NULL); */
-      3 * 640 * 480 * 1, NULL);
-  gst_buffer_append_memory (outbuf, buffer_mem);
-
+  out_size = get_tensor_element_count (filter->out_config.info.dimension) *
+      tensor_element_size[filter->out_config.info.type];
+  outbuf = gst_buffer_new_allocate (NULL, out_size, NULL);
   gst_buffer_map (outbuf, &dest_info, GST_MAP_WRITE);
 
   /** Get number of tensors */
-  num_tensors = gst_get_num_tensors (inbuf);
+  num_tensors = filter->in_config.info.num_tensors;
   debug_print (!filter->silent, "Number of Tensors : %d\n", num_tensors);
+
   for (i = 0; i < num_tensors; i++) {
-    GstMemory *mem = gst_get_tensor (inbuf, i);
-    if (!mem)
-      debug_print (!filter->silent, "Cannot get memory\n");
-    dim = gst_get_tensordim (inbuf, i);
-    ret = gst_memory_map (mem, &info, GST_MAP_WRITE);
-    if (!ret) {
-      debug_print (!filter->silent, "Cannot map memory\n");
-      return NULL;
-    }
-    size_t span = 0;
-    size_t span1 = 0;
-    for (d0 = 0; d0 < (*dim)[3]; d0++) {
-      for (d1 = 0; d1 < (*dim)[2]; d1++) {
-        span = d1 * (*dim)[1];
-        span1 = d1 * (*dim)[1] * 3;
-        for (d2 = 0; d2 < (*dim)[1]; d2++) {
+    GstMemory *mem;
+
+    mem = gst_buffer_peek_memory (inbuf, i);
+    g_assert (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (d0 = 0; d0 < filter->in_config.info.info[i].dimension[3]; d0++) {
+      for (d1 = 0; d1 < filter->in_config.info.info[i].dimension[2]; d1++) {
+        span = d1 * filter->in_config.info.info[i].dimension[1];
+        span1 = d1 * filter->in_config.info.info[i].dimension[1] * 3;
+        for (d2 = 0; d2 < filter->in_config.info.info[i].dimension[1]; d2++) {
           dest_info.data[span1 + (d2 * num_tensors) + i] = info.data[span + d2];
         }
       }
@@ -379,10 +281,9 @@ gst_tensors_check (Gsttensorscheck * filter, GstBuffer * inbuf)
   return outbuf;
 }
 
-/** GstElement vmethod implementations */
-
 /**
- * @brief this function handles sink events
+ * @brief this function handles sink events.
+ * GstElement vmethod implementations.
  */
 static gboolean
 gst_tensorscheck_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
@@ -412,8 +313,8 @@ gst_tensorscheck_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
 }
 
 /**
- * @brief chain function
- * this function does the actual processing
+ * @brief chain function, this function does the actual processing.
+ * GstElement vmethod implementations.
  */
 static GstFlowReturn
 gst_tensorscheck_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
@@ -431,3 +332,41 @@ gst_tensorscheck_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 
   return gst_pad_push (filter->srcpad, out);
 }
+
+/**
+ * @brief entry point to initialize the plug-in
+ * initialize the plug-in itself
+ * register the element factories and other features
+ */
+static gboolean
+tensorscheck_init (GstPlugin * plugin)
+{
+  /**
+   * debug category for fltering log messages
+   */
+  GST_DEBUG_CATEGORY_INIT (gst_tensorscheck_debug, "tensorscheck",
+      0, "Element tensorscheck to test tensors");
+
+  return gst_element_register (plugin, "tensorscheck", GST_RANK_NONE,
+      GST_TYPE_TENSORSCHECK);
+}
+
+/**
+ * PACKAGE: this is usually set by autotools depending on some _INIT macro
+ * in configure.ac and then written into and defined in config.h, but we can
+ * just set it ourselves here in case someone doesn't use autotools to
+ * compile this code. GST_PLUGIN_DEFINE needs PACKAGE to be defined.
+ */
+#ifndef PACKAGE
+#define PACKAGE "tensorscheck"
+#endif
+
+/**
+ * gstreamer looks for this structure to register tensorschecks
+ * exchange the string 'Template tensorscheck' with your tensorscheck description
+ */
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+    GST_VERSION_MINOR,
+    tensorscheck,
+    "Element tensorscheck to test tensors",
+    tensorscheck_init, VERSION, "LGPL", "GStreamer", "http://gstreamer.net/")

--- a/tests/nnstreamer_tensors/tensors_test/gsttensorscheck.h
+++ b/tests/nnstreamer_tensors/tensors_test/gsttensorscheck.h
@@ -1,31 +1,8 @@
-/*
+/**
  * GStreamer
  * Copyright (C) 2005 Thomas Vander Stichele <thomas@apestaart.org>
  * Copyright (C) 2005 Ronald S. Bultje <rbultje@ronald.bitfreak.net>
- * Copyright (C) 2018 jijoongmoon <<user@hostname.org>>
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *
- * Alternatively, the contents of this file may be used under the
- * GNU Lesser General Public License Version 2.1 (the "LGPL"), in
- * which case the following provisions apply instead of the ones
- * mentioned above:
+ * Copyright (C) 2018 Jijoong Moon <jijoong.moon@samsung.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,21 +13,16 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
  */
 
 /**
  * @file	gsttensorscheck.h
  * @date	26 June 2018
  * @brief	test element to check tensors
- * @see		http://github.com/TO-BE-DETERMINED-SOON
+ * @see		https://github.com/nnsuite/nnstreamer
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
- *
+ * @bug		No known bugs except for NYI items
  */
 
 #ifndef __GST_TENSORSCHECK_H__
@@ -58,11 +30,9 @@
 
 #include <gst/gst.h>
 #include <tensor_common.h>
-#include <tensor_meta.h>
 
 G_BEGIN_DECLS
 
-/* #defines don't like whitespacey bits */
 #define GST_TYPE_TENSORSCHECK \
   (gst_tensorscheck_get_type())
 #define GST_TENSORSCHECK(obj) \
@@ -74,7 +44,7 @@ G_BEGIN_DECLS
 #define GST_IS_TENSORSCHECK_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSORSCHECK))
 
-typedef struct _Gsttensorscheck      Gsttensorscheck;
+typedef struct _Gsttensorscheck Gsttensorscheck;
 typedef struct _GsttensorscheckClass GsttensorscheckClass;
 
 /**
@@ -86,28 +56,22 @@ struct _Gsttensorscheck
   GstPad *sinkpad, *srcpad;
 
   gboolean silent;
+  gboolean passthrough;
 
   /* For Tensor */
-  /* tensor_dim dimension; */
-  GArray *dimensions;
-  gint num_tensors;
-  gint rank;
-  GArray *types;
-  gint framerate_numerator;
-  gint framerate_denominator;
-  gboolean passthrough;
+  GstTensorsConfig in_config;
+  GstTensorConfig out_config;
 };
 
-/*
+/**
  * @brief GsttensorscheckClass inherits GstElementClass
- *
  */
 struct _GsttensorscheckClass
 {
   GstElementClass parent_class;
 };
 
-/*
+/**
  * @brief Get Type function required for gst elements
  */
 GType gst_tensorscheck_get_type (void);

--- a/tests/nnstreamer_tensors/tensors_test/gsttesttensors.h
+++ b/tests/nnstreamer_tensors/tensors_test/gsttesttensors.h
@@ -1,31 +1,8 @@
-/*
+/**
  * GStreamer
  * Copyright (C) 2005 Thomas Vander Stichele <thomas@apestaart.org>
  * Copyright (C) 2005 Ronald S. Bultje <rbultje@ronald.bitfreak.net>
- * Copyright (C) 2018 Jijoong.Moon <jijoong.moon@samsung.com>
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- *
- * Alternatively, the contents of this file may be used under the
- * GNU Lesser General Public License Version 2.1 (the "LGPL"), in
- * which case the following provisions apply instead of the ones
- * mentioned above:
+ * Copyright (C) 2018 Jijoong Moon <jijoong.moon@samsung.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -36,20 +13,16 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public
- * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
  */
+
 /**
  * @file	gsttesttensors.h
  * @date	26 June 2018
  * @brief	test element to generate tensors
- * @see		http://github.com/TO-BE-DETERMINED-SOON
+ * @see		https://github.com/nnsuite/nnstreamer
  * @see		https://github.sec.samsung.net/STAR/nnstreamer
  * @author	Jijoong Moon <jijoong.moon@samsung.com>
- *
+ * @bug		No known bugs except for NYI items
  */
 
 #ifndef __GST_TESTTENSORS_H__
@@ -57,11 +30,9 @@
 
 #include <gst/gst.h>
 #include <tensor_common.h>
-#include <tensor_meta.h>
 
 G_BEGIN_DECLS
 
-/* #defines don't like whitespacey bits */
 #define GST_TYPE_TESTTENSORS \
   (gst_testtensors_get_type())
 #define GST_TESTTENSORS(obj) \
@@ -73,11 +44,11 @@ G_BEGIN_DECLS
 #define GST_IS_TESTTENSORS_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TESTTENSORS))
 
-typedef struct _Gsttesttensors      Gsttesttensors;
+typedef struct _Gsttesttensors Gsttesttensors;
 typedef struct _GsttesttensorsClass GsttesttensorsClass;
 
 /**
- * @brief Internal data structure for tensorscheck instances.
+ * @brief Internal data structure for testtensors instances.
  */
 struct _Gsttesttensors
 {
@@ -86,29 +57,22 @@ struct _Gsttesttensors
   GstPad *sinkpad, *srcpad;
 
   gboolean silent;
-  gint width;
-  gint height;
+  gboolean passthrough;
 
   /* For Tensor */
-  /* tensor_dim dimension; */
-  gint num_tensors;
-  gint rank;
-  tensor_type type;
-  gint framerate_numerator;
-  gint framerate_denominator;
-  gboolean passthrough;
+  GstTensorConfig in_config;
+  GstTensorsConfig out_config;
 };
 
-/*
+/**
  * @brief Gsttesttensors inherits GstElementClass
- *
  */
 struct _GsttesttensorsClass
 {
   GstElementClass parent_class;
 };
 
-/*
+/**
  * @brief Get Type function required for gst elements
  */
 GType gst_testtensors_get_type (void);


### PR DESCRIPTION
1. Refactor test plugins to remove tensor-meta.
(these elements are for testing multi-tensors only)
2. Remove unnecessary header in saveload.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
