### PR TITLE
[Split/Demux/Trandform] remove rank and fix mem leak @open sesame 10/02 15:27 

### DIFF
--- a/gst/tensor_demux/gsttensordemux.c
+++ b/gst/tensor_demux/gsttensordemux.c
@@ -559,6 +559,7 @@ gst_tensor_demux_set_property (GObject * object, guint prop_id,
         filter->tensorpick =
             g_list_append (filter->tensorpick, GINT_TO_POINTER (val));
       }
+      g_strfreev (strv);
       break;
     }
     default:

--- a/gst/tensor_transform/tensor_transform.c
+++ b/gst/tensor_transform/tensor_transform.c
@@ -262,6 +262,7 @@ gst_tensor_transform_set_option_data (GstTensor_Transform * filter)
       filter->data_dimchg.from = a;
       filter->data_dimchg.to = b;
       filter->loaded = TRUE;
+      g_strfreev (strv);
     }
       break;
     case GTT_TYPECAST:
@@ -282,6 +283,7 @@ gst_tensor_transform_set_option_data (GstTensor_Transform * filter)
         filter->data_arithmetic.value = g_ascii_strtod (strv[1], NULL);
 
       filter->loaded = TRUE;
+      g_strfreev (strv);
     }
       break;
     case GTT_TRANSPOSE:
@@ -296,6 +298,7 @@ gst_tensor_transform_set_option_data (GstTensor_Transform * filter)
         filter->data_transpose.trans_order[i] = a;
       }
       filter->loaded = TRUE;
+      g_strfreev (strv);
     }
       break;
     default:


### PR DESCRIPTION
1. [split] remove rank in caps and use common structure to get tensor caps
2. add code to free the array of strings

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
