### PR TITLE
[Mux/Decoder] fix coverity issue

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -686,7 +686,7 @@ gst_tensordec_update_top_label_index (GstTensorDec * self,
   gint index = -1;
   guint8 max_score = 0;
 
-  g_return_if_fail (scores != NULL);
+  g_return_val_if_fail (scores != NULL, -1);
   g_return_val_if_fail (len == self->tensordec_image_label.total_labels, -1);
 
   for (i = 0; i < len; i++) {

--- a/gst/tensor_mux/gsttensormux.c
+++ b/gst/tensor_mux/gsttensormux.c
@@ -426,13 +426,13 @@ gst_tensor_mux_collected (GstCollectPads * pads, GstTensorMux * tensor_mux)
   }
 
   tensors_buf = gst_buffer_new ();
+  g_assert (tensors_buf);
   isEOS =
       gst_tensor_mux_collect_buffer (tensor_mux, tensors_buf, &pts_time,
       &dts_time);
 
   if (isEOS) {
-    if (tensors_buf)
-      gst_buffer_unref (tensors_buf);
+    gst_buffer_unref (tensors_buf);
     gst_pad_push_event (tensor_mux->srcpad, gst_event_new_eos ());
     ret = GST_FLOW_EOS;
     goto beach;


### PR DESCRIPTION
fix coverity issue 1030251, 1030250 in tensor-decoder and tensor-mux

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
