### PR TITLE
[SVACE-Fix] Fix 376961 / str without termination

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -741,6 +741,7 @@ gst_tensordec_label_set_output (GstTensorDec * self, GstBuffer * outbuf,
   g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
 
   strncpy ((char *) out_info.data, label, len);
+  ((char *) out_info.data)[len] = '\0';
 
   gst_buffer_append_memory (outbuf, out_mem);
 


### PR DESCRIPTION
Fixed error: WID:57241610 Copying from string 'label' to 'out_info.data' without null termination at tensordec.c:743 by calling function 'strncpy'.
Reference: https://stackoverflow.com/questions/1453876/why-does-strncpy-not-null-terminate

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
