### PR TITLE
[Example] change plugin to get scaled video frame from v4l2

### DIFF
--- a/nnstreamer_example/example_cam/nnstreamer_example_cam.c
+++ b/nnstreamer_example/example_cam/nnstreamer_example_cam.c
@@ -191,8 +191,8 @@ main (int argc, char **argv)
   /** init pipeline */
   str_pipeline =
       g_strdup_printf
-      ("v4l2src name=cam_src ! videoconvert ! "
-      "video/x-raw,width=%d,height=%d,format=RGB,framerate=30/1 ! tee name=t_raw "
+      ("v4l2src name=cam_src ! videoscale ! "
+      "video/x-raw,width=%d,height=%d,format=RGB ! tee name=t_raw "
       "videomixer name=mix "
       "sink_0::xpos=0 sink_0::ypos=0 sink_0::zorder=0 "
       "sink_1::xpos=0 sink_1::ypos=0 sink_1::zorder=1 sink_1::alpha=0.7 ! "

--- a/nnstreamer_example/example_filter/nnstreamer_example_filter.py
+++ b/nnstreamer_example/example_filter/nnstreamer_example_filter.py
@@ -67,8 +67,8 @@ class NNStreamerExample:
 
         # init pipeline
         self.pipeline = Gst.parse_launch(
-            'v4l2src name=cam_src ! videoconvert ! '
-            'video/x-raw,width=640,height=480,format=RGB,framerate=30/1 ! tee name=t_raw '
+            'v4l2src name=cam_src ! videoscale ! '
+            'video/x-raw,width=640,height=480,format=RGB ! tee name=t_raw '
             't_raw. ! queue ! textoverlay name=tensor_res font-desc=\"Sans, 24\" ! '
             'videoconvert ! ximagesink name=img_tensor '
             't_raw. ! queue ! videoscale ! video/x-raw,width=224,height=224 ! tensor_converter ! '


### PR DESCRIPTION
1. change to videoscale to set 640x480 frame
2. remove framerate in caps filter

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
