### PR TITLE
[Converter] support byte-stream @open sesame 10/08 22:10

### DIFF
--- a/gst/tensor_converter/tensor_converter.h
+++ b/gst/tensor_converter/tensor_converter.h
@@ -68,6 +68,7 @@ struct _GstTensorConverter
 
   gboolean silent; /**< true to print minimized log */
   guint frames_per_tensor; /**< number of frames in output tensor */
+  GstTensorInfo tensor_info; /**< data structure to get/set tensor info */
 
   GstAdapter *adapter; /**< adapt incoming media stream */
 


### PR DESCRIPTION
add new properties input-dim and input-type to get tensor info from byte-stream (application/octet-stream)
add testcase for byte-stream

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
