### PR TITLE
[Transform] Add Test Case for transform/standardization mode @open sesame 10/11 10:33

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -28,6 +28,7 @@ BuildRequires:	gst-plugins-base
 BuildRequires:	gtest-devel
 # a few test cases uses python
 BuildRequires:	python
+BuildRequires:	python-numpy
 # Testcase requires bmp2png, which requires libpng
 BuildRequires:  pkgconfig(libpng)
 # for tensorflow-lite

--- a/tests/transform_stand/checkResult.py
+++ b/tests/transform_stand/checkResult.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file checkResult.py
+# @brief Check if the tranform results are correct with typecast
+# @author Jijoong Moon <jijoong.moo@samsung.com>
+# @date 20 Jul 2018
+# @bug No known bugs
+
+import sys
+import struct
+
+##
+# @brief Check typecast from typea to typeb with file fna/fnb
+#
+def testStandardization (fna, fnb, typeasize, typebsize,typeapack, typebpack):
+  lena = len(fna)
+  lenb = len(fnb)
+
+  if (0 < (lena % typeasize)) or (0 < (lenb % typebsize)):
+    return 10
+  num = lena / typeasize
+  if num != (lenb / typebsize):
+    return 11
+  limitb = 2 ** (8 * typebsize)
+  maskb = limitb - 1
+  for x in range(0, num):
+    vala = struct.unpack(typeapack, fna[x * typeasize: x * typeasize + typeasize])[0]
+    valb = struct.unpack(typebpack, fnb[x * typebsize: x * typebsize + typebsize])[0]
+    diff = vala - valb
+    if diff > 0.01 or diff < -0.01:
+      return 20
+  return 0
+
+def readfile (filename):
+  F = open(filename, 'r')
+  readfile = F.read()
+  F.close
+  return readfile
+
+if len(sys.argv) < 2:
+  exit(5)
+
+if (sys.argv[1] == 'standardization'):
+  if len(sys.argv) < 8:
+    exit(5)
+  fna = readfile(sys.argv[2])
+  fnb = readfile(sys.argv[3])
+  typeasize = int(sys.argv[4])
+  typebsize = int(sys.argv[5])
+  typeapack = (sys.argv[6])
+  typebpack = (sys.argv[7])
+
+  exit(testStandardization(fna, fnb, typeasize, typebsize, typeapack, typebpack))
+
+exit(5)

--- a/tests/transform_stand/generateTest.py
+++ b/tests/transform_stand/generateTest.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file generateTest.py
+# @brief Generate golden test results for test cases
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from struct import pack
+import random
+
+import numpy as np
+
+def saveTestData(filename, width, height):
+    string = b''
+    data = []
+
+    for w in range(0,width):
+        for h in range(0,height):
+            n = random.uniform(0.0, 10.0)
+            string += pack('f', n)
+            data.append(n)
+
+    with open(filename,'wb') as file:
+        file.write(string)
+
+    file.close()
+
+    a=np.array(data)
+    mean = np.mean(a)
+    standard = np.std(a)
+    result=abs((a-np.mean(a)) / (np.std(a)+1e-10))
+
+    s = ''
+    for w in range(0,width):
+        for h in range(0,height):
+            s += pack('f',result[w*height+h])
+
+    with open(filename+".golden",'wb') as file1:
+        file1.write(s)
+
+    return result, mean, standard
+
+buf = saveTestData("test_00.dat", 100, 50)

--- a/tests/transform_stand/runTest.sh
+++ b/tests/transform_stand/runTest.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+source ../testAPI.sh
+
+if [ "$SKIPGEN" == "YES" ]
+then
+  echo "Test Case Generation Skipped"
+  sopath=$2
+else
+  echo "Test Case Generation Started"
+  python generateTest.py
+  sopath=$1
+fi
+
+# Test gst availability. (0)
+gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! filesink location=\"testcase.apitest.log\" sync=true" 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"test_%02d.dat\" caps=\"application/octet-stream\" ! tensor_converter input-dim=50:100:1:1 input-type=float32 ! tensor_transform mode=stand option=default ! multifilesink location=\"./result_%02d.log\" sync=true" 1
+
+python checkResult.py standardization test_00.dat.golden result_00.log 4 4 f f default
+
+casereport 1 $? "Golden test comparison"
+
+report


### PR DESCRIPTION
# PR Description

Add Test Case for standardization mode.
Compare the result with python and approval diff is
-0.01 < diff < 0.01. (application/octet-stream mime is used.)

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>