### PR TITLE
[Transform] Remove hard coded values in transform

### DIFF
--- a/gst/tensor_transform/tensor_transform.c
+++ b/gst/tensor_transform/tensor_transform.c
@@ -289,7 +289,7 @@ gst_tensor_transform_set_option_data (GstTensor_Transform * filter)
     case GTT_TRANSPOSE:
     {
       int a, i;
-      gchar **strv = g_strsplit (filter->option, ":", 4);
+      gchar **strv = g_strsplit (filter->option, ":", NNS_TENSOR_RANK_LIMIT);
       for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
         if (strv[i] != NULL)
           a = g_ascii_strtoull (strv[i], NULL, 10);


### PR DESCRIPTION
# PR Description

Use NNS_TENSOR_RANK_LIMIT instead of 4 for transpose.

Resolves: #537

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>