### PR TITLE
[Transform/Arithmetic] Support fused operators such as mul-add and add-mul

### DIFF
--- a/gst/tensor_transform/tensor_transform.h
+++ b/gst/tensor_transform/tensor_transform.h
@@ -60,6 +60,7 @@ G_BEGIN_DECLS
 #define GST_IS_TENSOR_TRANSFORM_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_TRANSFORM))
 #define GST_TENSOR_TRANSFORM_CAST(obj)  ((GstTensor_Transform *)(obj))
+#define ARITH_OPRND_NUM_LIMIT  2
 
 typedef struct _GstTensor_Transform GstTensor_Transform;
 
@@ -80,6 +81,9 @@ typedef enum
 {
   ARITH_ADD = 0,
   ARITH_MUL = 1,
+  ARITH_ADD_MUL = 2,            /* Fused add-multiply */
+  ARITH_MUL_ADD = 3,            /* Fused multiply-add */
+
   ARITH_END,
 } tensor_transform_arith_mode;
 
@@ -128,7 +132,7 @@ typedef struct _tensor_transform_arithmetic_operand {
  */
 typedef struct _tensor_transform_arithmetic {
   tensor_transform_arith_mode mode;
-  tensor_transform_arithmetic_operand value;
+  tensor_transform_arithmetic_operand value[ARITH_OPRND_NUM_LIMIT];
 } tensor_transform_arithmetic;
 
 /**

--- a/gst/tensor_transform/tensor_transform.h
+++ b/gst/tensor_transform/tensor_transform.h
@@ -89,6 +89,14 @@ typedef enum
   STAND_END,
 } tensor_transform_stand_mode;
 
+typedef enum
+{
+  ARITH_OPRND_TYPE_INT64 = 0,
+  ARITH_OPRND_TYPE_DOUBLE = 1,
+
+  ARITH_OPRND_TYPE_END
+} tensor_transform_arith_oprnd_type;
+
 /**
  * @brief Internal data structure for dimchg mode.
  */
@@ -105,12 +113,22 @@ typedef struct _tensor_transform_typecast {
 } tensor_transform_typecast;
 
 /**
+ * @brief Internal data structure for operand of arithmetic mode.
+ */
+typedef struct _tensor_transform_arithmetic_operand {
+  tensor_transform_arith_oprnd_type type;
+  union {
+    int64_t value_int64;
+    double value_double;
+  };
+} tensor_transform_arithmetic_operand;
+
+/**
  * @brief Internal data structure for arithmetic mode.
  */
 typedef struct _tensor_transform_arithmetic {
   tensor_transform_arith_mode mode;
-  /* TODO : Better to use union for various type*/
-  int64_t value;
+  tensor_transform_arithmetic_operand value;
 } tensor_transform_arithmetic;
 
 /**

--- a/tests/transform_arithmetic/checkResult.py
+++ b/tests/transform_arithmetic/checkResult.py
@@ -16,7 +16,7 @@ import struct
 ##
 # @brief Check typecast from typea to typeb with file fna/fnb
 #
-def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, value):
+def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, value1, value2):
   lena = len(fna)
   lenb = len(fnb)
 
@@ -30,12 +30,20 @@ def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, v
   for x in range(0, num):
     vala = struct.unpack(typeapack, fna[x * typeasize: x * typeasize + typeasize])[0]
     valb = struct.unpack(typebpack, fnb[x * typebsize: x * typebsize + typebsize])[0]
-    if (mode[0:3] == 'add'):
-      diff = vala + float(value) - valb
+    if (mode == 'add'):
+      diff = vala + float(value1) - valb
       if diff > 0.01 or diff < -0.01:
         return 20
-    elif (mode[0:3] == 'mul'):
-      diff = vala * float(value) - valb
+    elif (mode == 'mul'):
+      diff = vala * float(value1) - valb
+      if diff > 0.01 or diff < -0.01:
+        return 20
+    elif (mode == 'add-mul'):
+      diff = (vala + float(value1)) * float(value2) - valb
+      if diff > 0.01 or diff < -0.01:
+        return 20
+    elif (mode == 'mul-add'):
+      diff = (vala * float(value1)) + float(value2) - valb
       if diff > 0.01 or diff < -0.01:
         return 20
     else:
@@ -52,7 +60,7 @@ if len(sys.argv) < 2:
   exit(5)
 
 if (sys.argv[1] == 'arithmetic'):
-  if len(sys.argv) < 10:
+  if len(sys.argv) < 11:
     exit(5)
   fna = readfile(sys.argv[2])
   fnb = readfile(sys.argv[3])
@@ -61,8 +69,9 @@ if (sys.argv[1] == 'arithmetic'):
   typeapack = (sys.argv[6])
   typebpack = (sys.argv[7])
   mode = sys.argv[8]
-  value = sys.argv[9]
+  value1 = sys.argv[9]
+  value2 = sys.argv[10]
 
-  exit(testArithmetic(fna, fnb, typeasize, typebsize, typeapack, typebpack, mode, value))
+  exit(testArithmetic(fna, fnb, typeasize, typebsize, typeapack, typebpack, mode, value1, value2))
 
 exit(5)

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -33,10 +33,52 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 python checkResult.py arithmetic testcase03.direct.log testcase03.arithmetic.log 4 4 f f mul -5.5 0
 casereport 3 $? "Golden test comparison"
 
+# Fail Test 3-F: for mul with floating-point operand
+gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul::-5.5 ! filesink location=\"testcase03.arithmetic.fail.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.fail.log\" sync=true" 3-F
+
+python checkResult.py arithmetic testcase03.direct.fail.log testcase03.arithmetic.fail.log 4 4 f f mul 0 -5.5
+casereport 3-F $? "Golden test comparison"
+
 # Test for add with floating-point operand
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:9.900000e-001 ! filesink location=\"testcase04.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.log\" sync=true" 4
 
 python checkResult.py arithmetic testcase04.direct.log testcase04.arithmetic.log 8 8 d d add 9.900000e-001 0
 casereport 4 $? "Golden test comparison"
+
+# Test for add with two floating-point operand: the second operand will be ignored.
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:9.900000e-001:-80.256 ! filesink location=\"testcase04.arithmetic.ok.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.ok.log\" sync=true" 4-OK
+
+python checkResult.py arithmetic testcase04.direct.ok.log testcase04.arithmetic.ok.log 8 8 d d add 9.900000e-001 -80.256
+casereport 4-OK $? "Golden test comparison"
+
+# Test for add-mul with floating-point operands
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3:-11.4823e-002 ! filesink location=\"testcase05.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5
+
+casereport 5 $? "Golden test comparison"
+python checkResult.py arithmetic testcase05.direct.log testcase05.arithmetic.log 8 8 d d add-mul -9.3 -11.4823e-002
+
+# Fail Test 5-F1: add-mul with single floating-point operand
+gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3 ! filesink location=\"testcase05.arithmetic.fail1.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail1.log\" sync=true" 5-F1
+
+casereport 5-F1 $? "Golden test comparison"
+python checkResult.py arithmetic testcase05.direct.fail1.log testcase05.arithmetic.fail1.log 8 8 d d add-mul -9.3 0
+
+# Fail Test 5-F2: add-mul with single floating-point operand
+gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3: ! filesink location=\"testcase05.arithmetic.fail2.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail2.log\" sync=true" 5-F2
+
+casereport 5-F2 $? "Golden test comparison"
+python checkResult.py arithmetic testcase05.direct.fail2.log testcase05.arithmetic.fail2.log 8 8 d d add-mul -9.3 0
+
+# Fail Test 5-F3: add-mul with single floating-point operand
+gstFailTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul::-11.4823e-002 ! filesink location=\"testcase05.arithmetic.fail3.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail3.log\" sync=true" 5-F3
+
+casereport 5-F3 $? "Golden test comparison"
+python checkResult.py arithmetic testcase05.direct.fail3.log testcase05.arithmetic.fail3.log 8 8 d d add-mul 30 -11.4823e-002
+
+# Test for mul-add with floating-point operands
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul-add:-50.0987e+003:15.3 ! filesink location=\"testcase06.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase06.direct.log\" sync=true" 6
+
+casereport 6 $? "Golden test comparison"
+python checkResult.py arithmetic testcase06.direct.log testcase06.arithmetic.log 8 8 d d add-mul -50.0987e+003 15.3
 
 report

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -18,25 +18,25 @@ gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40
 # Test with small stream (1, 2)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:-10 ! filesink location=\"testcase01.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase01.direct.log\" sync=true" 1
 
-python checkResult.py arithmetic testcase01.direct.log testcase01.arithmetic.log 4 4 f f add -10
+python checkResult.py arithmetic testcase01.direct.log testcase01.arithmetic.log 4 4 f f add -10 0
 casereport 1 $? "Golden test comparison"
 
 # Test with small stream (1, 2)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:2.0 ! filesink location=\"testcase02.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase02.direct.log\" sync=true" 2
 
-python checkResult.py arithmetic testcase02.direct.log testcase02.arithmetic.log 4 4 f f mul 2.0
+python checkResult.py arithmetic testcase02.direct.log testcase02.arithmetic.log 4 4 f f mul 2.0 0
 casereport 2 $? "Golden test comparison"
 
 # Test for mul with floating-point operand
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:-5.5 ! filesink location=\"testcase03.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.log\" sync=true" 3
 
-python checkResult.py arithmetic testcase03.direct.log testcase03.arithmetic.log 4 4 f f mul -5.5
+python checkResult.py arithmetic testcase03.direct.log testcase03.arithmetic.log 4 4 f f mul -5.5 0
 casereport 3 $? "Golden test comparison"
 
 # Test for add with floating-point operand
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:9.900000e-001 ! filesink location=\"testcase04.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.log\" sync=true" 4
 
-python checkResult.py arithmetic testcase04.direct.log testcase04.arithmetic.log 8 8 d d add 9.900000e-001
+python checkResult.py arithmetic testcase04.direct.log testcase04.arithmetic.log 8 8 d d add 9.900000e-001 0
 casereport 4 $? "Golden test comparison"
 
 report

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -27,4 +27,16 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 python checkResult.py arithmetic testcase02.direct.log testcase02.arithmetic.log 4 4 f f mul 2.0
 casereport 2 $? "Golden test comparison"
 
+# Test for mul with floating-point operand
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:-5.5 ! filesink location=\"testcase03.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.log\" sync=true" 3
+
+python checkResult.py arithmetic testcase03.direct.log testcase03.arithmetic.log 4 4 f f mul -5.5
+casereport 3 $? "Golden test comparison"
+
+# Test for add with floating-point operand
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:9.900000e-001 ! filesink location=\"testcase04.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.log\" sync=true" 4
+
+python checkResult.py arithmetic testcase04.direct.log testcase04.arithmetic.log 8 8 d d add 9.900000e-001
+casereport 4 $? "Golden test comparison"
+
 report


### PR DESCRIPTION
Resolves #523 

This PR includes
- supporting operand value of floating point type (the first sub-item of #523)
- supporting add-mul and mul-add  (the second sub-item of #523)
- adding several test cases in order to test both above cases

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped