### PR TITLE
[Transform/Common] code clean

### DIFF
--- a/gst/tensor_transform/tensor_transform.h
+++ b/gst/tensor_transform/tensor_transform.h
@@ -18,25 +18,11 @@
 /**
  * @file	tensor_transform.c
  * @date	10 Jul 2018
- * @brief	GStreamer plugin to transform other/tensor dimensions
- *
- * @see		http://github.com/nnsuite/nnstreamer
+ * @brief	GStreamer plugin to transform tensor dimension or type
+ * @see		https://github.com/nnsuite/nnstreamer
  * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug		No known bugs.
  *
- */
-/**
- * SECTION:element-tensor_transform
- *
- * A filter that converts other/tensor formats
- * The input/output is always in the format of other/tensor
- *
- * <refsect2>
- * <title>Example launch line</title>
- * |[
- * gst-launch -v -m fakesrc ! tensor_transform mode=dimchg option=0:2 ! fakesink silent=TRUE
- * ]|
- * </refsect2>
  */
 
 #ifndef __GST_TENSOR_TRANSFORM_H__
@@ -48,23 +34,22 @@
 
 G_BEGIN_DECLS
 
-/* #defines don't like whitespacey bits */
 #define GST_TYPE_TENSOR_TRANSFORM \
   (gst_tensor_transform_get_type())
 #define GST_TENSOR_TRANSFORM(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_TRANSFORM,GstTensor_Transform))
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_TRANSFORM,GstTensorTransform))
 #define GST_TENSOR_TRANSFORM_CLASS(klass) \
-  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_TRANSFORM,GstTensor_TransformClass))
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_TRANSFORM,GstTensorTransformClass))
 #define GST_IS_TENSOR_TRANSFORM(obj) \
   (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_TRANSFORM))
 #define GST_IS_TENSOR_TRANSFORM_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_TRANSFORM))
-#define GST_TENSOR_TRANSFORM_CAST(obj)  ((GstTensor_Transform *)(obj))
+#define GST_TENSOR_TRANSFORM_CAST(obj)  ((GstTensorTransform *)(obj))
+
 #define ARITH_OPRND_NUM_LIMIT  2
 
-typedef struct _GstTensor_Transform GstTensor_Transform;
-
-typedef struct _GstTensor_TransformClass GstTensor_TransformClass;
+typedef struct _GstTensorTransform GstTensorTransform;
+typedef struct _GstTensorTransformClass GstTensorTransformClass;
 
 typedef enum
 {
@@ -152,7 +137,7 @@ typedef struct _tensor_transform_stand {
 /**
  * @brief Internal data structure for tensor_transform instances.
  */
-struct _GstTensor_Transform
+struct _GstTensorTransform
 {
   GstBaseTransform element;	/**< This is the parent object */
 
@@ -174,13 +159,13 @@ struct _GstTensor_Transform
 };
 
 /**
- * @brief GstTensor_TransformClass inherits GstBaseTransformClass.
+ * @brief GstTensorTransformClass inherits GstBaseTransformClass.
  *
  * Referring another child (sibiling), GstVideoFilter (abstract class) and
  * its child (concrete class) GstVideoTransform.
- * Note that GstTensor_TransformClass is a concrete class; thus we need to look at both.
+ * Note that GstTensorTransformClass is a concrete class; thus we need to look at both.
  */
-struct _GstTensor_TransformClass
+struct _GstTensorTransformClass
 {
   GstBaseTransformClass parent_class;	/**< Inherits GstBaseTransformClass */
 };

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -346,32 +346,6 @@ extern gchar *get_tensor_dimension_string (const tensor_dim dim);
 extern size_t get_tensor_element_count (const tensor_dim dim);
 
 /**
- * @brief Read GstStructure, return corresponding tensor-dim/type. (other/tensor)
- * @return Notifies which part of dim/type is determined.
- * @param[in] str the GstStructure to be interpreted.
- * @param[out] dim the corresponging dimension info from the cap.
- * @param[out] type the corresponding element type from the cap.
- * @param[out] framerate_num Numerator of framerate. Set null to not use this.
- * @param[out] framerate_denum Denumerator of framerate. Set null to not use this.
- */
-extern GstTensor_Filter_CheckStatus
-get_tensor_from_structure (const GstStructure * str, tensor_dim dim,
-    tensor_type * type, int *framerate_num, int *framerate_denum);
-
-/**
- * @brief Read pad-cap, return corresponding tensor-dim/type. (other/tensor)
- * @return Notifies which part of dim/type is determined.
- * @param[in] caps the pad-cap to be interpreted.
- * @param[out] dim the corresponging dimension info from the cap.
- * @param[out] type the corresponding element type from the cap.
- * @param[out] framerate_num Numerator of framerate. Set null to not use this.
- * @param[out] framerate_denum Denumerator of framerate. Set null to not use this.
- */
-extern GstTensor_Filter_CheckStatus
-get_tensor_from_padcap (const GstCaps * caps, tensor_dim dim,
-    tensor_type * type, int *framerate_num, int *framerate_denum);
-
-/**
  * @brief Make str(xyz) ==> "xyz" with macro expansion
  */
 #define str(s) xstr(s)

--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -88,18 +88,6 @@ typedef enum _nnfw_type
 struct _GstTensorFilterFramework;
 typedef struct _GstTensorFilterFramework GstTensorFilterFramework;
 
-typedef enum
-{
-  _TFC_INIT = 0,
-  _TFC_DIMENSION = 1,
-  _TFC_TYPE = 2,
-  _TFC_ALL = _TFC_DIMENSION | _TFC_TYPE,
-
-  _TFC_FRAMERATE = 4,
-
-  /** @todo Add "consistency checked. don't check it again" and implement .c accordingly. */
-} GstTensor_Filter_CheckStatus;
-
 typedef uint32_t tensor_dim[NNS_TENSOR_RANK_LIMIT];
 
 /**


### PR DESCRIPTION
1. use common functions and structure in tensor-transform
2. add macros to print debug message
3. remove functions to parse caps (get_tensor_from_padcap, get_tensor_from_structure in common)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
