### PR TITLE
[TensorMerge] Add Proper GstMemory Generation according to direction

### DIFF
--- a/gst/tensor_merge/gsttensormerge.h
+++ b/gst/tensor_merge/gsttensormerge.h
@@ -51,9 +51,10 @@ typedef enum
 
 typedef enum
 {
-  LINEAR_WIDTH = 0,
-  LINEAR_HEIGHT = 1,
-  LINEAR_CHANNEL = 2,
+  LINEAR_FIRST = 0, 		/* CHANNEL */
+  LINEAR_SECOND = 1,		/* WIDTH */
+  LINEAR_THIRD = 2,		/* HEIGHT */
+  LINEAR_FOURTH = 3,  		/* BATCH */
   LINEAR_END,
 } tensor_merge_linear_mode;
 

--- a/tests/nnstreamer_merge/generateTest.py
+++ b/tests/nnstreamer_merge/generateTest.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file generateTest.py
+# @brief Generate golden test results for test cases
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from struct import pack
+import random
+
+import numpy as np
+
+def saveTestData(filename, width, height, channel, batch):
+    string = b''
+    data = []
+
+    for b in range(0,batch):
+        for h in range(0,height):
+            for w in range(0,width):
+                for c in range(0,channel):
+                    n = random.uniform(0.0, 10.0)
+                    string += pack('f', n)
+                    data.append(n)
+
+    with open(filename,'wb') as file:
+        file.write(string)
+    file.close()
+
+    return data
+
+#merge with channel direction
+ch = [3, 2, 4]
+width = 100
+height= 50
+batch= 1
+
+buf=[]
+
+buf.append(saveTestData("channel_00.dat", width, height, 3, batch))
+buf.append(saveTestData("channel_01.dat", width, height, 2, batch))
+buf.append(saveTestData("channel_02.dat", width, height, 4, batch))
+
+out = ''
+for b in range(0, batch):
+    for h in range(0,height):
+        for w in range(0,width):
+            for n in range(0,3):
+                for c in range(0,ch[n]):
+                    out += pack('f',buf[n][b*height*width*ch[n]+h*width*ch[n] + w * ch[n] + c])
+
+with open("channel.golden", 'wb') as file:
+    file.write(out)
+
+#merge with width direction
+width = [100, 200, 300]
+ch = 3
+height= 50
+batch= 1
+
+buf=[]
+
+buf.append(saveTestData("width_100.dat", width[0], height, ch, batch))
+buf.append(saveTestData("width_200.dat", width[1], height, ch, batch))
+buf.append(saveTestData("width_300.dat", width[2], height, ch, batch))
+
+out = ''
+
+for b in range(0, batch):
+    for h in range(0,height):
+        for n in range(0,3):
+            for w in range(0,width[n]):
+                for c in range(0,ch):
+                    out += pack('f',buf[n][b*height*width[n]*ch + h*width[n]*ch + w * ch + c])
+
+with open("width.golden", 'wb') as file:
+    file.write(out)
+
+#merge with width direction
+batch = [1, 2, 3]
+ch = 3
+height= 50
+width= 100
+
+buf=[]
+
+buf.append(saveTestData("batch_1.dat", width, height, ch, batch[0]))
+buf.append(saveTestData("batch_2.dat", width, height, ch, batch[1]))
+buf.append(saveTestData("batch_3.dat", width, height, ch, batch[2]))
+
+out = ''
+for n in range(0,3):
+    for b in range(0, batch[n]):
+        for h in range(0,height):
+            for w in range(0,width):
+                for c in range(0,ch):
+                    out += pack('f',buf[n][b*height*width*ch + h*width*ch + w * ch + c])
+
+with open("batch.golden", 'wb') as file:
+    file.write(out)

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -8,36 +8,51 @@ then
 else
   echo "Test Case Generation Started"
   python ../nnstreamer_converter/generateGoldenTestResult.py 9
+  python generateTest.py
   sopath=$1
 fi
 convertBMP2PNG
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase01_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0" 1
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase01_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0" 1
 
 compareAllSizeLimit testcase01_RGB_100x100.golden testcase01_RGB_100x100.log 1
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase02_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_1" 2
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase02_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_1" 2
 
 compareAllSizeLimit testcase02_RGB_100x100.golden testcase02_RGB_100x100.log 2
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase03_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_1 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_2" 3
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase03_RGB_100x100.log filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_0 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_1 filesrc location=testcase02_RGB_100x100.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,width=100,height=100,framerate=0/1  ! tensor_converter ! merge.sink_2" 3
 
 compareAllSizeLimit testcase03_RGB_100x100.golden testcase03_RGB_100x100.log 3
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase01.log multifilesrc location=\"testsequence01_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0" 4
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase01.log multifilesrc location=\"testsequence01_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0" 4
 
 compareAllSizeLimit testcase01.golden testcase01.log 4
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase02.log multifilesrc location=\"testsequence02_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence02_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1" 5
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase02.log multifilesrc location=\"testsequence02_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence02_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1" 5
 
 compareAllSizeLimit testcase02.golden testcase02.log 5
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase03.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_2" 6
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase03.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_2" 6
 
 compareAllSizeLimit testcase03.golden testcase03.log 6
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=channel ! filesink location=testcase04.log multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_2 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_3" 7
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 ! filesink location=testcase04.log multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_2 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_3" 7
 
 compareAllSizeLimit testcase03.golden testcase03.log 7
+
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=0 ! filesink location=channel.log filesrc location=channel_00.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:50:100:1 input-type=float32 ! merge.sink_0 filesrc location=channel_01.dat blocksize=40000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=2:50:100:1 input-type=float32 ! merge.sink_1 filesrc location=channel_02.dat blocksize=80000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=4:50:100:1 input-type=float32 ! merge.sink_2" 8
+
+compareAllSizeLimit channel.golden channel.log 8
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=1 ! filesink location=width.log filesrc location=width_100.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:100:50:1 input-type=float32 ! merge.sink_0 filesrc location=width_200.dat blocksize=120000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:200:50:1 input-type=float32 ! merge.sink_1 filesrc location=width_300.dat blocksize=180000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:300:50:1 input-type=float32 ! merge.sink_2" 9
+
+compareAllSizeLimit width.golden width.log 9
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=3 ! filesink location=batch.log filesrc location=batch_1.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:100:50:1 input-type=float32 ! merge.sink_0 filesrc location=batch_2.dat blocksize=120000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:100:50:2 input-type=float32 ! merge.sink_1 filesrc location=batch_3.dat blocksize=180000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:100:50:3 input-type=float32 ! merge.sink_2" 10
+
+compareAllSizeLimit batch.golden batch.log 10
+
 
 report


### PR DESCRIPTION
# PR Description

Add gst_tensor_merge_generate_mem function to generate output
GstMemory to push.
Now support linear mode and channel, width, height option.

Assume tensor a is aC:aW:aH:aB and b is bC:bW:bH:bB.
if the mode is linear and channel option,
the output tensor is generated by
  aC+bC:aW:aH:aB ( should be aH==bH, aW==bW and a.type==b.type ).
  That means,

   [[aB][aH][aW][aC,bC]]

if linear and width option,
  aC:aW+bW:aH,aB ( should be aC==bC, aH==bH and a.type==b.type ).

  [[aB][aH][aW,bW][aC]]

if linear and height option
  aC:aW:aH+bH,aB (should be aC==bC, aW==bW and a.type==b.type ).

  [[aB][aH,bH][aW][aC]]

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>