### PR TITLE
[TensorMerge] Add Synchronization based on PTS Time

### DIFF
--- a/gst/tensor_merge/gsttensormerge.h
+++ b/gst/tensor_merge/gsttensormerge.h
@@ -72,6 +72,7 @@ typedef struct
   GstCollectData collect;
   GstClockTime pts_timestamp;
   GstClockTime dts_timestamp;
+  GstBuffer *buffer;
   GstPad *pad;
 } GstTensorMergePadData;
 
@@ -97,6 +98,9 @@ struct _GstTensorMerge
   gboolean need_stream_start;
   gboolean send_stream_start;
 
+  gboolean need_buffer;
+  GstClockTime current_time;
+  gboolean need_set_time;
   GstTensorsConfig tensors_config; /**< output tensors info */
 };
 


### PR DESCRIPTION
# PR Description

We need time synchronization based on PTS (GST_FORMAT_TIME).

if there is three src with 30/1, 20/1, 10/1 framerates, then it should
be synchronized as follow.

```
          src_0              src_1                 src_2
(Synch) 000000000          000000000             000000000 : merged
(Drop)   33333333
(Drop)   66666666           50000000
(Synch)  99999999          100000000             100000000 : merged
(Drop)  133333333
(Drop)  166666666          150000000
(Synch) 199999999          200000000             200000000 : merged
(Drop)  233333333
(Drop)  266666666          250000000
(Synch) 299999999          300000000             300000000 : merged
    ....
```

In order to do this, gst_tensor_merge_collect_buffer() is modified.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
