### PR TITLE
[Common/Test] expand video formats

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -360,6 +360,7 @@ gst_tensor_config_from_video_info (GstTensorConfig * config,
   GstVideoFormat format = GST_VIDEO_FORMAT_UNKNOWN;
   gint width = 0;
   gint height = 0;
+  gint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
   gst_tensor_config_init (config);
@@ -383,10 +384,18 @@ gst_tensor_config_from_video_info (GstTensorConfig * config,
       config->info.dimension[0] = 1;
       break;
     case GST_VIDEO_FORMAT_RGB:
+    case GST_VIDEO_FORMAT_BGR:
       config->info.type = _NNS_UINT8;
       config->info.dimension[0] = 3;
       break;
+    case GST_VIDEO_FORMAT_RGBx:
     case GST_VIDEO_FORMAT_BGRx:
+    case GST_VIDEO_FORMAT_xRGB:
+    case GST_VIDEO_FORMAT_xBGR:
+    case GST_VIDEO_FORMAT_RGBA:
+    case GST_VIDEO_FORMAT_BGRA:
+    case GST_VIDEO_FORMAT_ARGB:
+    case GST_VIDEO_FORMAT_ABGR:
       config->info.type = _NNS_UINT8;
       config->info.dimension[0] = 4;
       break;
@@ -399,6 +408,10 @@ gst_tensor_config_from_video_info (GstTensorConfig * config,
   config->info.dimension[1] = width;
   config->info.dimension[2] = height;
   config->info.dimension[3] = 1; /** Supposed 1 frame in tensor, change this if tensor contains N frames. */
+
+  for (i = 4; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    config->info.dimension[i] = 1;
+  }
 
   return (config->info.type != _NNS_END);
 }
@@ -423,6 +436,7 @@ gst_tensor_config_from_audio_info (GstTensorConfig * config,
   GstAudioFormat format = GST_AUDIO_FORMAT_UNKNOWN;
   gint channels = 0;
   gint rate = 0;
+  gint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
   gst_tensor_config_init (config);
@@ -471,8 +485,10 @@ gst_tensor_config_from_audio_info (GstTensorConfig * config,
 
   config->info.dimension[0] = channels;
   config->info.dimension[1] = 1; /** Supposed 1 frame in tensor, change this if tensor contains N frames */
-  config->info.dimension[2] = 1;
-  config->info.dimension[3] = 1;
+
+  for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    config->info.dimension[i] = 1;
+  }
 
   if (rate > 0) {
     config->rate_n = rate;
@@ -498,6 +514,7 @@ gst_tensor_config_from_text_info (GstTensorConfig * config,
    * A string-type Tensor
    */
   const gchar *format_string;
+  gint i;
 
   g_return_val_if_fail (config != NULL, FALSE);
   gst_tensor_config_init (config);
@@ -517,8 +534,10 @@ gst_tensor_config_from_text_info (GstTensorConfig * config,
   /** [size][frames] */
   config->info.dimension[0] = GST_TENSOR_STRING_SIZE; /** fixed size of string */
   config->info.dimension[1] = 1; /** Supposed 1 frame in tensor, change this if tensor contains N frames */
-  config->info.dimension[2] = 1;
-  config->info.dimension[3] = 1;
+
+  for (i = 2; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    config->info.dimension[i] = 1;
+  }
 
   if (gst_structure_has_field (structure, "framerate")) {
     gst_structure_get_fraction (structure, "framerate", &config->rate_n,
@@ -554,11 +573,6 @@ gst_tensor_config_from_octet_stream_info (GstTensorConfig * config,
    * All tensor info should be updated.
    */
   config->info.type = _NNS_UINT8;
-
-  config->info.dimension[0] = 1;
-  config->info.dimension[1] = 1;
-  config->info.dimension[2] = 1;
-  config->info.dimension[3] = 1;
 
   if (gst_structure_has_field (structure, "framerate")) {
     gst_structure_get_fraction (structure, "framerate", &config->rate_n,

--- a/include/tensor_common.h
+++ b/include/tensor_common.h
@@ -43,7 +43,7 @@ G_BEGIN_DECLS
 #endif
 
 #define GST_TENSOR_VIDEO_CAPS_STR \
-    GST_VIDEO_CAPS_MAKE ("{ RGB, BGRx, GRAY8 }") \
+    GST_VIDEO_CAPS_MAKE ("{ RGB, BGR, RGBx, BGRx, xRGB, xBGR, RGBA, BGRA, ARGB, ABGR, GRAY8 }") \
     ", views = (int) 1, interlace-mode = (string) progressive"
 
 #define GST_TENSOR_AUDIO_CAPS_STR \

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -52,8 +52,17 @@ typedef enum
 typedef enum
 {
   TEST_TYPE_VIDEO_RGB, /**< pipeline for video (RGB) */
+  TEST_TYPE_VIDEO_BGR, /**< pipeline for video (BGR) */
   TEST_TYPE_VIDEO_RGB_PADDING, /**< pipeline for video (RGB), remove padding */
+  TEST_TYPE_VIDEO_BGR_PADDING, /**< pipeline for video (BGR), remove padding */
   TEST_TYPE_VIDEO_RGB_3F, /**< pipeline for video (RGB) 3 frames */
+  TEST_TYPE_VIDEO_RGBA, /**< pipeline for video (RGBA) */
+  TEST_TYPE_VIDEO_BGRA, /**< pipeline for video (BGRA) */
+  TEST_TYPE_VIDEO_ARGB, /**< pipeline for video (ARGB) */
+  TEST_TYPE_VIDEO_ABGR, /**< pipeline for video (ABGR) */
+  TEST_TYPE_VIDEO_RGBx, /**< pipeline for video (RGBx) */
+  TEST_TYPE_VIDEO_xRGB, /**< pipeline for video (xRGB) */
+  TEST_TYPE_VIDEO_xBGR, /**< pipeline for video (xBGR) */
   TEST_TYPE_VIDEO_BGRx, /**< pipeline for video (BGRx) */
   TEST_TYPE_VIDEO_BGRx_2F, /**< pipeline for video (BGRx) 2 frames */
   TEST_TYPE_VIDEO_GRAY8, /**< pipeline for video (GRAY8) */
@@ -377,11 +386,25 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
           "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
       break;
+    case TEST_TYPE_VIDEO_BGR:
+      /** video 160x120 BGR */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGR,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
     case TEST_TYPE_VIDEO_RGB_PADDING:
       /** video 162x120 RGB, remove padding */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_BGR_PADDING:
+      /** video 162x120 BGR, remove padding */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGR,framerate=(fraction)30/1 ! "
           "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
       break;
     case TEST_TYPE_VIDEO_RGB_3F:
@@ -392,11 +415,60 @@ _setup_pipeline (TestOption & option)
           "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink",
           option.num_buffers);
       break;
-    case TEST_TYPE_VIDEO_BGRx:
-      /** video 160x120 BGRx */
+    case TEST_TYPE_VIDEO_RGBA:
+      /** video 162x120 RGBA */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGRx,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBA,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_BGRA:
+      /** video 162x120 BGRA */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRA,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_ARGB:
+      /** video 162x120 ARGB */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ARGB,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_ABGR:
+      /** video 162x120 ABGR */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ABGR,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_RGBx:
+      /** video 162x120 RGBx */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBx,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_xRGB:
+      /** video 162x120 xRGB */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xRGB,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_xBGR:
+      /** video 162x120 xBGR */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xBGR,framerate=(fraction)30/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+      break;
+    case TEST_TYPE_VIDEO_BGRx:
+      /** video 162x120 BGRx */
+      str_pipeline =
+          g_strdup_printf
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRx,framerate=(fraction)30/1 ! "
           "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
       break;
     case TEST_TYPE_VIDEO_BGRx_2F:
@@ -519,7 +591,7 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("appsrc name=appsrc caps=application/octet-stream,framerate=(fraction)100/1 ! "
-          "tensor_converter input-dim=1:5 input-type=uint8 ! tensor_sink name=test_sink");
+          "tensor_converter input-dim=1:5 input-type=int8 ! tensor_sink name=test_sink");
       break;
     case TEST_TYPE_TENSORS:
       /** other/tensors with tensor_mux */
@@ -953,7 +1025,7 @@ TEST (tensor_sink_test, caps_tensors)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 2);
-  EXPECT_EQ (g_test_data.received_size, 115200); /** 160 * 120 * 3 * 2 */
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
@@ -1017,7 +1089,49 @@ TEST (tensor_stream_test, video_rgb)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 57600);
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format BGR.
+ */
+TEST (tensor_stream_test, video_bgr)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1059,7 +1173,49 @@ TEST (tensor_stream_test, video_rgb_padding)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 58320);
+  EXPECT_EQ (g_test_data.received_size, 3 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format BGR, remove padding.
+ */
+TEST (tensor_stream_test, video_bgr_padding)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGR_PADDING };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 3 * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1101,7 +1257,7 @@ TEST (tensor_stream_test, video_rgb_3f)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 57600 * 3);
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1116,6 +1272,300 @@ TEST (tensor_stream_test, video_rgb_3f)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format RGBA.
+ */
+TEST (tensor_stream_test, video_rgba)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGBA };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format BGRA.
+ */
+TEST (tensor_stream_test, video_bgra)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_BGRA };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format ARGB.
+ */
+TEST (tensor_stream_test, video_argb)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_ARGB };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format ABGR.
+ */
+TEST (tensor_stream_test, video_abgr)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_ABGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format RGBx.
+ */
+TEST (tensor_stream_test, video_rgbx)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_RGBx };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format xRGB.
+ */
+TEST (tensor_stream_test, video_xrgb)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_xRGB };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
+
+  EXPECT_FALSE (g_test_data.test_failed);
+  _free_test_data ();
+}
+
+/**
+ * @brief Test for video format xBGR.
+ */
+TEST (tensor_stream_test, video_xbgr)
+{
+  const guint num_buffers = 5;
+  TestOption option = { num_buffers, TEST_TYPE_VIDEO_xBGR };
+
+  ASSERT_TRUE (_setup_pipeline (option));
+
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
+  g_main_loop_run (g_test_data.loop);
+  gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
+
+  /** check eos message */
+  EXPECT_EQ (g_test_data.status, TEST_EOS);
+
+  /** check received buffers and signals */
+  EXPECT_EQ (g_test_data.received, num_buffers);
+  EXPECT_EQ (g_test_data.mem_blocks, 1);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+
+  /** check caps name */
+  EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
+
+  /** check timestamp */
+  EXPECT_FALSE (g_test_data.invalid_timestamp);
+
+  /** check tensor config for video */
+  EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1143,7 +1593,7 @@ TEST (tensor_stream_test, video_bgrx)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 76800);
+  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1155,7 +1605,7 @@ TEST (tensor_stream_test, video_bgrx)
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
@@ -1185,7 +1635,7 @@ TEST (tensor_stream_test, video_bgrx_2f)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 2);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 76800 * 2);
+  EXPECT_EQ (g_test_data.received_size, 4 * 160 * 120 * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1227,7 +1677,7 @@ TEST (tensor_stream_test, video_gray8)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 19200);
+  EXPECT_EQ (g_test_data.received_size, 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1269,7 +1719,7 @@ TEST (tensor_stream_test, video_gray8_padding)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 19440);
+  EXPECT_EQ (g_test_data.received_size, 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1311,7 +1761,7 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 19440 * 3);
+  EXPECT_EQ (g_test_data.received_size, 162 * 120 * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1839,7 +2289,7 @@ TEST (tensor_stream_test, octet_2)
 
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
-  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
+  EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT8);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 5);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
@@ -1871,7 +2321,7 @@ TEST (tensor_stream_test, custom_filter_tensor)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 57600);
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2489,7 +2939,7 @@ TEST (tensor_stream_test, video_aggregate_1)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, (num_buffers - 10) / 5 + 1);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 57600 * 10);
+  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 10);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2531,7 +2981,7 @@ TEST (tensor_stream_test, video_aggregate_2)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, (num_buffers - 10) / 5 + 1);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 57600 * 10);
+  EXPECT_EQ (g_test_data.received_size, 3 * 1600 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));


### PR DESCRIPTION
1. add video formats for caps negotiation in tensor-converter
2. change code to init tensor dimension
3. add simple stream testcases for added video formats

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
