### PR TITLE
[Common/Typedef] Include a header file 'stddef.h' to use 'size_t' and revise the boilerplate code

### DIFF
--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -28,6 +28,8 @@
 #ifndef __GST_TENSOR_TYPEDEF_H__
 #define __GST_TENSOR_TYPEDEF_H__
 
+#include <stddef.h>
+
 #define NNS_TENSOR_RANK_LIMIT	(4)
 #define NNS_TENSOR_SIZE_LIMIT	(16)
 #define NNS_TENSOR_SIZE_LIMIT_STR	"16"

--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -14,7 +14,7 @@
  *
  */
 /**
- * @file	tensor_common_typedef.h
+ * @file	tensor_typedef.h
  * @date	01 Jun 2018
  * @brief	Common header file for NNStreamer, the GStreamer plugin for neural networks
  * @see		http://github.com/nnsuite/nnstreamer


### PR DESCRIPTION
In this PR, 
- A header file 'stddef.h' is included in 'tensor_typedef.h' to use 'size_t'. Without 'stddef.h', it is failed to build the source code that include 'tensor_typedef.h' alone.
- A file name on boilerplate code is corrected as well: tensor_common_typedef.h ->tensor_typedef.h

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped