### PR TITLE
[Tensor Decoder] Security: fixed not null termination of strncpy(3)

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -738,6 +738,7 @@ gst_get_image_label (GstTensorDec * self, gint label)
       (self->tensordec_image_label.labels, check_label);
 }
 
+
 /**
  * @brief set output of tensor decoder that will send to src pad  
  * @param self "this" pointer
@@ -761,11 +762,22 @@ gst_tensordec_label_set_output (GstTensorDec * self, GstBuffer * outbuf,
   g_assert (out_mem != NULL);
   g_assert (gst_memory_map (out_mem, &out_info, GST_MAP_WRITE));
 
+  /**
+   * Security: strncpy protects from buffer overflows. But, if it prevents an
+   * overflow without null termiating, a subsequent string operation cause overflow.
+   *
+   * Gstreamer: Note that gst-plugins-base/gstbasetextoverlay.c:g_utf8_validate()
+   * displays '*' at back of the string if a string includes a NULL character.
+   *
+   * Won't Fix: The warning might be a defect according to the gst-plugins-base (GStreamer),
+   * but it will not make trouble in this code.
+   */
   strncpy ((char *) out_info.data, label, len);
+
+  gst_memory_unmap (out_mem, &out_info);
 
   gst_buffer_append_memory (outbuf, out_mem);
 
-  gst_memory_unmap (out_mem, &out_info);
 }
 
 /**


### PR DESCRIPTION
Fixed issue #690.

This commit is to fix not null termination issue in strncpy library call
in the tensor decoder element.

strncpy() supposedly protects from buffer overflows. But if it prevents
an overflow without null terminating, in all likelyhood a subsequent
string operation is going to overflow.

**Change proposed in this PR:**
* Version 3:
  1. Commented security issue and Gstreamer (gstbasetextoverlay.c) policy

* Version 2:
  1. Replasced strncpy with memcpy.
  2. Added annotation.

* Version 1:
  1. Fixed not null termination issue of strncpy() by using memset().

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
