### PR TITLE
[CMAKE] Set VERSION to use @VERSION@ in input file of config_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ ELSE(SINGLE_BINARY)
 	MESSAGE(STATUS "The nnstreamer elements will be created as multple plugin binaries, one binary for one element. This is no more the standard method to release since nnstreamer 0.0.3.")
 ENDIF(SINGLE_BINARY)
 
-ADD_DEFINITIONS(-DVERSION="0.0.3")
+SET(VERSION "0.0.3")
+ADD_DEFINITIONS(-DVERSION="${VERSION}")
 
 SET(PREFIX ${CMAKE_INSTALL_PREFIX})
 SET(EXEC_PREFIX "${PREFIX}/bin")


### PR DESCRIPTION
# PR Description
In order to reference variable values using '@VAR@' forms, VAR should be defined using the 'set' cmake command. However, 'instead of 'VERSION', since '-DVERSION' is defined using 'add_definitions', @VERSION@ could not be properly substitued. As a result, the 'Version' field in the pkg-config file for nnstreamer only contains a white space. 

This PR fixes this issue #698.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [  ]Skipped

```bash
$ cat nnstreamer.pc 
# Package Information for pkg-config, for custom nnstreamer plugin writers

prefix=...
exec_prefix=...
libdir=...
includedir=...

Name: nnstreamer
Description: Custom Plugin Dev Kit of Neural Network Suite for GStreamer
Version: 0.0.3
Requires:
Libs:
Cflags: -I${includedir}/nnstreamer
```

Signed-off-by: Wook Song <wook16.song@samsung.com>