### PR TITLE
[WIP][Common/Typedef] add rank_type to easily access a dimension of tensor

### DIFF
--- a/include/tensor_typedef.h
+++ b/include/tensor_typedef.h
@@ -56,6 +56,16 @@ typedef enum _nns_tensor_type
   _NNS_END,
 } tensor_type;
 
+typedef enum _nns_rank_type
+{
+  NNS_CHANNEL = 0,
+  NNS_X_AXIS,
+  NNS_Y_AXIS,
+  NNS_BATCH,
+
+  NNS_END,
+} rank_type;
+
 /**
  * @brief Byte-per-element of each tensor element type.
  */

--- a/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
+++ b/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
@@ -70,8 +70,8 @@ set_inputDim (void *private_data, const GstTensorFilterProperties * prop,
     out_info->info[0].dimension[i] = in_info->info[0].dimension[i];
 
   /* Update output dimension [1] and [2] with new-x, new-y */
-  out_info->info[0].dimension[1] = 1;
-  out_info->info[0].dimension[2] = 1;
+  out_info->info[0].dimension[NNS_X_AXIS] = 1;
+  out_info->info[0].dimension[NNS_Y_AXIS] = 1;
 
   out_info->info[0].type = in_info->info[0].type;
   return 0;


### PR DESCRIPTION
In order to easily access a dimension of tensor instead of naive integer
index, this patch newly adds an rank_type enumeration. Using this, developers
make a custom filter more easily without further confusion.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>