### PR TITLE
[PkgConfig] Use @INCLUDE_INSTALL_DIR@ instead of the hard-coded path

### DIFF
--- a/nnstreamer.pc.in
+++ b/nnstreamer.pc.in
@@ -3,7 +3,7 @@
 prefix=@PREFIX@
 exec_prefix=@EXEC_PREFIX@
 libdir=@LIB_INSTALL_DIR@
-includedir=/usr/include
+includedir=@INCLUDE_INSTALL_DIR@
 
 Name: nnstreamer
 Description: Custom Plugin Dev Kit of Neural Network Suite for GStreamer


### PR DESCRIPTION
# PR Description

This PR is also related to #698.

The existing input file for pkg-config uses the hard-coded path, '/usr/include', to set the location to install the header files. In order to improve portability, this PR replaces '/usr/include' with @INCLUDE_INSTALL_DIR@ which is provided from the build script.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>