### PR TITLE
[Aggregator] fix new caps event in sink-pad

### DIFF
--- a/gst/tensor_aggregator/tensor_aggregator.c
+++ b/gst/tensor_aggregator/tensor_aggregator.c
@@ -407,9 +407,12 @@ gst_tensor_aggregator_sink_event (GstPad * pad, GstObject * parent,
         silent_debug_caps (out_caps, "out-caps");
 
         gst_pad_set_caps (self->srcpad, out_caps);
-        gst_pad_push_event (self->srcpad, gst_event_new_caps (out_caps));
+
+        gst_event_unref (event);
+        event = gst_event_new_caps (out_caps);
+
         gst_caps_unref (out_caps);
-        return TRUE;
+        return gst_pad_push_event (self->srcpad, event);
       }
       break;
     }


### PR DESCRIPTION
unref old event and push the configured tensor caps to src pad

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
