### PR TITLE
[Converter] handle segment and timestamp

### DIFF
--- a/gst/tensor_converter/tensor_converter.h
+++ b/gst/tensor_converter/tensor_converter.h
@@ -86,6 +86,7 @@ struct _GstTensorConverter
   gboolean have_segment; /**< True if received segment */
   gboolean need_segment; /**< True to handle seg event */
   GstSegment segment; /**< Segment, supposed time format */
+  GstClockTime old_timestamp; /**< timestamp at prev buffer */
 };
 
 /**

--- a/gst/tensor_converter/tensor_converter.h
+++ b/gst/tensor_converter/tensor_converter.h
@@ -66,6 +66,7 @@ struct _GstTensorConverter
   GstPad *srcpad; /**< src pad */
 
   gboolean silent; /**< true to print minimized log */
+  gboolean set_timestamp; /**< true to set timestamp when received a buffer with invalid timestamp */
   guint frames_per_tensor; /**< number of frames in output tensor */
   GstTensorInfo tensor_info; /**< data structure to get/set tensor info */
 

--- a/gst/tensor_converter/tensor_converter.h
+++ b/gst/tensor_converter/tensor_converter.h
@@ -81,6 +81,10 @@ struct _GstTensorConverter
   gboolean remove_padding; /**< If true, zero-padding must be removed */
   gboolean tensor_configured; /**< True if already successfully configured tensor metadata */
   GstTensorConfig tensor_config; /**< output tensor info */
+
+  gboolean have_segment; /**< True if received segment */
+  gboolean need_segment; /**< True to handle seg event */
+  GstSegment segment; /**< Segment, supposed time format */
 };
 
 /**


### PR DESCRIPTION
[Project NS] invalid timestamp in byte-stream

tensor-converter sets new timestamp if incoming buffer has invalid timestamp.

1. push time formatted segment event to down-stream.
2. add new property to set timestamp.
3. set timestamp using framerate.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
