### PR TITLE
[Converter] fix to unref old caps event

### DIFF
--- a/gst/tensor_converter/tensor_converter.c
+++ b/gst/tensor_converter/tensor_converter.c
@@ -401,9 +401,12 @@ gst_tensor_converter_sink_event (GstPad * pad, GstObject * parent,
         silent_debug_caps (out_caps, "out-caps");
 
         gst_pad_set_caps (self->srcpad, out_caps);
-        gst_pad_push_event (self->srcpad, gst_event_new_caps (out_caps));
+
+        gst_event_unref (event);
+        event = gst_event_new_caps (out_caps);
+
         gst_caps_unref (out_caps);
-        return TRUE;
+        return gst_pad_push_event (self->srcpad, event);
       }
       break;
     }


### PR DESCRIPTION
unref old caps event and push new caps to src pad.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
