### PR TITLE
[Merge] change code to compare timestamp @open sesame 10/30 19:50

### DIFF
--- a/gst/tensor_merge/gsttensormerge.c
+++ b/gst/tensor_merge/gsttensormerge.c
@@ -514,9 +514,11 @@ gst_tensor_merge_collect_buffer (GstTensorMerge * tensor_merge,
         return FALSE;
       }
 
-      if (pad->buffer != NULL
-          && ABS (tensor_merge->current_time - GST_BUFFER_PTS (pad->buffer)) <
-          ABS (tensor_merge->current_time - GST_BUFFER_PTS (buf))) {
+      if (pad->buffer != NULL &&
+          ABS (GST_CLOCK_DIFF (tensor_merge->current_time,
+                  GST_BUFFER_PTS (pad->buffer))) <
+          ABS (GST_CLOCK_DIFF (tensor_merge->current_time,
+                  GST_BUFFER_PTS (buf)))) {
         gst_buffer_unref (buf);
         buf = pad->buffer;
       } else {


### PR DESCRIPTION
to fix coverity issue, use GST_CLOCK_DIFF to get time-diff of buffer pts time.
(pts is unsigned value, diff of two buffer timestamp always returns unsigned value)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
