### PR TITLE
[Example] add leaky to drop old buffers @open sesame 11/02 17:59

### DIFF
--- a/nnstreamer_example/example_decoder_image_labelling/nnstreamer_example_decoder_image_labelling.c
+++ b/nnstreamer_example/example_decoder_image_labelling/nnstreamer_example_decoder_image_labelling.c
@@ -293,12 +293,12 @@ main (int argc, char **argv)
   /** init pipeline */
   str_pipeline =
       g_strdup_printf
-      ("textoverlay name=overlay font-desc=\"Sans, 24\" ! videoconvert ! ximagesink name=img_test "
+      ("textoverlay name=overlay font-desc=Sans,24 ! videoconvert ! ximagesink name=img_test "
       "v4l2src name=cam_src ! videoscale ! video/x-raw,width=640,height=480,format=RGB ! tee name=t_raw "
       "t_raw. ! queue ! overlay.video_sink "
-      "t_raw. ! queue ! videoscale ! video/x-raw,width=%d,height=%d !tensor_converter !"
+      "t_raw. ! queue ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter !"
       "tensor_filter framework=tensorflow-lite model=%s ! "
-      "tensor_decoder output-type=2 mode=image_labeling mode-option-1=%s ! overlay.text_sink ",
+      "tensor_decoder output-type=2 mode=image_labeling mode-option-1=%s ! overlay.text_sink",
       width, height, g_app.tflite_info.model_path, tflite_label);
   g_app.pipeline = gst_parse_launch (str_pipeline, NULL);
   g_free (str_pipeline);

--- a/nnstreamer_example/example_filter/nnstreamer_example_filter.c
+++ b/nnstreamer_example/example_filter/nnstreamer_example_filter.c
@@ -441,9 +441,9 @@ main (int argc, char **argv)
       g_strdup_printf
       ("v4l2src name=cam_src ! videoscale ! "
       "video/x-raw,width=640,height=480,format=RGB ! tee name=t_raw "
-      "t_raw. ! queue ! textoverlay name=tensor_res font-desc=\"Sans, 24\" ! "
+      "t_raw. ! queue ! textoverlay name=tensor_res font-desc=Sans,24 ! "
       "videoconvert ! ximagesink name=img_tensor "
-      "t_raw. ! queue ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter ! "
+      "t_raw. ! queue leaky=2 max-size-buffers=2 ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter ! "
       "tensor_filter framework=tensorflow-lite model=%s ! "
       "tensor_sink name=tensor_sink",
       width, height, g_app.tflite_info.model_path);

--- a/nnstreamer_example/example_filter/nnstreamer_example_filter.py
+++ b/nnstreamer_example/example_filter/nnstreamer_example_filter.py
@@ -70,9 +70,9 @@ class NNStreamerExample:
         self.pipeline = Gst.parse_launch(
             'v4l2src name=cam_src ! videoscale ! '
             'video/x-raw,width=640,height=480,format=RGB ! tee name=t_raw '
-            't_raw. ! queue ! textoverlay name=tensor_res font-desc=\"Sans, 24\" ! '
+            't_raw. ! queue ! textoverlay name=tensor_res font-desc=Sans,24 ! '
             'videoconvert ! ximagesink name=img_tensor '
-            't_raw. ! queue ! videoscale ! video/x-raw,width=224,height=224 ! tensor_converter ! '
+            't_raw. ! queue leaky=2 max-size-buffers=2 ! videoscale ! video/x-raw,width=224,height=224 ! tensor_converter ! '
             'tensor_filter framework=tensorflow-lite model=' + self.tflite_model + ' ! '
             'tensor_sink name=tensor_sink'
         )

--- a/nnstreamer_example/example_object_detection/nnstreamer_example_object_detection.cc
+++ b/nnstreamer_example/example_object_detection/nnstreamer_example_object_detection.cc
@@ -673,7 +673,7 @@ main (int argc, char ** argv)
       ("v4l2src name=src ! videoscale ! "
       "video/x-raw,width=%d,height=%d,format=RGB ! tee name=t_raw "
       "t_raw. ! queue ! videoconvert ! cairooverlay name=tensor_res ! ximagesink name=img_tensor "
-      "t_raw. ! queue ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter ! "
+      "t_raw. ! queue leaky=2 max-size-buffers=2 ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter ! "
       "tensor_transform mode=typecast option=float32 ! "
       "tensor_transform mode=arithmetic option=add:-127 ! "
       "tensor_transform mode=arithmetic option=mul:0.007843 ! "


### PR DESCRIPTION
In the example using tf-lite model, add leaky property to drop old buffers (leaky on downstream).

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
