### PR TITLE
[Merge/Mux] Extract Common Functions & Data Type @open sesame 11/02 18:04

### DIFF
--- a/gst/tensor_merge/gsttensormerge.h
+++ b/gst/tensor_merge/gsttensormerge.h
@@ -29,7 +29,6 @@
 #define __GST_TENSOR_MERGE_H__
 
 #include <gst/gst.h>
-#include <gst/base/gstcollectpads.h>
 #include <tensor_common.h>
 
 G_BEGIN_DECLS
@@ -65,16 +64,6 @@ typedef enum
 typedef struct _tensor_merge_linear {
   tensor_merge_linear_mode direction;
 } tensor_merge_linear;
-
-
-typedef struct
-{
-  GstCollectData collect;
-  GstClockTime pts_timestamp;
-  GstClockTime dts_timestamp;
-  GstBuffer *buffer;
-  GstPad *pad;
-} GstTensorMergePadData;
 
 /**
  * @brief Tensor Merge data structure

--- a/gst/tensor_mux/gsttensormux.h
+++ b/gst/tensor_mux/gsttensormux.h
@@ -29,7 +29,6 @@
 #define __GST_TENSOR_MUX_H__
 
 #include <gst/gst.h>
-#include <gst/base/gstcollectpads.h>
 #include <tensor_common.h>
 
 G_BEGIN_DECLS
@@ -42,17 +41,6 @@ G_BEGIN_DECLS
 #define GST_TENSOR_MUX_CAST(obj)((GstTensorMux*)(obj))
 typedef struct _GstTensorMux GstTensorMux;
 typedef struct _GstTensorMuxClass GstTensorMuxClass;
-
-
-
-typedef struct
-{
-  GstCollectData collect;
-  GstClockTime pts_timestamp;
-  GstClockTime dts_timestamp;
-  GstBuffer *buffer;
-  GstPad *pad;
-} GstTensorMuxPadData;
 
 /**
  * @brief Tensor Muxer data structure


### PR DESCRIPTION
# PR Description
There are duplicated function call such as
gst_tensor_mux(merge)_collect_buffer(). It could be extracted and
rewrite as common function. Also there is duplicated structure
definition called GstTensorMux(Merge)PadData. It is placed in
tensor_common.h.
Considering Synchronization Options, It is more reasonable to set 
current_time value as GST_BUFFER_PTS(tensors). Therefore there is no need gst_tensor_merge_compare_pads() function.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>