### PR TITLE
[Testcase] Recurrent Network, Input Stream @open sesame 11/02 17:47

### DIFF
--- a/tests/recurrent_pipeline/generateTestCase.py
+++ b/tests/recurrent_pipeline/generateTestCase.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file generateTestCase.py
+# @brief Generate a sequence of video/x-raw frames
+# @todo Generate corresponding golden results
+# @author MyungJoo Ham <myungjoo.ham@samsung.com>
+# @url https://github.com/nnsuite/nnstreamer/issues/738
+
+
+from __future__ import print_function
+
+import sys
+import os
+import array as arr
+
+##
+# @brief Generate a video/x-raw single frame
+# @return The frame buffer contents
+def genFrame(seq):
+    frame = arr.array('B', [0] * 64)
+    width = 4
+    height = 4
+    bpp = 4 # Byte per pixel
+
+    # (ALLCOLOR, 0, 0), 0 to 255
+    frame[bpp * ( 0 + width * 0 ) + 0] = seq # B
+    frame[bpp * ( 0 + width * 0 ) + 1] = seq # G
+    frame[bpp * ( 0 + width * 0 ) + 2] = seq # R
+
+    # (ALLCOLOR, 3, 3), 255 to 0
+    frame[bpp * ( 3 + width * 3 ) + 0] = 255 - seq # B
+    frame[bpp * ( 3 + width * 3 ) + 1] = 255 - seq # G
+    frame[bpp * ( 3 + width * 3 ) + 2] = 255 - seq # R
+
+    # (RED, 1, 1), 0 to 255
+    frame[bpp * ( 1 + width * 1 ) + 2] = seq # R
+
+    return frame.tostring()
+
+filename = "video_4x4xBGRx.xraw"
+f = open(filename, "w")
+
+for seq in range(0, 256):
+    f.write(genFrame(seq))
+
+f.close()
+
+print("File (%s) is written.\n" % filename)

--- a/tests/recurrent_pipeline/runTest.sh
+++ b/tests/recurrent_pipeline/runTest.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+##
+## @file runTest.sh
+## @author MyungJoo Ham <myungjoo.ham@gmail.com>
+## @date Nov 01 2018
+## @brief This is a template file for SSAT test cases. You may designate your own license.
+##
+if [[ "$SSATAPILOADED" != "1" ]]
+then
+	SILENT=0
+	INDEPENDENT=1
+	search="ssat-api.sh"
+	source $search
+	printf "${Blue}Independent Mode${NC}
+"
+fi
+testInit $1 # You may replace this with Test Group Name
+
+# Generate video_4x4xBGRx.xraw
+python generateTestCase.py
+
+# This test case is WIP. So do not fail unittest even if this case fails.
+gstTest "filesrc location=video_4x4xBGRx.xraw ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! fakesink" 1R 1 0 0
+
+report


### PR DESCRIPTION
In order to test recurrent neural networks,
we need to implement #738 (we surely need new synchronization
policy from tensor_mux/merge)

As the first step of #738, I, hereby, provide
the 4x4 BGRx video/x-raw steam with frame-sequence
identification marks.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

Verified with HEX viewer.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped
