### PR TITLE
[Merge/Mux] Implement BasePad Time Synchronization Policy  - @open sesame 11/08 17:21

### DIFF
--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -159,6 +159,25 @@ typedef enum
 } tensor_time_sync_mode;
 
 /**
+ * @brief Tensor Merge/Mux sync data for baspad mode
+ */
+typedef struct _tensor_sync_basepad_data{
+  guint sink_id;
+  GstClockTime duration;
+} tensor_sync_basepad_data;
+
+/**
+ * @brief Tensor Merge/Mux time sync data
+ */
+typedef struct _tensor_time_sync_data {
+  tensor_time_sync_mode mode;
+  gchar *option;
+  union {
+    tensor_sync_basepad_data data_basepad;
+  };
+} tensor_time_sync_data;
+
+/**
  * @brief Internal data structure for Collect Pad in mux / merge
  */
 typedef struct
@@ -432,7 +451,7 @@ extern void gst_tensors_typefind_function (GstTypeFind * tf, gpointer pdata);
  * @param current_time Current time
  * @param sync Synchronization Option (NOSYNC, SLOWEST, BASEPAD, END)
  */
-extern gboolean gst_tensor_set_current_time(GstCollectPads *collect, GstClockTime *current_time, tensor_time_sync_mode sync);
+extern gboolean gst_tensor_set_current_time(GstCollectPads *collect, GstClockTime *current_time, tensor_time_sync_data sync);
 
 /**
  * @brief  A function call to make tensors from collected pads
@@ -445,7 +464,7 @@ extern gboolean gst_tensor_set_current_time(GstCollectPads *collect, GstClockTim
  * @param tensors_buf Generated GstBuffer for Collected Buffer
  * @param configs Configuration Info for Collected Buffer
  */
-extern gboolean gst_gen_tensors_from_collectpad (GstCollectPads * collect, tensor_time_sync_mode sync, GstClockTime current_time, gboolean *need_buffer, GstBuffer *tensors_buf, GstTensorsConfig *configs);
+extern gboolean gst_gen_tensors_from_collectpad (GstCollectPads * collect, tensor_time_sync_data sync, GstClockTime current_time, gboolean *need_buffer, GstBuffer *tensors_buf, GstTensorsConfig *configs);
 
 G_END_DECLS
 #endif /* __GST_TENSOR_COMMON_H__ */

--- a/gst/tensor_merge/gsttensormerge.h
+++ b/gst/tensor_merge/gsttensormerge.h
@@ -42,14 +42,6 @@ G_BEGIN_DECLS
 typedef struct _GstTensorMerge GstTensorMerge;
 typedef struct _GstTensorMergeClass GstTensorMergeClass;
 
-/**
- * @brief Tensor Merge time sync data for baspad mode
- */
-typedef struct _tensor_time_sync_basepad {
-  guint sink_id;
-  guint duration;
-} tensor_time_sync_basepad;
-
 typedef enum
 {
   GTT_LINEAR = 0,               /* Dimension Change. "dimchg" */
@@ -81,11 +73,7 @@ struct _GstTensorMerge
   GstElement element;
 
   gboolean silent;
-  tensor_time_sync_mode sync_mode;
-  gchar *sync_option;
-  union{
-    tensor_time_sync_basepad data_basepad;
-  };
+  tensor_time_sync_data sync;
   GstPad *srcpad;
   gchar *option;
   tensor_merge_mode mode;

--- a/gst/tensor_mux/gsttensormux.h
+++ b/gst/tensor_mux/gsttensormux.h
@@ -43,14 +43,6 @@ typedef struct _GstTensorMux GstTensorMux;
 typedef struct _GstTensorMuxClass GstTensorMuxClass;
 
 /**
- * @brief Tensor Muxer time sync data for baspad mode
- */
-typedef struct _tensor_time_sync_basepad {
-  guint sink_id;
-  guint duration;
-} tensor_time_sync_basepad;
-
-/**
  * @brief Tensor Muxer data structure
  */
 struct _GstTensorMux
@@ -58,12 +50,7 @@ struct _GstTensorMux
   GstElement element;
 
   gboolean silent;
-  tensor_time_sync_mode sync_mode;
-  gchar *sync_option;
-  union{
-    tensor_time_sync_basepad data_basepad;
-  };
-
+  tensor_time_sync_data sync;
   GstPad *srcpad;
 
   GstCollectPads *collect;

--- a/tests/nnstreamer_converter/generateGoldenTestResult.py
+++ b/tests/nnstreamer_converter/generateGoldenTestResult.py
@@ -50,6 +50,21 @@ if target == -1 or target == 9:
             file.write(s[i])
         file.close()
 
+    for i in range(0,10):
+        sink_1 = i/3;
+        with open("testsynch03_"+str(i)+".golden",'wb') as file:
+            file.write(s[i])
+            file.write(s[sink_1])
+        file.close()
+
+    id=[0,1,1,2,3,3,4,5,5,6]
+    for i in range(0,10):
+        sink_1 = id[i]
+        with open("testsynch04_"+str(i)+".golden",'wb') as file:
+            file.write(s[i])
+            file.write(s[sink_1])
+        file.close()
+
     id=[0,2,3,5,6,8,9]
     for i in range(0,7):
         sink_0 = id[i]
@@ -65,6 +80,16 @@ if target == -1 or target == 9:
             file.write(s[sink_0])
             file.write(s[sink_1])
             file.write(s[i])
+        file.close()
+
+    id=[0,1,1,2,3,3,4,5,5,6]
+    for i in range(0,10):
+        sink_0 = id[i]
+        sink_1 = i/3
+        with open("testsynch05_"+str(i)+".golden",'wb') as file:
+            file.write(s[i])
+            file.write(s[sink_0])
+            file.write(s[sink_1])
         file.close()
 
 if target == -1 or target == 10:

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -92,4 +92,43 @@ callCompareTest testsynch02_1.log testsynch02_1.golden 13-2 "Compare 13-2" 1 0
 callCompareTest testsynch02_2.log testsynch02_2.golden 13-3 "Compare 13-3" 1 0
 callCompareTest testsynch02_3.log testsynch02_3.golden 13-4 "Compare 13-4" 1 0
 
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch03_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! merge.sink_1" 14 0 0 $PERFORMANCE
+
+callCompareTest testsynch03_0.log testsynch03_0.golden 14-1 "Compare 14-1" 1 0
+callCompareTest testsynch03_1.log testsynch03_1.golden 14-2 "Compare 14-2" 1 0
+callCompareTest testsynch03_2.log testsynch03_2.golden 14-3 "Compare 14-3" 1 0
+callCompareTest testsynch03_3.log testsynch03_3.golden 14-4 "Compare 14-4" 1 0
+callCompareTest testsynch03_4.log testsynch03_4.golden 14-5 "Compare 14-5" 1 0
+callCompareTest testsynch03_5.log testsynch03_5.golden 14-6 "Compare 14-6" 1 0
+callCompareTest testsynch03_6.log testsynch03_6.golden 14-7 "Compare 14-7" 1 0
+callCompareTest testsynch03_7.log testsynch03_7.golden 14-8 "Compare 14-8" 1 0
+callCompareTest testsynch03_8.log testsynch03_8.golden 14-9 "Compare 14-9" 1 0
+callCompareTest testsynch03_9.log testsynch03_9.golden 14-10 "Compare 14-10" 1 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch04_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! merge.sink_1" 15 0 0 $PERFORMANCE
+
+callCompareTest testsynch04_0.log testsynch04_0.golden 15-1 "Compare 15-1" 1 0
+callCompareTest testsynch04_1.log testsynch04_1.golden 15-2 "Compare 15-2" 1 0
+callCompareTest testsynch04_2.log testsynch04_2.golden 15-3 "Compare 15-3" 1 0
+callCompareTest testsynch04_3.log testsynch04_3.golden 15-4 "Compare 15-4" 1 0
+callCompareTest testsynch04_4.log testsynch04_4.golden 15-5 "Compare 15-5" 1 0
+callCompareTest testsynch04_5.log testsynch04_5.golden 15-6 "Compare 15-6" 1 0
+callCompareTest testsynch04_6.log testsynch04_6.golden 15-7 "Compare 15-7" 1 0
+callCompareTest testsynch04_7.log testsynch04_7.golden 15-8 "Compare 15-8" 1 0
+callCompareTest testsynch04_8.log testsynch04_8.golden 15-9 "Compare 15-9" 1 0
+callCompareTest testsynch04_9.log testsynch04_9.golden 15-10 "Compare 15-10" 1 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_merge:5 tensor_merge name=merge mode=linear option=2 silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch05_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! merge.sink_2" 16 0 0 $PERFORMANCE
+
+callCompareTest testsynch05_0.log testsynch05_0.golden 16-1 "Compare 16-1" 1 0
+callCompareTest testsynch05_1.log testsynch05_1.golden 16-2 "Compare 16-2" 1 0
+callCompareTest testsynch05_2.log testsynch05_2.golden 16-3 "Compare 16-3" 1 0
+callCompareTest testsynch05_3.log testsynch05_3.golden 16-4 "Compare 16-4" 1 0
+callCompareTest testsynch05_4.log testsynch05_4.golden 16-5 "Compare 16-5" 1 0
+callCompareTest testsynch05_5.log testsynch05_5.golden 16-6 "Compare 16-6" 1 0
+callCompareTest testsynch05_6.log testsynch05_6.golden 16-7 "Compare 16-7" 1 0
+callCompareTest testsynch05_7.log testsynch05_7.golden 16-8 "Compare 16-8" 1 0
+callCompareTest testsynch05_8.log testsynch05_8.golden 16-9 "Compare 16-9" 1 0
+callCompareTest testsynch05_9.log testsynch05_9.golden 16-10 "Compare 16-10" 1 0
+
 report

--- a/tests/nnstreamer_mux/runTest.sh
+++ b/tests/nnstreamer_mux/runTest.sh
@@ -78,4 +78,43 @@ callCompareTest testsynch02_1.log testsynch02_1.golden 10-2 "Compare 10-2" 1 0
 callCompareTest testsynch02_2.log testsynch02_2.golden 10-3 "Compare 10-3" 1 0
 callCompareTest testsynch02_3.log testsynch02_3.golden 10-4 "Compare 10-4" 1 0
 
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_mux:5 tensor_mux name=mux silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch03_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! mux.sink_1" 11 0 0 $PERFORMANCE
+
+callCompareTest testsynch03_0.log testsynch03_0.golden 11-1 "Compare 11-1" 1 0
+callCompareTest testsynch03_1.log testsynch03_1.golden 11-2 "Compare 11-2" 1 0
+callCompareTest testsynch03_2.log testsynch03_2.golden 11-3 "Compare 11-3" 1 0
+callCompareTest testsynch03_3.log testsynch03_3.golden 11-4 "Compare 11-4" 1 0
+callCompareTest testsynch03_4.log testsynch03_4.golden 11-5 "Compare 11-5" 1 0
+callCompareTest testsynch03_5.log testsynch03_5.golden 11-6 "Compare 11-6" 1 0
+callCompareTest testsynch03_6.log testsynch03_6.golden 11-7 "Compare 11-7" 1 0
+callCompareTest testsynch03_7.log testsynch03_7.golden 11-8 "Compare 11-8" 1 0
+callCompareTest testsynch03_8.log testsynch03_8.golden 11-9 "Compare 11-9" 1 0
+callCompareTest testsynch03_9.log testsynch03_9.golden 11-10 "Compare 11-10" 1 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_mux:5 tensor_mux name=mux silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch04_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! mux.sink_1" 12 0 0 $PERFORMANCE
+
+callCompareTest testsynch04_0.log testsynch04_0.golden 12-1 "Compare 12-1" 1 0
+callCompareTest testsynch04_1.log testsynch04_1.golden 12-2 "Compare 12-2" 1 0
+callCompareTest testsynch04_2.log testsynch04_2.golden 12-3 "Compare 12-3" 1 0
+callCompareTest testsynch04_3.log testsynch04_3.golden 12-4 "Compare 12-4" 1 0
+callCompareTest testsynch04_4.log testsynch04_4.golden 12-5 "Compare 12-5" 1 0
+callCompareTest testsynch04_5.log testsynch04_5.golden 12-6 "Compare 12-6" 1 0
+callCompareTest testsynch04_6.log testsynch04_6.golden 12-7 "Compare 12-7" 1 0
+callCompareTest testsynch04_7.log testsynch04_7.golden 12-8 "Compare 12-8" 1 0
+callCompareTest testsynch04_8.log testsynch04_8.golden 12-9 "Compare 12-9" 1 0
+callCompareTest testsynch04_9.log testsynch04_9.golden 12-10 "Compare 12-10" 1 0
+
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} --gst-debug=tensor_mux:5 tensor_mux name=mux silent=false sync_mode=basepad sync_option=0:33333333 ! multifilesink location=testsynch05_%1d.log multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! tensor_converter ! mux.sink_1 multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)10/1\" ! pngdec ! tensor_converter ! mux.sink_2" 13 0 0 $PERFORMANCE
+
+callCompareTest testsynch05_0.log testsynch05_0.golden 13-1 "Compare 13-1" 1 0
+callCompareTest testsynch05_1.log testsynch05_1.golden 13-2 "Compare 13-2" 1 0
+callCompareTest testsynch05_2.log testsynch05_2.golden 13-3 "Compare 13-3" 1 0
+callCompareTest testsynch05_3.log testsynch05_3.golden 13-4 "Compare 13-4" 1 0
+callCompareTest testsynch05_4.log testsynch05_4.golden 13-5 "Compare 13-5" 1 0
+callCompareTest testsynch05_5.log testsynch05_5.golden 13-6 "Compare 13-6" 1 0
+callCompareTest testsynch05_6.log testsynch05_6.golden 13-7 "Compare 13-7" 1 0
+callCompareTest testsynch05_7.log testsynch05_7.golden 13-8 "Compare 13-8" 1 0
+callCompareTest testsynch05_8.log testsynch05_8.golden 13-9 "Compare 13-9" 1 0
+callCompareTest testsynch05_9.log testsynch05_9.golden 13-10 "Compare 13-10" 1 0
+
 report


### PR DESCRIPTION
# PR Description

Implement BasePad Time Synchronization Policy. The sync_mode name is
"basepad" and it has sync_options which is base pad number and
duration. It is more like "sync_mode=basepad
sync_option=0:33333333". Duration is GstClockTime (unsigned int 64)
and pad number is unsigned int.

Once this sync_mode is enabled, then the merge time is decided based
on this "basepad". For example, if the framerate of basepad is 30/1,
then the time which is pushed by merge/mux is 33333333, 66666666,
99999999, 133333333, 166666666, etc. Some details are below. It
calculate difference between current time and pts time of updated buffer 
and if it is bigger than duration, it use previous pad buffer.

Test Case 1:
 - srcpad0 ( framerate 30/1 ) : basepad with 33333333 duration.
 - srcpad1 ( framerate 20/1 )
 - srcpad2 ( framerate 10/1 )

then, merge/mux pushed as below.
````
    *srcpad0        srcpad1         srcpad2
       0               0               0     
    33333333        50000000           0     
    66666666        50000000           0    
    99999999       100000000      1000000000 
   133333332       150000000      1000000000
   166666666       150000000      1000000000
   199999999       200000000      2000000000
   233333331       250000000      2000000000
   266666666       250000000      2000000000 
   299999997       300000000      3000000000
````

if sync_mode is slowest,
then, merge/mux pushed as below.
````
    srcpad0         srcpad1         *srcpad2
       0               0               0     
    99999999       100000000      1000000000 
   199999999       200000000      2000000000
   299999997       300000000      3000000000 
````

if sync_mode is nosync,
then, merge/mux pushed as below.
````
    *srcpad0        *srcpad1        *srcpad2
       0               0               0     
    33333333        50000000      1000000000 
    66666666       100000000      2000000000 
    99999999       150000000      3000000000 
   133333332       200000000      4000000000 
   166666666       250000000      5000000000 
   199999999       300000000      6000000000
   233333331       350000000      7000000000 
   266666666       400000000      8000000000 
   299999997       450000000      9000000000 
````

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
