### PR TITLE
[TensorDec]update bounding boxes mode implement

### DIFF
--- a/gst/tensor_decoder/CMakeLists.txt
+++ b/gst/tensor_decoder/CMakeLists.txt
@@ -1,1 +1,2 @@
-ADD_LIBRARY(tensor_decoderOBJ OBJECT tensordec.c)
+set(DECODER_SOURCE tensordec.c tensordec_bounding_boxes_core.cc)
+ADD_LIBRARY(tensor_decoderOBJ OBJECT ${DECODER_SOURCE})

--- a/gst/tensor_decoder/tensordec.h
+++ b/gst/tensor_decoder/tensordec.h
@@ -45,8 +45,31 @@ G_BEGIN_DECLS
 #define GST_IS_TENSORDEC_CLASS(klass) \
   (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSORDEC))
 #define GST_TENSORDEC_CAST(obj)  ((GstTensorDec *)(obj))
+#define Y_SCALE         10.0f
+#define X_SCALE         10.0f
+#define H_SCALE         5.0f
+#define W_SCALE         5.0f
+#define VIDEO_WIDTH     640
+#define VIDEO_HEIGHT    480
+#define MODEL_WIDTH     300
+#define MODEL_HEIGHT    300
 #define BOX_SIZE        4
+#define LABEL_SIZE      91
 #define DETECTION_MAX   1917
+/**
+ * @brief Max objects in display.
+ */
+#define MAX_OBJECT_DETECTION 5
+    typedef struct
+{
+  gint x;
+  gint y;
+  gint width;
+  gint height;
+  gint class_id;
+  gfloat prob;
+} DetectedObject;
+
 typedef struct _GstTensorDec GstTensorDec;
 typedef struct _GstTensorDecClass GstTensorDecClass;
 
@@ -127,15 +150,6 @@ typedef enum
   DECODE_MODE_UNKNOWN
 } dec_modes;
 
-/**
- * @brief Decoder Mode  string.
- */
-static const gchar *mode_names[] = {
-  [DIRECT_VIDEO] = "direct_video",
-  [IMAGE_LABELING] = "image_labeling",
-  [BOUNDING_BOXES] = "bounding_boxes",
-  NULL
-};
 
 /**
  * @brief Output type for each mode

--- a/gst/tensor_decoder/tensordec_bounding_boxes_core.cc
+++ b/gst/tensor_decoder/tensordec_bounding_boxes_core.cc
@@ -1,0 +1,231 @@
+/**
+ * Copyright (C) 2018 Samsung Electronics Co., Ltd. All rights reserved.
+ * Copyright (C) 2018 Jinhyuck Park <jinhyuck83.park@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   tensordec_bounding_box_core.cc
+ * @author Jinhyuck Park <jinhyuck83.park@samsung.com>
+ * @date   11/06/2018
+ * @brief  c++ apis for bounding boxes of tensor decoder.
+ *
+ * @bug     No known bugs.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <glib.h>
+#include <gst/gst.h>
+#include <gst/video/video.h>
+
+#include <cstring>
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <math.h>
+#include "tensordec.h"
+
+/**
+ * @brief Macro for debug mode.
+ */
+#ifndef DBG
+#define DBG FALSE
+#endif
+
+/**
+ * @brief Macro for debug message.
+ */
+#define _print_log(...) if (DBG) g_message (__VA_ARGS__)
+
+#define _expit(x) \
+    (1.f / (1.f + expf (-x)))
+
+/**
+ * @brief Data structure for bounding_boxes_core.
+ */
+typedef struct
+{
+  gboolean running; /**< true when app is running */
+  GMutex mutex; /**< mutex for processing */
+  Mode_boundig_boxes boxes_info; /**< tflite model info */
+    std::vector < DetectedObject > detected_objects;
+} core_Data;
+
+/**
+ * @brief Data for pipeline and result.
+ */
+static core_Data core;
+
+/**
+ * @brief Compare score of detected objects.
+ */
+static bool
+gst_tensordec_compare_objs (DetectedObject & a, DetectedObject & b)
+{
+  return a.prob > b.prob;
+}
+
+/**
+ * @brief Read strings from file.
+ */
+extern gboolean
+gst_tensordec_read_lines (const gchar * file_name, GList ** lines)
+{
+  std::ifstream file (file_name);
+  if (!file) {
+    _print_log ("Failed to open file %s", file_name);
+    return FALSE;
+  }
+
+  std::string str;
+  while (std::getline (file, str)) {
+    *lines = g_list_append (*lines, g_strdup (str.c_str ()));
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Intersection of union
+ */
+static gfloat
+gst_tensordec_iou (DetectedObject & A, DetectedObject & B)
+{
+  int x1 = std::max (A.x, B.x);
+  int y1 = std::max (A.y, B.y);
+  int x2 = std::min (A.x + A.width, B.x + B.width);
+  int y2 = std::min (A.y + A.height, B.y + B.height);
+  int w = std::max (0, (x2 - x1 + 1));
+  int h = std::max (0, (y2 - y1 + 1));
+  float inter = w * h;
+  float areaA = A.width * A.height;
+  float areaB = B.width * B.height;
+  float o = inter / (areaA + areaB - inter);
+  return (o >= 0) ? o : 0;
+}
+
+/**
+ * @brief NMS (non-maximum suppression)
+ */
+static void
+gst_tensordec_nms (std::vector < DetectedObject > &detected)
+{
+  const float threshold_iou = .5f;
+  guint boxes_size;
+  guint i, j;
+
+  std::sort (detected.begin (), detected.end (), gst_tensordec_compare_objs);
+  boxes_size = detected.size ();
+
+  std::vector < bool > del (boxes_size, false);
+  for (i = 0; i < boxes_size; i++) {
+    if (!del[i]) {
+      for (j = i + 1; j < boxes_size; j++) {
+        if (gst_tensordec_iou (detected.at (i),
+                detected.at (j)) > threshold_iou) {
+          del[j] = true;
+        }
+      }
+    }
+  }
+
+  /* update result */
+  g_mutex_lock (&core.mutex);
+
+  core.detected_objects.clear ();
+  for (i = 0; i < boxes_size; i++) {
+    if (!del[i]) {
+      core.detected_objects.push_back (detected[i]);
+
+      if (DBG) {
+        _print_log ("==============================");
+        _print_log ("Label           : %s",
+            (gchar *) g_list_nth_data (core.boxes_info.labels,
+                detected[i].class_id));
+        _print_log ("x               : %d", detected[i].x);
+        _print_log ("y               : %d", detected[i].y);
+        _print_log ("width           : %d", detected[i].width);
+        _print_log ("height          : %d", detected[i].height);
+        _print_log ("Confidence Score: %f", detected[i].prob);
+      }
+    }
+  }
+
+  g_mutex_unlock (&core.mutex);
+}
+
+/**
+ * @brief Get detected objects.
+ */
+extern void
+gst_tensordec_get_detected_objects (gfloat * detections, gfloat * boxes)
+{
+  const float threshold_score = .5f;
+  std::vector < DetectedObject > detected;
+
+  for (int d = 0; d < DETECTION_MAX; d++) {
+    float ycenter =
+        boxes[0] / Y_SCALE * core.boxes_info.box_priors[2][d] +
+        core.boxes_info.box_priors[0][d];
+    float xcenter =
+        boxes[1] / X_SCALE * core.boxes_info.box_priors[3][d] +
+        core.boxes_info.box_priors[1][d];
+    float h =
+        (float) expf (boxes[2] / H_SCALE) * core.boxes_info.box_priors[2][d];
+    float w =
+        (float) expf (boxes[3] / W_SCALE) * core.boxes_info.box_priors[3][d];
+
+    float ymin = ycenter - h / 2.f;
+    float xmin = xcenter - w / 2.f;
+    float ymax = ycenter + h / 2.f;
+    float xmax = xcenter + w / 2.f;
+
+    int x = xmin * MODEL_WIDTH;
+    int y = ymin * MODEL_HEIGHT;
+    int width = (xmax - xmin) * MODEL_WIDTH;
+    int height = (ymax - ymin) * MODEL_HEIGHT;
+
+    for (int c = 1; c < LABEL_SIZE; c++) {
+      gfloat score = _expit (detections[c]);
+      /**
+       * This score cutoff is taken from Tensorflow's demo app.
+       * There are quite a lot of nodes to be run to convert it to the useful possibility
+       * scores. As a result of that, this cutoff will cause it to lose good detections in
+       * some scenarios and generate too much noise in other scenario.
+       */
+      if (score < threshold_score)
+        continue;
+
+      DetectedObject object;
+
+      object.class_id = c;
+      object.x = x;
+      object.y = y;
+      object.width = width;
+      object.height = height;
+      object.prob = score;
+
+      detected.push_back (object);
+    }
+
+    detections += LABEL_SIZE;
+    boxes += BOX_SIZE;
+  }
+
+  gst_tensordec_nms (detected);
+}

--- a/gst/tensor_decoder/tensordec_bounding_boxes_core.h
+++ b/gst/tensor_decoder/tensordec_bounding_boxes_core.h
@@ -1,0 +1,46 @@
+
+/**
+ * Copyright (C) 2018 Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   tensordec_bounding_boxes_core.h
+ * @author Jinhyuck Park <jinhyuck83.park@samsung.com>
+ * @date   11/6/2018
+ * @brief	 tensor decoder bounding boxes mode c++ apis.
+ *
+ * @bug     No known bugs.
+ */
+
+
+/**
+ * @brief	the definition of functions to be used at C files.
+ */
+
+#ifdef __cplusplus
+#include <glib.h>
+#include <iostream>
+#include <vector>
+#include <stdint.h>
+#include "tensordec.h"
+
+extern "C"
+{
+#endif
+  extern gboolean gst_tensordec_read_lines (const gchar * file_name,
+      GList ** lines);
+  extern void gst_tensordec_get_detected_objects (gfloat * detections,
+      gfloat * boxes);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Update tensor decoder bounding boxes mode implementation
refer by nnstreamer object detection example
need to continue implemtation for drawing boxes
send to out buffer with video/x-raw RGBA

Signed-off-by: jinhyuck-park <jinhyuck83.park@samsung.com>


**Self evaluation:**
1. Build test: [ *]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

