### PR TITLE
[Decoder] Mode may be unknown with get-property - @open sesame 11/08 08:20

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -664,7 +664,6 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       g_value_set_boolean (value, self->silent);
       break;
     case PROP_MODE:
-      g_assert (self->mode < DECODE_MODE_UNKNOWN);
       g_value_set_string (value, mode_names[self->mode]);
       break;
     case PROP_MODE_OPTION1:


### PR DESCRIPTION
If we are using GUI tools or dynamic pipelines,
the initial state may be unknown when a process
probes its mode or states.

Fixes the first subissue of #700

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped


