### PR TITLE
[Decoder/direct_video] Pipeline may allocate buffer for you already @open sesame 11/14 16:02

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -587,6 +587,7 @@ gst_tensordec_class_init (GstTensorDecClass * klass)
 
   /** Refer: https://gstreamer.freedesktop.org/documentation/design/element-transform.html */
   trans_class->passthrough_on_same_caps = FALSE;
+  trans_class->transform_ip_on_passthrough = FALSE;
 
   /** Processing units */
   trans_class->transform = GST_DEBUG_FUNCPTR (gst_tensordec_transform);


### PR DESCRIPTION
Do not die when the pipeline has already allocated the exact
size of buffer for you. Just reuse what's already there.
    
This fixes the 3rd subissue of #700.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped