### PR TITLE
[Filter] null check & die grarefully if not configured. 

### DIFF
--- a/gst/tensor_filter/tensor_filter.c
+++ b/gst/tensor_filter/tensor_filter.c
@@ -767,7 +767,7 @@ gst_tensor_filter_load_tensor_info (GstTensorFilter * self)
    * supposed fixed in-tensor info if getInputDimension is defined.
    */
   if (!prop->input_configured) {
-    if (self->fw->getInputDimension) {
+    if (self->fw && self->fw->getInputDimension) {
       GstTensorsInfo in_info;
 
       gst_tensors_info_init (&in_info);
@@ -793,7 +793,7 @@ gst_tensor_filter_load_tensor_info (GstTensorFilter * self)
    * supposed fixed out-tensor info if getOutputDimension is defined.
    */
   if (!prop->output_configured) {
-    if (self->fw->getOutputDimension) {
+    if (self->fw && self->fw->getOutputDimension) {
       GstTensorsInfo out_info;
 
       gst_tensors_info_init (&out_info);
@@ -1160,7 +1160,8 @@ gst_tensor_filter_start (GstBaseTransform * trans)
   GstTensorFilter *self;
 
   self = GST_TENSOR_FILTER_CAST (trans);
-  g_assert (self->fw != NULL);
+  if (self->fw == NULL)
+    return FALSE;
 
   gst_tensor_filter_open_fw (self);
   return TRUE;


### PR DESCRIPTION
To support pipeviz, the 4th subissue of #700 is resolved.

- Check if framework is configured (null check) at gst_tensor_filter_load_tensor_info()
- Don't die, get out gracefully if it is not configured and the pipeline wants to starts though.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
