### PR TITLE
[Tests] Upgrade framecounter custom filter

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ TARGET_LINK_LIBRARIES(unittest_sink ${pkgs_LIBRARIES} ${testpkgs_LIBRARIES} ${gt
 
 # Unit test uses this custom filter
 ADD_LIBRARY(nnscustom_framecounter SHARED nnstreamer_sink/nnscustom_framecounter.c)
-TARGET_LINK_LIBRARIES(nnscustom_framecounter ${CUSTOMFILTERDEP})
+TARGET_LINK_LIBRARIES(nnscustom_framecounter ${CUSTOMFILTERDEP} glib-2.0)
 
 # Unit test for nnstreamer plugins
 ADD_EXECUTABLE(unittest_plugins nnstreamer_plugins/unittest_plugins.cpp ${gtestSrc})

--- a/tests/nnstreamer_sink/nnscustom_framecounter.c
+++ b/tests/nnstreamer_sink/nnscustom_framecounter.c
@@ -16,13 +16,28 @@
  * If Input dimension is 1:1:1:1 uint32, single-tensor,
  * The output will copy the same value, ignoring the internal counter.
  *
+ * This accepts custom properties from tensor_filter.
+ * - custom=delay-300
+ *     Adds 300ms of sleep for each invoke
+ * - custom=stderr
+ *     Do fprintf(stderr) of each frame invoke
+ * - custom=stdout
+ *     Do fprintf(stdout) of each frame invoke
+ *
+ * You may combine those with deliminator, ":"
+ * - custom=stderr:delay-1000
+ *     Do fprintf(stderr) and add 1000ms sleep for each invoke.
+ *
  * @bug  No known bugs
  */
 
+
 #include <tensor_filter_custom.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
+#include <glib.h>
+#include <string.h>
+#include <stdlib.h>
 
 static uint32_t maxid = 0;
 
@@ -34,7 +49,42 @@ typedef struct _pt_data
   uint32_t id;
   uint32_t counter; /***< This counts the frame number from 0 */
   int copy; /***< Set 1 if input is 1:1:1:1 uint32 */
+  int inputn; /***< # tensors in input */
+  FILE *outf; /***< Where do you want to print? NULL if no print outs */
+  uint32_t delay; /***< Delay per invoke in us */
 } pt_data;
+
+/**
+ * @brief internal function to configure the filter from custom properties
+ * @param[in] prop The properties of tensor_filter
+ * @param[out] data The internal data structure of this custom filter.
+ */
+static void
+configure (const GstTensorFilterProperties * prop, pt_data * data)
+{
+  if (prop->custom_properties != NULL) {
+    gchar **str_ops;
+    int counter = 0;
+
+    str_ops = g_strsplit (prop->custom_properties, ":", -1);
+
+    while (str_ops[counter]) {
+      gchar *parsed = str_ops[counter];
+
+      if (0 == strncmp (parsed, "stdout", 6)) {
+        data->outf = stdout;
+      } else if (0 == strncmp (parsed, "stderr", 6)) {
+        data->outf = stderr;
+      } else if (0 == strncmp (parsed, "delay-", 6)) {
+        parsed = parsed + 6;
+        if (*parsed)
+          data->delay = (uint32_t) atoi (parsed);
+      }
+
+      counter++;
+    }
+  }
+}
 
 /**
  * @brief nnstreamer custom filter standard vmethod
@@ -48,6 +98,10 @@ pt_init (const GstTensorFilterProperties * prop)
   data->id = maxid;
   data->counter = 0U;
   data->copy = 0;
+  data->inputn = 0;
+  data->outf = NULL;
+  data->delay = 0;
+  configure (prop, data);
   return data;
 }
 
@@ -60,6 +114,8 @@ pt_exit (void *_data, const GstTensorFilterProperties * prop)
 {
   pt_data *data = _data;
   assert (data);
+  if (data->outf)
+    fprintf (data->outf, "[%u] %u\n", data->id, data->counter); /* The last counter value */
   free (data);
 }
 
@@ -73,22 +129,27 @@ set_inputDim (void *_data, const GstTensorFilterProperties * prop,
 {
   int i;
   pt_data *data = _data;
+
+  configure (prop, data);
+
   out_info->num_tensors = 1;
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++)
     out_info->info[0].dimension[i] = 1;
   out_info->info[0].type = _NNS_UINT32;
 
+  data->inputn = in_info->num_tensors;
   data->copy = 1;
-  if (in_info->info[0].type != _NNS_UINT32) {
-    data->copy = 0;
-  } else {
-    for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
-      if (in_info->info[0].dimension[i] != 1) {
-        data->copy = 0;
-        break;
-      }
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    if (in_info->info[0].dimension[i] != 1) {
+      data->copy = 0;
+      break;
     }
+    if (in_info->info[0].type != _NNS_UINT32)
+      data->copy = 0;
   }
+
+  if (data->outf)
+    fprintf (data->outf, "[%u] Returning dim.\n", data->id);
   return 0;
 }
 
@@ -111,6 +172,17 @@ invoke (void *_data, const GstTensorFilterProperties * prop,
     *counter = data->counter;
   }
   data->counter = data->counter + 1;
+
+  if (data->outf) {
+    if (data->inputn > 1) {
+      fprintf (data->outf, "[%u] Counter: %u / Output: %u <- %u\n", data->id, data->counter, *counter, *((uint32_t *) input[1].data));  /* The last counter value */
+    } else {
+      fprintf (data->outf, "[%u] Counter: %u / Output: %u\n", data->id, data->counter, *counter);       /* The last counter value */
+    }
+  }
+
+  if (data->delay > 0)
+    g_usleep (data->delay * 1000U);
   return 0;
 }
 


### PR DESCRIPTION
- For local internal testing, use custom option to make printouts
- For further synchronization testing, use custom option to add usleep()

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

The main purpose is to populate more sync-test cases with this custom filter. (resolving #739)

ps. This will further increase unit-test latencies. sorry..

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

