### PR TITLE
[GBS] Add timeout flag

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -97,25 +97,31 @@ make %{?_smp_mflags}
 ./tests/unittest_sink --gst-plugin-path=.
 popd
 pushd tests
-# The ssat requires 6~7min to run armv7l binary files in the current CI server.
-# The timeout value is 10min as a heuristic value from our experience.
-timeout=600
-ssat &
-pid=$!
-# CAUTION: Note that you have to keep the coding style of the existing statement
-# in case that you have to update the below statement in the future.
-# a. Do not run repetitive statement(ex. while) to avoid too log messages in the log file.
-# b. Declare appropriate heuristic timeout value
-# c. Do not declare too long sleep time to keep the reasonable waiting time after submitting PR
-(sleep $timeout
-kill $pid
-if [[ "$?" -eq 0 ]]; then
-    echo "[DEBUG] GBS is stopped because of 'ssat' timeout(10min)"
-    exit 124 # 124 is ubuntu status code of timeout
-fi) &
-pid2=$!
-wait $pid
-kill $pid2
+# Able to release timeout while gbs build using option '--define "timeout 1"'
+# Default is to apply time limit.
+%if 0%{?timeout}
+    ssat
+%else 
+    # The ssat requires 6~7min to run armv7l binary files in the current CI server.
+    # The timeout value is 10min as a heuristic value from our experience.
+    timeout=600
+    ssat &
+    pid=$!
+    # CAUTION: Note that you have to keep the coding style of the existing statement 
+    # in case that you have to update the below statement in the future. 
+    # a. Do not run repetitive statement(ex. while) to avoid too log messages in the log file. 
+    # b. Declare appropriate heuristic timeout value
+    # c. Do not declare too long sleep time to keep the reasonable waiting time after submitting PR
+    (sleep $timeout 
+    kill $pid 
+    if [[ "$?" -eq 0 ]]; then
+        echo "[DEBUG] GBS is stopped because of 'ssat' timeout(10min)"
+        exit 124 # 124 is ubuntu status code of timeout
+    fi) &
+    pid2=$!
+    wait $pid
+    kill $pid2
+%endif
 popd
 
 %install


### PR DESCRIPTION
For test or other reasons, add timeout flag to gbs build.

Signed-off-by: sewon.oh <sewon.oh@samsung.com>


---
# [Template] PR Description

In general, github system automatically copies your commit message for your convenience.
Please remove unused part of the template after writing your own PR description with this template.
```bash
$ git commit -s filename1 filename2 ... [enter]

Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical;
various tools like `log`, `shortlog` and `rebase` can get confused 
if you run the two together.

Further paragraphs come after blank lines.

**Changes proposed in this PR:**
- Bullet points are okay, too
- Typically a hyphen or asterisk is used for the bullet, preceded
  by a single space, with blank lines in between, but conventions vary here.

Resolves: #123
See also: #456, #789

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

