### PR TITLE
[WIP] Execute ssat on TMPFS for faster QEMU I/O @open sesame 11/10 20:30

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -97,6 +97,14 @@ make %{?_smp_mflags}
 ./tests/unittest_sink --gst-plugin-path=.
 ./tests/unittest_plugins --gst-plugin-path=.
 popd
+
+# Use /tmp to accelerate I/O for systems using /tmp as tmpfs
+TMPLOC=`mktemp -d`
+CURLOC=`pwd`
+pushd $TMPLOC
+ln -s ${CURLOC}/build build
+cp -R ${CURLOC}/tests .
+
 pushd tests
 # The ssat requires 6~7min to run armv7l binary files in the current CI server.
 # The timeout value is 10min as a heuristic value from our experience.
@@ -117,6 +125,8 @@ fi) &
 pid2=$!
 wait $pid
 kill $pid2
+popd
+
 popd
 
 %install

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -50,6 +50,8 @@ BuildRequires: lcov
 
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
 BuildRequires: ssat
+# Accelerate ssat execution
+BuildRequires: gbs-tmpfs
 
 %package unittest-coverage
 Summary:	NNStreamer UnitTest Coverage Analysis Result


### PR DESCRIPTION
Execute ssat @ /tmp (1st commit)
Mount /tmp as tmpfs (2nd commit)

> [Tests] Use /tmp for ssat testing for faster I/O
    
    We are experiencing 10min timeout for armv7l ssat,
    mainly due to the slow I/O of QEMU in AWS VM.
    
    In order to accelerate it, let's use /tmp assuming
    that @leemgs @ohsewon has configured /tmp to use
    tmpfs.



> [Tests] Accelerate SSAT with gbs-tmpfs
    
    The new package "gbs-tmpfs" allows to accelerate
    QEMU I/O


    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
