### PR TITLE
[Filter/Converter] Support pipeviz with tensor_filter @open sesame 11/14 16:02

### DIFF
--- a/gst/tensor_converter/tensor_converter.c
+++ b/gst/tensor_converter/tensor_converter.c
@@ -332,12 +332,14 @@ gst_tensor_converter_set_property (GObject * object, guint prop_id,
 
   switch (prop_id) {
     case PROP_INPUT_DIMENSION:
-      g_assert (get_tensor_dimension (g_value_get_string (value),
-              self->tensor_info.dimension) > 0);
+      if (get_tensor_dimension (g_value_get_string (value),
+              self->tensor_info.dimension) == 0)
+        GST_WARNING ("input dimension unknown (optinal).");
       break;
     case PROP_INPUT_TYPE:
       self->tensor_info.type = get_tensor_type (g_value_get_string (value));
-      g_assert (self->tensor_info.type != _NNS_END);
+      if (self->tensor_info.type == _NNS_END)
+        GST_WARNING ("input type unknown (optional).");
       break;
     case PROP_FRAMES_PER_TENSOR:
       self->frames_per_tensor = g_value_get_uint (value);

--- a/gst/tensor_filter/tensor_filter.h
+++ b/gst/tensor_filter/tensor_filter.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <gst/gst.h>
+#include <gst/gstinfo.h>
 #include <gst/base/gstbasetransform.h>
 #include <tensor_common.h>
 
@@ -165,11 +166,12 @@ struct _GstTensorFilterFramework
        * @return 0 if OK. non-zero if error.
        */
 
-  void (*open) (const GstTensorFilter * filter, void **private_data);
+  int (*open) (const GstTensorFilter * filter, void **private_data);
       /**< Optional. tensor_filter.c will call this before any of other callbacks and will call once before calling close
        *
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, open() allocates memory for private_data.
+       * @return 0 if ok. < 0 if error.
        */
 
   void (*close) (const GstTensorFilter * filter, void **private_data);

--- a/gst/tensor_filter/tensor_filter_tensorflow.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow.c
@@ -68,11 +68,12 @@ tf_loadModelFile (const GstTensorFilter * filter, void **private_data)
  * @param filter : tensor_filter instance
  * @param private_data : tensorflow lite plugin's private data
  */
-static void
+static int
 tf_open (const GstTensorFilter * filter, void **private_data)
 {
   int retval = tf_loadModelFile (filter, private_data);
   g_assert (retval == 0);       /** This must be called only once */
+  return 0;
 }
 
 /**

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -68,11 +68,12 @@ tflite_loadModelFile (const GstTensorFilter * filter, void **private_data)
  * @param filter : tensor_filter instance
  * @param private_data : tensorflow lite plugin's private data
  */
-static void
+static int
 tflite_open (const GstTensorFilter * filter, void **private_data)
 {
   int retval = tflite_loadModelFile (filter, private_data);
   g_assert (retval == 0);       /** This must be called only once */
+  return 0;
 }
 
 /**


### PR DESCRIPTION
    
Set of workarounds to let tensor_filter work with pipeviz.
    
Mostly it is related with dynamic tensor_filter configurations
and grace error handling.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
