### PR TITLE
[Transform] refactor arith / typecast mode

### DIFF
--- a/nnstreamer_example/example_object_detection/nnstreamer_example_object_detection.cc
+++ b/nnstreamer_example/example_object_detection/nnstreamer_example_object_detection.cc
@@ -674,9 +674,7 @@ main (int argc, char ** argv)
       "video/x-raw,width=%d,height=%d,format=RGB ! tee name=t_raw "
       "t_raw. ! queue ! videoconvert ! cairooverlay name=tensor_res ! ximagesink name=img_tensor "
       "t_raw. ! queue leaky=2 max-size-buffers=2 ! videoscale ! video/x-raw,width=%d,height=%d ! tensor_converter ! "
-      "tensor_transform mode=typecast option=float32 ! "
-      "tensor_transform mode=arithmetic option=add:-127 ! "
-      "tensor_transform mode=arithmetic option=mul:0.007843 ! "
+      "tensor_transform mode=arithmetic option=typecast:float32,add:-127,mul:0.007843 ! "
       "tensor_filter framework=tensorflow-lite model=%s ! "
       "tensor_sink name=tensor_sink",
       VIDEO_WIDTH, VIDEO_HEIGHT, MODEL_WIDTH, MODEL_HEIGHT,

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -160,7 +160,7 @@ TEST (test_tensor_transform, typecast_2)
 
     for (i = 0; i < array_size; i++) {
       double expected = (i + 1) * (b + 1);
-      EXPECT_EQ (((double *) info.data)[i], expected);
+      EXPECT_DOUBLE_EQ (((double *) info.data)[i], expected);
     }
 
     gst_memory_unmap (mem, &info);
@@ -229,7 +229,7 @@ TEST (test_tensor_transform, arithmetic_1)
 
     for (i = 0; i < array_size; i++) {
       float expected = (i + 1) * (b + 1) + .2 + .5;
-      EXPECT_EQ (((float *) info.data)[i], expected);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
     }
 
     gst_memory_unmap (mem, &info);
@@ -298,7 +298,226 @@ TEST (test_tensor_transform, arithmetic_2)
 
     for (i = 0; i < array_size; i++) {
       double expected = ((i + 1) * (b + 1) + .2) * .5;
-      EXPECT_EQ (((double *) info.data)[i], expected);
+      EXPECT_DOUBLE_EQ (((double *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (typecast uint8 > float32, add .5, mul .2)
+ */
+TEST (test_tensor_transform, arithmetic_3)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:float32,add:.5,mul:0.2", NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_UINT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = ((i + 1) * (b + 1) + .5) * .2;
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (typecast uint8 > float64, add .2, add .1, typecast uint16)
+ */
+TEST (test_tensor_transform, arithmetic_4)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:float64,add:0.2,add:0.1,typecast:uint16", NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_UINT16;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      uint16_t expected = (i + 1) * (b + 1);
+      EXPECT_EQ (((uint16_t *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (typecast uint8 > int32, mul 2, div 2, add -1)
+ */
+TEST (test_tensor_transform, arithmetic_5)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:int32,mul:2,div:2,add:-1", NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_INT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      int32_t expected = (i + 1) * (b + 1) - 1;
+      EXPECT_EQ (((int32_t *) info.data)[i], expected);
     }
 
     gst_memory_unmap (mem, &info);

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -45,16 +45,16 @@ python checkResult.py arithmetic testcase02.direct.log testcase02.arithmetic.log
 testResult $? 2 "Golden test comparison" 0 1
 
 # Test for mul with floating-point operand
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:-5.5 ! filesink location=\"testcase03.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.log\" sync=true" 3 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:-5.5 ! filesink location=\"testcase03.arithmetic.1.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.1.log\" sync=true" 3 0 0 $PERFORMANCE
 
-python checkResult.py arithmetic testcase03.direct.log testcase03.arithmetic.log 4 4 f f mul -5.5 0
+python checkResult.py arithmetic testcase03.direct.1.log testcase03.arithmetic.1.log 4 4 f f mul -5.5 0
 testResult $? 3 "Golden test comparison" 0 1
 
-# Fail Test 3-F: for mul with floating-point operand
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float32 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul::-5.5 ! filesink location=\"testcase03.arithmetic.fail.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.fail.log\" sync=true" 3-F 0 1 $PERFORMANCE
+# Test 3-2 for typecast,mul with floating-point operand
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:float32,mul:-5.5 ! filesink location=\"testcase03.arithmetic.2.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=float32 ! filesink location=\"testcase03.direct.2.log\" sync=true" 3-2 0 0 $PERFORMANCE
 
-python checkResult.py arithmetic testcase03.direct.fail.log testcase03.arithmetic.fail.log 4 4 f f mul 0 -5.5
-testResult $? 3-F "Golden test comparison" 0 1
+python checkResult.py arithmetic testcase03.direct.2.log testcase03.arithmetic.2.log 4 4 f f mul -5.5 0
+testResult $? 3-2 "Golden test comparison" 0 1
 
 # Test for add with floating-point operand
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:9.900000e-001 ! filesink location=\"testcase04.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.log\" sync=true" 4 0 0 $PERFORMANCE
@@ -68,32 +68,14 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 python checkResult.py arithmetic testcase04.direct.ok.log testcase04.arithmetic.ok.log 8 8 d d add 9.900000e-001 -80.256
 testResult $? 4-OK "Golden test comparison" 0 1
 
-# Test for add-mul with floating-point operands
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3:-11.4823e-002 ! filesink location=\"testcase05.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5 0 0 $PERFORMANCE
+# Test for add,mul with floating-point operands
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add:-9.3,mul:-11.4823e-002 ! filesink location=\"testcase05.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5 0 0 $PERFORMANCE
 
 testResult $? 5 "Golden test comparison" 0 1
 python checkResult.py arithmetic testcase05.direct.log testcase05.arithmetic.log 8 8 d d add-mul -9.3 -11.4823e-002
 
-# Fail Test 5-F1: add-mul with single floating-point operand
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3 ! filesink location=\"testcase05.arithmetic.fail1.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail1.log\" sync=true" 5-F1 0 1 $PERFORMANCE
-
-testResult $? 5-F1 "Golden test comparison" 0 1
-python checkResult.py arithmetic testcase05.direct.fail1.log testcase05.arithmetic.fail1.log 8 8 d d add-mul -9.3 0
-
-# Fail Test 5-F2: add-mul with single floating-point operand
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul:-9.3: ! filesink location=\"testcase05.arithmetic.fail2.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail2.log\" sync=true" 5-F2 0 1 $PERFORMANCE
-
-testResult $? 5-F2 "Golden test comparison" 0 1
-python checkResult.py arithmetic testcase05.direct.fail2.log testcase05.arithmetic.fail2.log 8 8 d d add-mul -9.3 0
-
-# Fail Test 5-F3: add-mul with single floating-point operand
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=add-mul::-11.4823e-002 ! filesink location=\"testcase05.arithmetic.fail3.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.fail3.log\" sync=true" 5-F3 0 1 $PERFORMANCE
-
-testResult $? 5-F3 "Golden test comparison" 0 1
-python checkResult.py arithmetic testcase05.direct.fail3.log testcase05.arithmetic.fail3.log 8 8 d d add-mul 30 -11.4823e-002
-
-# Test for mul-add with floating-point operands
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul-add:-50.0987e+003:15.3 ! filesink location=\"testcase06.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase06.direct.log\" sync=true" 6 0 0 $PERFORMANCE
+# Test for mul,add with floating-point operands
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=typecast option=float64 ! tee name=t ! queue ! tensor_transform mode=arithmetic option=mul:-50.0987e+003,add:15.3 ! filesink location=\"testcase06.arithmetic.log\" sync=true t. ! queue ! filesink location=\"testcase06.direct.log\" sync=true" 6 0 0 $PERFORMANCE
 
 testResult $? 6 "Golden test comparison" 0 1
 python checkResult.py arithmetic testcase06.direct.log testcase06.arithmetic.log 8 8 d d add-mul -50.0987e+003 15.3


### PR DESCRIPTION
refactor arith and typecast mode to handle arithmetic in sequence

1. define structure for tensor element value
2. add operators to handle tensor element with parsed option
3. remove multi-op (add-mul and mul-add)
4. change arith / typecast mode with added structure and functions

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
