### PR TITLE
doc: Fixed an incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ For more details, please access the following manual.
 ## CI Server
 
 - [CI service status](http://nnsuite.mooo.com/)
-- [TAOS-CI config files for nnstreamer](Documentation/ci-config).
+- [TAOS-CI config files for nnstreamer](.TAOS-CI).


### PR DESCRIPTION
It is trivial. This commit is to fix incorrect link address
of TAOS-CI configruation folder.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
 
