### PR TITLE
[Decoder] Add one more option

### DIFF
--- a/gst/tensor_decoder/tensordec.c
+++ b/gst/tensor_decoder/tensordec.c
@@ -92,7 +92,8 @@ enum
   PROP_SILENT,
   PROP_MODE,
   PROP_MODE_OPTION1,
-  PROP_MODE_OPTION2
+  PROP_MODE_OPTION2,
+  PROP_MODE_OPTION3
 };
 
 /**
@@ -573,6 +574,11 @@ gst_tensordec_class_init (GstTensorDecClass * klass)
           "Secondary option for the decoder", "",
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_MODE_OPTION3,
+      g_param_spec_string ("mode-option-3", "Mode option 3",
+          "Secondary option for the decoder", "",
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   gst_element_class_set_details_simple (gstelement_class,
       "TensorDecoder",
       "Converter/Tensor",
@@ -752,7 +758,13 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
     case PROP_MODE_OPTION2:
       self->option[1] = g_value_dup_string (value);
       if (self->mode == DECODE_MODE_PLUGIN) {
-        g_assert (_tensordec_process_plugin_options (self, 0) == TRUE);
+        g_assert (_tensordec_process_plugin_options (self, 1) == TRUE);
+      }
+      break;
+    case PROP_MODE_OPTION3:
+      self->option[2] = g_value_dup_string (value);
+      if (self->mode == DECODE_MODE_PLUGIN) {
+        g_assert (_tensordec_process_plugin_options (self, 2) == TRUE);
       }
       break;
     default:
@@ -786,6 +798,9 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       break;
     case PROP_MODE_OPTION2:
       g_value_set_string (value, self->option[1]);
+      break;
+    case PROP_MODE_OPTION3:
+      g_value_set_string (value, self->option[2]);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/gst/tensor_decoder/tensordec.h
+++ b/gst/tensor_decoder/tensordec.h
@@ -73,7 +73,7 @@ typedef struct
   guint total_labels; /**< count of labels */
 } Mode_boundig_boxes;
 
-#define TensorDecMaxOpNum (2)
+#define TensorDecMaxOpNum (3)
 /**
  * @brief Internal data structure for tensordec instances.
  */


### PR DESCRIPTION
Until we fix #837, I'll keep adding mode-options whenever needed.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped


Note that there is a bug for the previous option (Line 761 of tensordec.c in this PR)
However, this bug is fixed with #830 . so don't worry :)