### PR TITLE
[Dist/Debian] Only enable tensorflow-dev Build-Depends when building amd64 and arm64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: gcc, cmake, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev
  libgtest-dev,
  debhelper (>=9),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
- libpng-dev, tensorflow-lite-dev, tensorflow-dev, libcairo2-dev, libopencv-dev, 
+ libpng-dev, tensorflow-lite-dev, tensorflow-dev [amd64 arm64], libcairo2-dev, libopencv-dev,
  ssat, python, python-numpy
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnsuite/nnstreamer


### PR DESCRIPTION
Since tensorflow-dev package is only built for amd64 and arm64 on launchpad.net, nnstreamer for armhf and i386 count not be built. In order to solve this issue, this patch only enables the tensorflow-dev Build-Depends when building amd64 and arm64 architecture.

* related issue: #850 

Change-Id: Ie69058450fc1f05424063536b2afd0ecb140757e
Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

