### PR TITLE
DIST: Fix broken OBS build log of unit tests

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -97,7 +97,7 @@ make %{?_smp_mflags}
     ./tests/unittest_plugins --gst-plugin-path=.
     popd
     pushd tests
-    ssat
+    ssat -n
 %endif
 popd
 


### PR DESCRIPTION
SSAT writes colored text by default.
Apply -n (nocolor) in .spec so that SSAT writes non-colored results,
which will no more break OBS build logs.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
