### PR TITLE
[Meson] Support Ubuntu/Xenial and Tizen.

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -1,5 +1,6 @@
 tensor_common_sources = [
-    'tensor_common.c'
+    'tensor_common.c',
+    'tensor_repo.c'
 ]
 
 tensor_commonOBJ = static_library('tensor_common', 

--- a/gst/tensor_repopush/meson.build
+++ b/gst/tensor_repopush/meson.build
@@ -1,0 +1,13 @@
+tensor_repopush_sources = [
+    'tensor_repopush.c'
+]
+
+tensor_repopushOBJ = static_library('tensor_repopush',
+    tensor_repopush_sources,
+    dependencies: [
+        dependencies
+    ],
+    include_directories: inc
+).extract_all_objects()
+
+objects += tensor_repopushOBJ

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,10 @@
+# If you are using Ubuntu/Xenial, Do "force-version" on meson to get 0.40
+# If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
+
 project('nnstreamer', 'c', 'cpp',
     version: '0.0.3',
     license: ['LGPL'],
-    meson_version: '>=0.47.0',
+    meson_version: '>=0.40.0',
     default_options: [
         'warning_level=1',
         'c_std=c89',
@@ -49,7 +52,8 @@ projects = [
 	'tensor_sink',
 	'tensor_split',
 	'tensor_transform',
-	'tensor_filter'
+	'tensor_filter',
+	'tensor_repopush'
 ]
 
 objects = []
@@ -61,7 +65,8 @@ nnstreamer_sources = [
     'gst/nnstreamer/nnstreamer.c'
 ]
 
-nnstreamer = both_libraries('nnstreamer',
+# "both_libraries" are supported from 0.46.
+nnstreamer = shared_library('nnstreamer',
     nnstreamer_sources,
     dependencies: [
         dependencies
@@ -69,4 +74,11 @@ nnstreamer = both_libraries('nnstreamer',
     include_directories: inc,
     objects: objects
 )
-
+nnstreamer = static_library('nnstreamer',
+    nnstreamer_sources,
+    dependencies: [
+        dependencies
+    ],
+    include_directories: inc,
+    objects: objects
+)


### PR DESCRIPTION
Both Tizen and Ubuntu/Xenial does not support meson 0.47.
Lower down the Meson version requirement.

Fixes #897

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [x]Skipped
