### PR TITLE
[Common] build error fix for ubuntu/example.

### DIFF
--- a/gst/nnstreamer/tensor_typedef.h
+++ b/gst/nnstreamer/tensor_typedef.h
@@ -29,6 +29,7 @@
 #define __GST_TENSOR_TYPEDEF_H__
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define NNS_TENSOR_RANK_LIMIT	(4)
 #define NNS_TENSOR_SIZE_LIMIT	(16)


### PR DESCRIPTION
There is a missing header in typedef header.
Without stdint.h, you won't be able to find "uint8_t".

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
