### PR TITLE
[Transform/Orc] replace memcpy @open sesame 11/28 18:52

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ OPTION(ENABLE_TENSORFLOW_LITE "Enable tensorflow-lite support" ON)
 OPTION(ENABLE_TENSORFLOW "Enable tensorflow support" OFF)
 OPTION(INSTALL_EXAMPLE_APP "Install example applications" OFF)
 OPTION(ENABLE_TEST "Enable tests" ON)
+OPTION(ENABLE_ORC "Enable ORC" ON)
 
 IF(INSTALL_EXAMPLE_APP)
 	IF(EXAMPLE_EXEC_PREFIX)
@@ -41,6 +42,16 @@ SET(PKG_MODULES
 	gstreamer-audio-1.0
 	glib-2.0
 )
+
+IF(ENABLE_ORC)
+	FIND_LIBRARY(ORC_LIB orc-0.4)
+	IF(ORC_LIB)
+		SET(PKG_MODULES ${PKG_MODULES} orc-0.4)
+		ADD_DEFINITIONS(-DHAVE_ORC)
+	ELSE(ORC_LIB)
+		MESSAGE("Cannot find orc library")
+	ENDIF(ORC_LIB)
+ENDIF(ENABLE_ORC)
 
 pkg_check_modules(pkgs REQUIRED ${PKG_MODULES})
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: gcc, cmake, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev
  debhelper (>=9),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libpng-dev, tensorflow-lite-dev, tensorflow-dev [amd64 arm64], libcairo2-dev, libopencv-dev,
- ssat, python, python-numpy
+ liborc-0.4-dev, ssat, python, python-numpy
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnsuite/nnstreamer
 

--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -25,6 +25,10 @@
 #include <gst/gst.h>
 #include <gst/gstplugin.h>
 
+#ifdef HAVE_ORC
+#include <orc/orc.h>
+#endif
+
 #define NNSTREAMER_PLUGIN(name) \
   extern gboolean G_PASTE(nnstreamer_export_, name) (GstPlugin *plugin)
 
@@ -55,6 +59,11 @@ NNSTREAMER_PLUGIN (tensor_reposrc);
 static gboolean
 gst_nnstreamer_init (GstPlugin * plugin)
 {
+#ifdef HAVE_ORC
+  GST_INFO ("[NNStreamer] Initialize the Orc library");
+  orc_init ();
+#endif
+
   NNSTREAMER_INIT (tensor_converter, plugin);
   NNSTREAMER_INIT (tensor_aggregator, plugin);
   NNSTREAMER_INIT (tensor_decoder, plugin);

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -34,6 +34,20 @@
 #include <gst/base/gstcollectpads.h>
 #include <gst/gstplugin.h>
 
+#ifdef HAVE_ORC
+#include <orc/orc.h>
+
+#define nns_memcpy(d,s,n) do { \
+    if ((n) > 100) orc_memcpy ((d), (s), (n)); \
+    else memcpy ((d), (s), (n)); \
+  } while (0)
+
+#define nns_memset orc_memset
+#else
+#define nns_memcpy memcpy
+#define nns_memset memset
+#endif
+
 G_BEGIN_DECLS
 
 /**

--- a/gst/tensor_aggregator/tensor_aggregator.c
+++ b/gst/tensor_aggregator/tensor_aggregator.c
@@ -757,7 +757,7 @@ gst_tensor_aggregator_concat (GstTensorAggregator * self, GstBuffer * outbuf,
 
   do {
     for (f = 0; f < self->frames_out; f++) {
-      memcpy (dest_info.data + dest_idx,
+      nns_memcpy (dest_info.data + dest_idx,
           src_info.data + src_idx + (frame_size * f), block_size);
       dest_idx += block_size;
     }

--- a/gst/tensor_transform/tensor_transform.c
+++ b/gst/tensor_transform/tensor_transform.c
@@ -865,7 +865,8 @@ gst_tensor_transform_dimchg (GstTensorTransform * filter,
 
   if (from == to) {
     /** Useless memcpy. Do not call this or @todo do "IP" operation */
-    memcpy (outptr, inptr, gst_tensor_info_get_size (&filter->in_config.info));
+    nns_memcpy (outptr, inptr,
+        gst_tensor_info_get_size (&filter->in_config.info));
     GST_WARNING_OBJECT (filter,
         "Calling tensor_transform with high memcpy overhead WITHOUT any effects! Check your stream wheter you really need tensor_transform.\n");
     return GST_FLOW_OK;
@@ -900,7 +901,7 @@ gst_tensor_transform_dimchg (GstTensorTransform * filter,
       for (j = 0; j < toDim[to]; j++) {
         uint8_t *j_destptr = destptr + loopBlockSize * j;
         for (k = 0; k < copyblocklimit; k++) {
-          memcpy (j_destptr + copyblocksize * k,
+          nns_memcpy (j_destptr + copyblocksize * k,
               srcptr + k * copyblocksize * toDim[to] + j * copyblocksize,
               copyblocksize);
         }
@@ -1033,7 +1034,7 @@ gst_tensor_transform_arithmetic (GstTensorTransform * filter,
 	    inidx = SK*SJ*SI*l + SJ*SI*k + SI*j + i; \
 	    const uint8_t *_in = inptr+inidx*typesize; \
 	    uint8_t *_out = outptr + outidx *typesize; \
-	    memcpy(_out, _in, typesize); \
+	    nns_memcpy(_out, _in, typesize); \
 	  }                                                      \
   } while(0);
 
@@ -1064,7 +1065,8 @@ gst_tensor_transform_transpose (GstTensorTransform * filter,
   }
 
   if (!checkdim) {
-    memcpy (outptr, inptr, gst_tensor_info_get_size (&filter->in_config.info));
+    nns_memcpy (outptr, inptr,
+        gst_tensor_info_get_size (&filter->in_config.info));
     GST_WARNING_OBJECT (filter,
         "Calling tensor_transform with high memcpy overhead WITHOUT any effects!");
     return GST_FLOW_OK;

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -49,6 +49,9 @@ BuildRequires: lcov
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
 BuildRequires: ssat
 
+# For ORC (Oil Runtime Compiler)
+BuildRequires: orc-devel
+
 %package unittest-coverage
 Summary:	NNStreamer UnitTest Coverage Analysis Result
 %description unittest-coverage


### PR DESCRIPTION
1. define macro nns_memcpy/nns_memset
2. include liborc and use orc_memcpy instead in plugin tensor-transform and tensor-aggregator
3. add function orc_init to initialize orc library

TODO check cmake to use orc lib

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
