### PR TITLE
[Common/Conf] Close g_dir_open instance.

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -105,6 +105,7 @@ _get_fullpath_filenames (const gchar * dir, GSList * list, uint32_t * counter)
     *counter = *counter + 1;
   }
   g_free (dirfullpath);
+  g_dir_close (gdir);
   return list;
 }
 
@@ -129,6 +130,7 @@ _get_basenames (const gchar * dir, GSList * list, uint32_t * counter)
     list = g_slist_prepend (list, g_path_get_basename (name));
     *counter = *counter + 1;
   }
+  g_dir_close (gdir);
   return list;
 }
 


### PR DESCRIPTION
The returned object must be closed.

Reported-by: Wook Song <wook16.song@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

CC: @wooksong 