### PR TITLE
[Repo] Add runTest.sh for the dummy LSTM Test @open sesame 11/30 13:37

### DIFF
--- a/tests/nnstreamer_repo_lstm/generateTestCase.py
+++ b/tests/nnstreamer_repo_lstm/generateTestCase.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+##
+# Copyright (C) 2018 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file generateTestCase.py
+# @brief Generate a sequence of video/x-raw frames & golden
+# @todo Generate corresponding golden results
+# @author Jijoong Moon <jijoong.moon@samsung.com>
+# @url https://github.com/nnsuite/nnstreamer/
+#
+
+from __future__ import print_function
+
+import sys
+import os
+import array as arr
+import numpy as np
+
+def location(c, w, h):
+    return c+4*(w+4*h)
+
+##
+# @brief Generate a video/x-raw frame & update results
+# @return The frame buffer contents
+def genFrame(seq, out0, out1):
+    frame = arr.array('f', [0] * 64)
+    width = 4
+    height = 4
+    bpp = 4 # Byte per pixel
+
+    # (ALLCOLOR, 0, 0), 0 to 255
+    frame[bpp * ( 0 + width * 0 ) + 0] = seq # B
+    frame[bpp * ( 0 + width * 0 ) + 1] = seq # G
+    frame[bpp * ( 0 + width * 0 ) + 2] = seq # R
+
+    # (ALLCOLOR, 3, 3), 255 to 0
+    frame[bpp * ( 3 + width * 3 ) + 0] = 255 - seq # B
+    frame[bpp * ( 3 + width * 3 ) + 1] = 255 - seq # G
+    frame[bpp * ( 3 + width * 3 ) + 2] = 255 - seq # R
+
+    # (RED, 1, 1), 0 to 255
+    frame[bpp * ( 1 + width * 1 ) + 2] = seq # R
+
+    in0 = out0;
+    in1 = out1;
+    in2 = frame;
+
+    for h in range(0,4):
+        for w in range(0,4):
+            for c in range(0,4):
+                in2_tmp0 = (in2[location(c,w,h)] + in1[location(c,w,h)])/2
+                in2_tmp1 = np.tanh((in2[location(c,w,h)]))
+                in0[location(c,w,h)] = (in0[location(c,w,h)] * in2_tmp0)
+                in0[location(c,w,h)] += (in2_tmp0 * in2_tmp1)
+                out0[location(c,w,h)] = in0[location(c,w,h)]
+                out1[location(c,w,h)] = (np.tanh(in0[location(c,w,h)]) * in2_tmp0)
+
+    return frame.tostring(), out0, out1
+
+filename = "video_4x4xBGRx.xraw"
+f = open(filename, "w")
+
+out0 = arr.array('f',[0]*64)
+out1 = arr.array('f',[0]*64)
+
+for seq in range(0, 10):
+    outfilename = "lstm.golden"
+    string, out0, out1=genFrame(seq,out0, out1)
+    if(seq == 9):
+        with open(outfilename,'wb') as file:
+            file.write(out1.tostring())
+
+    f.write(string)
+
+f.close()
+
+print("File (%s) is written.\n" % filename)

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+##
+## @file runTest.sh
+## @author Jijoong Moon <jijoong.moon@samsung.com>
+## @date Nov 28 2018
+## @brief This is Testcase for the dummy lstm
+##
+##
+##
+##                                  repository
+##                              +-----------------+
+## +----------------------------|     slot 1      |<-----------------------------+
+## |                            +-----------------+                              |
+## |  +-------------------------|     slot 0      |<---------------------------+ |
+## |  |                         +-----------------+                            | |
+## |  |                                                                        | |
+## |  |                  +-------+    +--------+    +-------+                  | |
+## |  +-->repo_src:0 --->|       |--->|        |--->|       |---->repo_sink:0 -+ |
+## +----->repo_src:1 --->|  MUX  |    | Filter |    | DEMUX |---->repo_sink:1 ---+
+##        filesrc(new)-->|       |    |        |    |       |  |
+##                       +-------+    +--------+    +-------+  -->out_%1d.log
+##
+
+
+
+
+if [[ "$SSATAPILOADED" != "1" ]]
+then
+	SILENT=0
+	INDEPENDENT=1
+	search="ssat-api.sh"
+	source $search
+	printf "${Blue}Independent Mode${NC}
+"
+fi
+testInit $1 # You may replace this with Test Group Name
+
+# Generate video_4x4xBGRx.xraw & golden
+python generateTestCase.py
+
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=../../build/nnstreamer_example/custom_example_LSTM/libdummyLSTM.so ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor, dim1=4, dim2=4, dim3=4, dim4=1, type=float32, framerate=30/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor, dim1=4, dim2=4, dim3=4, dim4=1, type=float32, framerate=30/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+
+callCompareTest lstm.golden out_9.log 1-1 "Compare 1-1" 1 0
+
+report


### PR DESCRIPTION
# PR Description

- Add python script to generate input stream & golden data.
- Add runTest.sh to run.

```
                        repository
                      +-----------+
+---------------------|  slot 1   |<-------------------- ---+
|                     +-----------+                         |
|  +------------------|  slot 0   |<----------------------+ |
|  |                  +-----------+                       | |
|  |                                                      | |
|  |                  +---+   +---+  +---+                | |
|  +-->repo_src:0 --->|   |-->|   |->|   |-->repo_sink:0 -+ |
+----->repo_src:1 --->| M |   | F |  | D |-->repo_sink:1 ---+
       filesrc(new)-->|   |   |   |  |   |  |
                      +---+   +---+  +---+  -->out_%1d.log
```
**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>