### PR TITLE
[Repo] Fix bug return without releasing lock

### DIFF
--- a/gst/tensor_reposrc/tensor_reposrc.c
+++ b/gst/tensor_reposrc/tensor_reposrc.c
@@ -266,9 +266,6 @@ gst_tensor_reposrc_create (GstPushSrc * src, GstBuffer ** buffer)
 
   self = GST_TENSOR_REPOSRC (src);
   gst_tensor_repo_wait ();
-  if (gst_tensor_repo_check_eos (self->myid)) {
-    return GST_FLOW_EOS;
-  }
 
   if (!self->ini) {
     int i;


### PR DESCRIPTION
# PR Description

tensor_repo.c::gst_tensor_repo_add_repodata, unlock should be used
before return.

Resolves: #933

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>