### PR TITLE
[Decoder] Do not die for option errors. - @open sesame 11/30 15:09

### DIFF
--- a/gst/tensor_decoder/tensordec-imagelabel.c
+++ b/gst/tensor_decoder/tensordec-imagelabel.c
@@ -160,7 +160,6 @@ _setOption (GstTensorDec * self, int opNum, const gchar * param)
       return TRUE;
     else
       return FALSE;
-      /** @todo Do not die for this */
   }
 
   GST_INFO ("Property mode-option-%d is ignored", opNum + 1);


### PR DESCRIPTION
With dynamic pipeline configurations, the mode/option
properties may become incomplete. Do not die for such status
if the pipeline is not active.

This is critical for GUI toolkits.

Fixes a subitem of #827

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
