### PR TITLE
[Common/Conf] Fix coverity issue, uninitialized pointer read

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -204,7 +204,7 @@ gboolean
 nnstreamer_loadconf (gboolean force_reload)
 {
   g_autoptr (GError) error = NULL;
-  g_autoptr (GKeyFile) key_file;
+  g_autoptr (GKeyFile) key_file = NULL;
   GStatBuf gsbuf;
   int stt, i;
 


### PR DESCRIPTION
With auto-ptr, it tries to access read the pointer.
Thus, it should be initialized somehow.

Fixes Coverity Issue 1036166

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
