### PR TITLE
[Filter] Support pipeline stop and go.

### DIFF
--- a/gst/tensor_filter/tensor_filter.c
+++ b/gst/tensor_filter/tensor_filter.c
@@ -1281,25 +1281,12 @@ static gboolean
 gst_tensor_filter_stop (GstBaseTransform * trans)
 {
   GstTensorFilter *self;
-  GstTensorFilterProperties *prop;
 
   self = GST_TENSOR_FILTER_CAST (trans);
-  g_assert (self->fw != NULL);
-
-  prop = &self->prop;
+  if (self->fw == NULL)
+    return FALSE;
 
   gst_tensor_filter_close_fw (self);
-
-  if (prop->model_file) {
-    g_free ((void *) prop->model_file);
-    prop->model_file = NULL;
-  }
-
-  if (prop->custom_properties) {
-    g_free ((void *) prop->custom_properties);
-    prop->custom_properties = NULL;
-  }
-
   return TRUE;
 }
 

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -97,9 +97,7 @@ tflite_loadModelFile (const GstTensorFilter * filter, void **private_data)
 static int
 tflite_open (const GstTensorFilter * filter, void **private_data)
 {
-  int retval = tflite_loadModelFile (filter, private_data);
-  g_assert (retval == 0);       /** This must be called only once */
-  return 0;
+  return tflite_loadModelFile (filter, private_data);
 }
 
 /**


### PR DESCRIPTION
Pipeline Stop does not always mean pipeline close.
A pipeline may be paused and resumed (stop and start).
Thus, do not clean up internal data structure for stop.

Instead just notify the plugins of the events with
callbacks.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
