### PR TITLE
[Test] add more testcases

### DIFF
--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -46,6 +46,80 @@ TEST (test_tensor_transform, typecast_1)
   h = gst_harness_new ("tensor_transform");
 
   g_object_set (h->element, "mode", "typecast", "option", "uint32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_UINT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      uint32_t expected = (i + 1) * (b + 1);
+      EXPECT_EQ (((uint32_t *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, uint8 > uint32)
+ */
+TEST (test_tensor_transform, typecast_1_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "uint32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_UINT8;
@@ -118,6 +192,7 @@ TEST (test_tensor_transform, typecast_2)
   h = gst_harness_new ("tensor_transform");
 
   g_object_set (h->element, "mode", "typecast", "option", "float64", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_UINT32;
@@ -172,6 +247,809 @@ TEST (test_tensor_transform, typecast_2)
 }
 
 /**
+ * @brief Test for tensor_transform typecast (acceleration, uint32 > float64)
+ */
+TEST (test_tensor_transform, typecast_2_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float64", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT32;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT64;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint32_t value = (i + 1) * (b + 1);
+      ((uint32_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      double expected = (i + 1) * (b + 1);
+      EXPECT_DOUBLE_EQ (((double *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (int32 > float32)
+ */
+TEST (test_tensor_transform, typecast_3)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT32;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int32_t value = (i + 1) * (b + 1) * (-1);
+      ((int32_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, int32 > float32)
+ */
+TEST (test_tensor_transform, typecast_3_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT32;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int32_t value = (i + 1) * (b + 1) * (-1);
+      ((int32_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (int8 > float32)
+ */
+TEST (test_tensor_transform, typecast_4)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int8_t value = (i + 1) * (b + 1) * (-1);
+      ((int8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, int8 > float32)
+ */
+TEST (test_tensor_transform, typecast_4_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int8_t value = (i + 1) * (b + 1) * (-1);
+      ((int8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (uint8 > float32)
+ */
+TEST (test_tensor_transform, typecast_5)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, uint8 > float32)
+ */
+TEST (test_tensor_transform, typecast_5_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (int16 > float32)
+ */
+TEST (test_tensor_transform, typecast_6)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT16;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int16_t value = (i + 1) * (b + 1) * (-1);
+      ((int16_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, int16 > float32)
+ */
+TEST (test_tensor_transform, typecast_6_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_INT16;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      int16_t value = (i + 1) * (b + 1) * (-1);
+      ((int16_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) * (-1.);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (uint16 > float32)
+ */
+TEST (test_tensor_transform, typecast_7)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT16;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint16_t value = (i + 1) * (b + 1);
+      ((uint16_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform typecast (acceleration, uint16 > float32)
+ */
+TEST (test_tensor_transform, typecast_7_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT16;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint16_t value = (i + 1) * (b + 1);
+      ((uint16_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1);
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
  */
 TEST (test_tensor_transform, arithmetic_1)
@@ -190,6 +1068,77 @@ TEST (test_tensor_transform, arithmetic_1)
   h = gst_harness_new ("tensor_transform");
 
   g_object_set (h->element, "mode", "arithmetic", "option", "add:.5", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_FLOAT32;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      float value = (i + 1) * (b + 1) + .2;
+      ((float *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = (i + 1) * (b + 1) + .2 + .5;
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (acceleration, float32, add .5)
+ */
+TEST (test_tensor_transform, arithmetic_1_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic", "option", "add:.5", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_FLOAT32;
@@ -259,6 +1208,77 @@ TEST (test_tensor_transform, arithmetic_2)
   h = gst_harness_new ("tensor_transform");
 
   g_object_set (h->element, "mode", "arithmetic", "option", "mul:.5", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_FLOAT64;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      double value = (i + 1) * (b + 1) + .2;
+      ((double *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      double expected = ((i + 1) * (b + 1) + .2) * .5;
+      EXPECT_DOUBLE_EQ (((double *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (acceleration, float64, mul .5)
+ */
+TEST (test_tensor_transform, arithmetic_2_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic", "option", "mul:.5", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_FLOAT64;
@@ -329,6 +1349,81 @@ TEST (test_tensor_transform, arithmetic_3)
 
   g_object_set (h->element, "mode", "arithmetic",
       "option", "typecast:float32,add:.5,mul:0.2", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_UINT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      float expected = ((i + 1) * (b + 1) + .5) * .2;
+      EXPECT_FLOAT_EQ (((float *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > float32, add .5, mul .2)
+ */
+TEST (test_tensor_transform, arithmetic_3_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:float32,add:.5,mul:0.2", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_UINT8;
@@ -402,6 +1497,81 @@ TEST (test_tensor_transform, arithmetic_4)
 
   g_object_set (h->element, "mode", "arithmetic",
       "option", "typecast:float64,add:0.2,add:0.1,typecast:uint16", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_FLOAT64;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      double expected = (i + 1) * (b + 1) + .3;
+      EXPECT_DOUBLE_EQ (((double *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > float64, add .2, add .1, final typecast uint16 will be ignored)
+ */
+TEST (test_tensor_transform, arithmetic_4_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:float64,add:0.2,add:0.1,typecast:uint16", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_UINT8;
@@ -475,6 +1645,81 @@ TEST (test_tensor_transform, arithmetic_5)
 
   g_object_set (h->element, "mode", "arithmetic",
       "option", "typecast:int32,mul:2,div:2,add:-1", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
+
+  /* input tensor info */
+  config.info.type = _NNS_UINT8;
+  get_tensor_dimension ("5", config.info.dimension);
+  config.rate_n = 0;
+  config.rate_d = 1;
+
+  gst_harness_set_src_caps (h, gst_tensor_caps_from_config (&config));
+  data_in_size = gst_tensor_info_get_size (&config.info);
+
+  config.info.type = _NNS_INT32;
+  data_out_size = gst_tensor_info_get_size (&config.info);
+
+  /* push buffers */
+  for (b = 0; b < num_buffers; b++) {
+    /* set input buffer */
+    in_buf = gst_harness_create_buffer (h, data_in_size);
+
+    mem = gst_buffer_peek_memory (in_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_WRITE));
+
+    for (i = 0; i < array_size; i++) {
+      uint8_t value = (i + 1) * (b + 1);
+      ((uint8_t *) info.data)[i] = value;
+    }
+
+    gst_memory_unmap (mem, &info);
+
+    EXPECT_EQ (gst_harness_push (h, in_buf), GST_FLOW_OK);
+
+    /* get output buffer */
+    out_buf = gst_harness_pull (h);
+
+    ASSERT_TRUE (out_buf != NULL);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
+
+    mem = gst_buffer_peek_memory (out_buf, 0);
+    ASSERT_TRUE (gst_memory_map (mem, &info, GST_MAP_READ));
+
+    for (i = 0; i < array_size; i++) {
+      int32_t expected = (i + 1) * (b + 1) - 1;
+      EXPECT_EQ (((int32_t *) info.data)[i], expected);
+    }
+
+    gst_memory_unmap (mem, &info);
+    gst_buffer_unref (out_buf);
+  }
+
+  EXPECT_EQ (gst_harness_buffers_received (h), num_buffers);
+  gst_harness_teardown (h);
+}
+
+/**
+ * @brief Test for tensor_transform arithmetic (acceleration, typecast uint8 > int32, mul 2, div 2, add -1)
+ */
+TEST (test_tensor_transform, arithmetic_5_accel)
+{
+  const guint num_buffers = 3;
+  const guint array_size = 5;
+
+  GstHarness *h;
+  GstBuffer *in_buf, *out_buf;
+  GstTensorConfig config;
+  GstMemory *mem;
+  GstMapInfo info;
+  guint i, b;
+  gsize data_in_size, data_out_size;
+
+  h = gst_harness_new ("tensor_transform");
+
+  g_object_set (h->element, "mode", "arithmetic",
+      "option", "typecast:int32,mul:2,div:2,add:-1", NULL);
+  g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
   config.info.type = _NNS_UINT8;


### PR DESCRIPTION
Using gst-harness, add testcases for the property acceleration in tensor-transform.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
