### PR TITLE
[Transform/Orc] code clean to prepare meson

### DIFF
--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -25,6 +25,10 @@
 #ifndef __GST_TENSOR_COMMON_H__
 #define __GST_TENSOR_COMMON_H__
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <glib.h>
 #include <stdint.h>
 #include "tensor_typedef.h"

--- a/gst/tensor_transform/tensor_transform.h
+++ b/gst/tensor_transform/tensor_transform.h
@@ -28,6 +28,10 @@
 #ifndef __GST_TENSOR_TRANSFORM_H__
 #define __GST_TENSOR_TRANSFORM_H__
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
 #include <tensor_common.h>


### PR DESCRIPTION
1. Orc feature is defined in config, include config header to prepare meson build.
2. Set default property value with orc feature.
3. Add log message to indicate orc acceleration.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
