### PR TITLE
[Filter] Build Error Fix (gcc > 6)

### DIFF
--- a/gst/tensor_filter/tensor_filter.c
+++ b/gst/tensor_filter/tensor_filter.c
@@ -557,7 +557,8 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
           if (strlen (prop->input_meta.info[i].name))
             g_free ((char *) prop->input_meta.info[i].name);
           prop->input_meta.info[i].name = g_strdup (str_names[i]);
-          g_assert (prop->input_meta.info[i].name != '\0');
+          g_assert (prop->input_meta.info[i].name &&
+              prop->input_meta.info[i].name[0] != '\0');
         }
 
         g_strfreev (str_names);
@@ -578,7 +579,8 @@ gst_tensor_filter_set_property (GObject * object, guint prop_id,
           if (strlen (prop->output_meta.info[i].name))
             g_free ((char *) prop->output_meta.info[i].name);
           prop->output_meta.info[i].name = g_strdup (str_names[i]);
-          g_assert (prop->output_meta.info[i].name != '\0');
+          g_assert (prop->output_meta.info[i].name &&
+              prop->output_meta.info[i].name[0] != '\0');
         }
 
         g_strfreev (str_names);


### PR DESCRIPTION
Recent code commit has introduced the following errors in
modern gcc:

```
[ 20%] Building C object gst/tensor_filter/CMakeFiles/tensor_filterOBJ.dir/tensor_filter.c.o
cd /<<PKGBUILDDIR>>/build/gst/tensor_filter && /usr/bin/cc -DENABLE_TENSORFLOW_LITE -DHAVE_ORC=1 -DVERSION=\"0.1.0\" -I/<<PKGBUILDDIR>>/gst/nnstreamer -isystem /usr/include/gstreamer-1.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib/x86_64-linux-gnu/glib-2.0/include -isystem /usr/include/orc-0.4  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Werror -fPIC -g -std=c89  -Wno-sign-compare   -o CMakeFiles/tensor_filterOBJ.dir/tensor_filter.c.o   -c /<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c
In file included from /usr/lib/x86_64-linux-gnu/glib-2.0/include/glibconfig.h:9:0,
                 from /usr/include/glib-2.0/glib/gtypes.h:32,
                 from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from /usr/include/gstreamer-1.0/gst/gstinfo.h:27,
                 from /<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c:57:
/<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c: In function ‘gst_tensor_filter_set_property’:
/<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c:560:51: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
           g_assert (prop->input_meta.info[i].name != '\0');
                                                   ^
/<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c:560:21: note: did you mean to dereference the pointer?
           g_assert (prop->input_meta.info[i].name != '\0');
                     ^
/<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c:581:52: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
           g_assert (prop->output_meta.info[i].name != '\0');
                                                    ^
/<<PKGBUILDDIR>>/gst/tensor_filter/tensor_filter.c:581:21: note: did you mean to dereference the pointer?
           g_assert (prop->output_meta.info[i].name != '\0');
                     ^
```

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

CC: @helloahn 