### PR TITLE
[Filter/TF/TF-lite] remove link of tensor-common

### DIFF
--- a/gst/tensor_filter/tensor_filter_tensorflow_core.cc
+++ b/gst/tensor_filter/tensor_filter_tensorflow_core.cc
@@ -42,9 +42,6 @@
 TFCore::TFCore (const char *_model_path)
 {
   model_path = _model_path;
-
-  gst_tensors_info_init (&inputTensorMeta);
-  gst_tensors_info_init (&outputTensorMeta);
 }
 
 /**

--- a/gst/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/gst/tensor_filter/tensor_filter_tensorflow_core.h
@@ -27,15 +27,15 @@
 #define TENSOR_FILTER_TENSORFLOW_H
 
 #ifdef __cplusplus
-#include <stdint.h>
 #include <glib.h>
+#include <gst/gst.h>
 #include <setjmp.h>
 #include <stdio.h>
 #include <string.h>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-#include <vector>	 
+#include <vector>
 
 #include <tensorflow/cc/ops/const_op.h>
 #include <tensorflow/cc/ops/image_ops.h>
@@ -48,7 +48,7 @@
 #include <tensorflow/core/lib/strings/str_util.h>
 #include <tensorflow/tools/graph_transforms/transform_utils.h>
 
-#include <tensor_common.h>
+#include <tensor_typedef.h>
 
 using namespace tensorflow;
 
@@ -69,7 +69,7 @@ public:
   const char* getModelPath();
   int setInputTensorProp ();
   int setOutputTensorProp ();
-  
+
   int getInputTensorSize ();
   int getOutputTensorSize ();
   int getInputTensorDim (GstTensorsInfo * info);

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -21,7 +21,6 @@
  * @bug     No known bugs.
  */
 
-#include <sys/time.h>
 #include <unistd.h>
 #include <algorithm>
 
@@ -43,9 +42,6 @@
 TFLiteCore::TFLiteCore (const char *_model_path)
 {
   model_path = _model_path;
-
-  gst_tensors_info_init (&inputTensorMeta);
-  gst_tensors_info_init (&outputTensorMeta);
 }
 
 /**

--- a/gst/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/gst/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -25,15 +25,15 @@
 
 #ifdef __cplusplus
 #include <iostream>
-#include <stdint.h>
 #include <glib.h>
+#include <gst/gst.h>
 
 #include <tensorflow/contrib/lite/model.h>
 #include <tensorflow/contrib/lite/optional_debug_tools.h>
 #include <tensorflow/contrib/lite/string_util.h>
 #include <tensorflow/contrib/lite/kernels/register.h>
 
-#include <tensor_common.h>
+#include <tensor_typedef.h>
 
 /**
  * @brief	ring cache structure


### PR DESCRIPTION
remove dependency of tensor-common and unnecessary headers

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
