### PR TITLE
[Filter] add a new property for NNAPI path - @open sesame 1/21 10:26

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -32,6 +32,33 @@
 #include <string.h>
 
 /**
+ * @brief custom option enumeration for tensorflow-lite.
+ */
+enum
+{
+  TFLITE_OPTION_NNAPI = 0,
+  TFLITE_OPTION_MAX
+};
+
+/**
+ * @brief custom option string for tensorflow-lite.
+ */
+const char *tflite_options[TFLITE_OPTION_MAX] = {
+  "NNAPI",
+};
+
+/**
+ * @brief delimiter characters.
+ */
+static const char *tokens = "=:,";
+
+/**
+ * @brief a pointer to custom option string.
+ * @note the rule should be custom=OPTION1:VALUE1,...,OPTIONn:VALUEn
+ */
+static char *custom_options;
+
+/**
  * @brief internal data of tensorflow lite
  */
 struct _Tflite_data
@@ -40,6 +67,71 @@ struct _Tflite_data
 };
 typedef struct _Tflite_data tflite_data;
 
+/**
+  * @brief parse custom options for tensorflow lite
+  * @param filter : tensor_filter instance
+  * @param id : Option ID
+  * @return 0 or 1 if successfully parsed.
+  *        -1 if parsing a value of a given option failed.
+  */
+static int
+tflite_get_parser_boolean (const GstTensorFilter * filter, int id)
+{
+  int ret = -1;
+
+  if (filter->prop.custom_properties == NULL)
+    return ret;
+
+  if (id < 0 || id >= TFLITE_OPTION_MAX) {
+    GST_WARNING ("Invalid option id. (%d)\n", id);
+    return ret;
+  }
+
+  custom_options = g_strdup (filter->prop.custom_properties);
+  if (custom_options == NULL) {
+    GST_WARNING ("failed to dump custom property string\n");
+    return ret;
+  }
+
+  char *str = strtok (custom_options, tokens);
+  while (str != NULL) {
+    if (strcmp (str, tflite_options[id]) == 0) {
+      str = strtok (NULL, tokens);
+      break;
+    }
+
+    /** TODO. check other options here if required. */
+
+    str = strtok (NULL, tokens);
+    if (str == NULL)
+      break;
+
+    str = strtok (NULL, tokens);
+  }
+
+  if (str == NULL) {
+    GST_WARNING ("Invalid custom option.\n");
+    goto out;
+  }
+
+  switch (id) {
+    case TFLITE_OPTION_NNAPI:
+      if (strcmp (str, "TRUE") == 0)
+        ret = 1;
+      else if (strcmp (str, "FALSE") == 0)
+        ret = 0;
+      else
+        GST_WARNING ("Invalid custom value. (%s)\n", str);
+      break;
+  /** TODO. add additional cases if required. */
+    default:
+      break;
+  }
+
+out:
+  free (custom_options);
+  return ret;
+}
 
 /**
  * @brief Free privateData and move on.
@@ -79,7 +171,18 @@ tflite_loadModelFile (const GstTensorFilter * filter, void **private_data)
   }
   tf = g_new0 (tflite_data, 1); /** initialize tf Fill Zero! */
   *private_data = tf;
-  tf->tflite_private_data = tflite_core_new (filter->prop.model_file);
+
+  int use_nnapi = tflite_get_parser_boolean (filter, TFLITE_OPTION_NNAPI);
+  if (use_nnapi < 0) {
+    GST_INFO ("The supported option is custom=NNAPI:[TRUE|FALSE].\n");
+    GST_INFO ("In default, it uses CPU fallback path instead of NNAPI.\n");
+    use_nnapi = 0;
+  }
+
+  GST_LOG ("NNAPI=%s\n", use_nnapi ? "TRUE" : "FALSE");
+
+  tf->tflite_private_data =
+      tflite_core_new (filter->prop.model_file, use_nnapi);
   if (tf->tflite_private_data) {
     if (tflite_core_init (tf->tflite_private_data))
       return -2;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -36,12 +36,14 @@
 /**
  * @brief	TFLiteCore creator
  * @param	_model_path	: the logical path to '{model_name}.tffile' file
+ * @param	_use_nnapi	: enable NNAPI path for inference
  * @note	the model of _model_path will be loaded simultaneously
  * @return	Nothing
  */
-TFLiteCore::TFLiteCore (const char *_model_path)
+TFLiteCore::TFLiteCore (const char *_model_path, int _use_nnapi)
 {
   model_path = _model_path;
+  use_nnapi = _use_nnapi;
 
   memset (&inputTensorMeta, 0, sizeof (GstTensorsInfo));
   memset (&outputTensorMeta, 0, sizeof (GstTensorsInfo));
@@ -119,6 +121,9 @@ TFLiteCore::loadModel ()
       GST_ERROR ("Failed to construct interpreter\n");
       return -2;
     }
+
+    /* Set inference path of tensorflow-lite. */
+    interpreter->UseNNAPI (use_nnapi);
 
     /** set allocation type to dynamic for in/out tensors */
     int tensor_idx;
@@ -366,9 +371,9 @@ TFLiteCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
  * @return	TFLiteCore class
  */
 void *
-tflite_core_new (const char *_model_path)
+tflite_core_new (const char *_model_path, int _use_nnapi)
 {
-  return new TFLiteCore (_model_path);
+  return new TFLiteCore (_model_path, _use_nnapi);
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -41,7 +41,7 @@
 class TFLiteCore
 {
 public:
-  TFLiteCore (const char *_model_path);
+  TFLiteCore (const char *_model_path, int _use_nnapi);
   ~TFLiteCore ();
 
   int init();
@@ -56,6 +56,7 @@ public:
 private:
 
   const char *model_path;
+  int use_nnapi;
 
   GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
   GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
@@ -76,7 +77,7 @@ extern "C"
 {
 #endif
 
-  extern void *tflite_core_new (const char *_model_path);
+  extern void *tflite_core_new (const char *_model_path, int _use_nnapi);
   extern void tflite_core_delete (void *tflite);
   extern int tflite_core_init (void *tflite);
   extern const char *tflite_core_getModelPath (void *tflite);


### PR DESCRIPTION
Tensorflow lite uses CPU fallback as default inference path.
This patch adds a new property, use-nnapi, to choose the inference path.

To use NNAPI path,
... tensor_filter framework="tensorflow-lite" model="model_file"
use-nnapi=TRUE ...

To use CPU fallback path,
... tensor_filter framework="tensorflow-lite" model="model_file"
use-nnapi=FALSE ...

Signed-off-by: Inki Dae <inki.dae@samsung.com>