### PR TITLE
Plug-and-play sub-plugins for Tensor_Filter

### DIFF
--- a/gst/nnstreamer/tensor_decoder/tensordec-plugins.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec-plugins.c
@@ -24,6 +24,7 @@
  */
 
 #include "tensordec.h"
+#include <nnstreamer_subplugin.h>
 #include <gst/gstinfo.h>
 
 typedef struct _TensorDecDefList TensorDecDefList;
@@ -123,7 +124,7 @@ tensordec_exit (const gchar * name)
  * @brief Find decoders subplugin with the name
  * @param[in] name the name of decoder (modename)
  */
-TensorDecDef *
+const TensorDecDef *
 tensordec_find (const gchar * name)
 {
   TensorDecDefList *list = &listhead;
@@ -142,6 +143,6 @@ tensordec_find (const gchar * name)
     list = list->next;
   } while (list != NULL);
 
-  GST_ERROR ("Cannot find decoder subplugin, \"%s\"\n", name);
-  return NULL;
+  /* If not found, try to search with nnstreamer_subplugin APIs */
+  return get_subplugin (NNS_SUBPLUGIN_DECODER, name);
 }

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -397,7 +397,7 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
       break;
     case PROP_MODE:{
       int i;
-      TensorDecDef *decoder;
+      const TensorDecDef *decoder;
       gboolean retval = TRUE;
       temp_string = g_value_dup_string (value);
       decoder = tensordec_find (temp_string);

--- a/gst/nnstreamer/tensor_decoder/tensordec.h
+++ b/gst/nnstreamer/tensor_decoder/tensordec.h
@@ -71,7 +71,7 @@ struct _GstTensorDec
   void (*cleanup_plugin_data)(GstTensorDec *self); /**< exit() of subplugin is registered here. If it's null, gfree(plugin_data) is used. */
   GstTensorsConfig tensor_config; /**< configured tensor info @todo support tensors in the future */
 
-  TensorDecDef *decoder; /**< Plugin object */
+  const TensorDecDef *decoder; /**< Plugin object */
 };
 
 /**
@@ -158,7 +158,7 @@ struct _TensorDecDef
 
 extern gboolean tensordec_probe (TensorDecDef *decoder);
 extern void tensordec_exit (const gchar *name);
-extern TensorDecDef *tensordec_find (const gchar *name);
+extern const TensorDecDef *tensordec_find (const gchar *name);
 
 
 G_END_DECLS

--- a/gst/nnstreamer/tensor_filter/tensor_filter.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.h
@@ -53,8 +53,6 @@ typedef struct _GstTensorFilter GstTensorFilter;
 typedef struct _GstTensorFilterClass GstTensorFilterClass;
 typedef struct _GstTensorFilterFramework GstTensorFilterFramework;
 
-extern const char *nnfw_names[];
-
 /**
  * @brief Internal data structure for tensor_filter instances.
  */
@@ -64,7 +62,7 @@ struct _GstTensorFilter
 
   void *privateData; /**< NNFW plugin's private data is stored here */
   GstTensorFilterProperties prop; /**< NNFW plugin's properties */
-  GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
+  const GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
 
   /** internal properties for tensor-filter */
   int silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
@@ -187,6 +185,10 @@ extern GstTensorFilterFramework NNS_support_tensorflow;
 extern GstTensorFilterFramework NNS_support_custom;
 
 extern GstTensorFilterFramework *tensor_filter_supported[];
+
+/* extern functions for subplugin management */
+extern gboolean tensor_filter_probe (GstTensorFilterFramework *tfsp);
+extern void tensor_filter_exit (const gchar *name);
 
 G_END_DECLS
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -244,3 +244,17 @@ GstTensorFilterFramework NNS_support_custom = {
   .open = custom_open,
   .close = custom_close,
 };
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+__attribute__ ((constructor))
+     void init_filter_custom (void)
+{
+  tensor_filter_probe (&NNS_support_custom);
+}
+
+/** @brief Destruct the subplugin */
+__attribute__ ((destructor))
+     void fini_filter_custom (void)
+{
+  tensor_filter_exit (NNS_support_custom.name);
+}

--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -158,3 +158,17 @@ GstTensorFilterFramework NNS_support_tensorflow = {
   .open = tf_open,
   .close = tf_close,
 };
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+__attribute__ ((constructor))
+     void init_filter_tf (void)
+{
+  tensor_filter_probe (&NNS_support_tensorflow);
+}
+
+/** @brief Destruct the subplugin */
+__attribute__ ((destructor))
+     void fini_filter_tf (void)
+{
+  tensor_filter_exit (NNS_support_tensorflow.name);
+}

--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -157,3 +157,17 @@ GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .open = tflite_open,
   .close = tflite_close,
 };
+
+/** @brief Initialize this object for tensor_filter subplugin runtime register */
+__attribute__ ((constructor))
+     void init_filter_tflite (void)
+{
+  tensor_filter_probe (&NNS_support_tensorflow_lite);
+}
+
+/** @brief Destruct the subplugin */
+__attribute__ ((destructor))
+     void fini_filter_tflite (void)
+{
+  tensor_filter_exit (NNS_support_tensorflow_lite.name);
+}

--- a/gst/nnstreamer/tensor_typedef.h
+++ b/gst/nnstreamer/tensor_typedef.h
@@ -145,7 +145,7 @@ typedef struct
  */
 typedef struct _GstTensorFilterProperties
 {
-  nnfw_type nnfw; /**< The enum value of corresponding NNFW. _T_F_UNDEFINED if not configured */
+  const char *fwname; /**< The name of NN Framework */
   int fw_opened; /**< TRUE IF open() is called or tried. Use int instead of gboolean because this is refered by custom plugins. */
   const char *model_file; /**< Filepath to the model file (as an argument for NNFW). char instead of gchar for non-glib custom plugins */
 


### PR DESCRIPTION
Allow tensor_filter sub-plugins to be independently built
and attached/detached in run-time with subplugin APIs.
    
This resolves one of "future work" in ATC 2019 submitted paper already :)

Objective:
#786 & #846 
- Allow independently developed and built subplugins for tensor_filter
- Search for sub-plugins in a pre-defined paths amd env-var
- Flexing muscles for coding after the long disappearance.


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
