### PR TITLE
DIST: apply meson/ninja to debian build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc, cmake, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
+Build-Depends: gcc, ninja-build, meson (>=0.40), libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  libgtest-dev,
  debhelper (>=9),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,

--- a/debian/nnstreamer.install
+++ b/debian/nnstreamer.install
@@ -1,2 +1,2 @@
-/usr/lib/*/libtensor_filter_tf*core.so
+/usr/lib/*/libtensor_filter_*.so
 /usr/lib/*/gstreamer-1.0/*.so

--- a/debian/rules
+++ b/debian/rules
@@ -13,12 +13,35 @@
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+ROOT_DIR:=$(shell pwd)
 export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --buildsystem=cmake --builddirectory=build --parallel
+	dh $@ --parallel
 
-NNS_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH)
+override_dh_auto_clean:
+	rm -rf build
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_INSTALL_LIBDIR=$(NNS_INSTALL_LIBDIR)
+	mkdir -p build
+	meson --buildtype=plain --werror --prefix=/usr --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include -Dinstall-example=true -Denable-tensorflow=false build
+# @todo @hello-ahn Enablet tensorflow after the update of protobuf packaging
+
+override_dh_auto_build:
+	ninja -C build
+
+override_dh_auto_test:
+	export LD_LIBRARY_PATH=${ROOT_DIR}/build/gst/nnstreamer:${ROOT_DIR}/build/gst/nnstreamer/tensor_filter
+	export GST_PLUGIN_PATH=${ROOT_DIR}/build
+	ls -l
+	cd build && ./tests/unittest_common && cd ..
+	cd build && ./tests/unittest_sink --gst-plugin-path=. && cd ..
+	cd build && ./tests/unittest_plugins --gst-plugin-path=. && cd ..
+	cd tests && ssat -n && cd ..
+
+override_dh_auto_install:
+	DESTDIR=$(CURDIR)/debian/tmp ninja -C build install
+
+override_dh_install:
+	dh_install --sourcedir=debian/tmp --list-missing
+# Add --fail-missing option after adding *.install files for all subpackages.


### PR DESCRIPTION
Before remocing CMAKE infrastructure,
migrate build system to meson/ninja for debian builds.

TODO
- Disable tensorflow for non-supporting arch in rules.
- Resolve #1024 for Ubuntu 16.04 pdebuild


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [  ]Skipped

**How to evaluate:**
1. Describe how to evaluate in order to be reproduced by reviewer(s).

Add signed-off message automatically by running **$git commit -s ...** command.

$ git push origin <your_branch_name>
```

