### PR TITLE
[Converter] remove code to update property

### DIFF
--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -1196,7 +1196,6 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
   self->in_media_type = in_type;
   self->tensor_configured = TRUE;
   self->tensor_config = config;
-  self->tensor_info = config.info;
   return TRUE;
 }
 


### PR DESCRIPTION
Updating tensor info property may cause an error when doing caps negotiation.

related issue : #941

error case:
1. run pipeviz (e.g., videotestsrc - capsfilter - tensor_converter - tensor_sink)
2. set caps video/x-raw,format=RGB,width=640,height=480 in capsfilter and run pipeline
3. stop pipeline, and change caps (width=320,height=240)
4. run pipeline again, then it will make caps-negotiation failure.

If set tensor_info (line 1199), stop and run pipeline again,
- It resets the flag tensor_configured false. (in gst_tensor_converter_change_state())
- After running pipeline again, gst_tensor_info_validate (line 1189) returned true
  and in-caps is different with saved tensor_info. This makes caps-negotiation failure.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
