### PR TITLE
[Build] remove unnecessary installation

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -160,9 +160,6 @@ mkdir -p %{buildroot}%{_datadir}/nnstreamer/unittest/
 cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %endif
 
-install build/gst/nnstreamer/libnnstreamer.a %{buildroot}%{_libdir}/
-install build/gst/nnstreamer/tensor_filter/*.a %{buildroot}%{_libdir}/
-
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
 


### PR DESCRIPTION
installing libraries (.a) is unnecessary with meson.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
