### PR TITLE
[Filter] add a method destoryNotify() to handle data pointer @open sesame 1/17 17:20 

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -869,7 +869,8 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
       /* filter-subplugin allocated new memory, update this */
       out_mem[i] =
           gst_memory_new_wrapped (0, out_tensors[i].data, out_tensors[i].size,
-          0, out_tensors[i].size, out_tensors[i].data, g_free);
+          0, out_tensors[i].size, out_tensors[i].data,
+          self->fw->destroyNotify ? self->fw->destroyNotify : g_free);
     } else {
       gst_memory_unmap (out_mem[i], &out_info[i]);
     }

--- a/gst/nnstreamer/tensor_filter/tensor_filter.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.h
@@ -178,6 +178,12 @@ struct _GstTensorFilterFramework
        * @param[in] filter "this" pointer. Use this to read property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, close() frees private_data and set NULL.
        */
+
+  void (*destroyNotify) (void * data);
+      /**< Optional. tensor_filter.c will call it when 'allocate_in_invoke' flag of the framework is TRUE. Basically, it is called when the data element is destroyed. If it's set as NULL, g_free() will be used as a default. It will be helpful when the data pointer is included as an object of a nnfw. For instance, if the data pointer is removed when the object is gone, it occurs error. In this case, the objects should be maintained for a while first and destroyed when the data pointer is destroyed. Those kinds of logic could be defined at this method.
+       * 
+       * @param[in] data the data element.
+       */
 };
 
 extern GstTensorFilterFramework NNS_support_tensorflow_lite;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -117,8 +117,10 @@ custom_open (const GstTensorFilter * filter, void **private_data)
   ptr = *private_data;
   g_assert (!ptr->methods->invoke != !ptr->methods->allocate_invoke);   /* XOR! */
 
-  if (ptr->methods->allocate_invoke)
+  if (ptr->methods->allocate_invoke) {
     NNS_support_custom.allocate_in_invoke = TRUE;
+    NNS_support_custom.destroyNotify = ptr->methods->destroy_notify;
+  }
   return 0;
 }
 
@@ -243,6 +245,7 @@ GstTensorFilterFramework NNS_support_custom = {
   .setInputDimension = custom_setInputDim,
   .open = custom_open,
   .close = custom_close,
+  .destroyNotify = NULL,        /* default null. if allocate_in_invoke is true, this will be set from custom filter. */
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */

--- a/gst/nnstreamer/tensor_filter_custom.h
+++ b/gst/nnstreamer/tensor_filter_custom.h
@@ -109,6 +109,12 @@ typedef int (*NNS_custom_allocate_invoke) (void *private_data,
     const GstTensorFilterProperties * prop, const GstTensorMemory * input, GstTensorMemory * output);
 
 /**
+ * @brief It's a post-processing method about the used data pointer if it has been allocated at custom filter.
+ * @param[in] data the data element.
+ */
+typedef void (*NNS_custom_destroy_notify) (void * data);
+
+/**
  * @brief Custom Filter Class
  *
  * Note that exery function pointer is MANDATORY!
@@ -122,6 +128,7 @@ struct _NNStreamer_custom_class
   NNS_custom_set_input_dimension setInputDim; /**< without getI/O-Dim, this allows framework to set input dimension and get output dimension from the custom filter according to the input dimension */
   NNS_custom_invoke invoke; /**< the main function, "invoke", that transforms input to output. invoke is supposed to fill in the given output buffer. (invoke) XOR (allocate_invoke) MUST hold. */
   NNS_custom_allocate_invoke allocate_invoke; /**< the main function, "allocate & invoke", that transforms input to output. allocate_invoke is supposed to allocate output buffer by itself. (invoke) XOR (allocate_invoke) MUST hold. */
+  NNS_custom_destroy_notify destroy_notify; /**< it handles the data pointer allocated in the custom framework. when the data pointer has been destroyed at the pipeline, this method will be called. the data pointer or an object including data pointer could be deleted safely with this function. this method is only used when allocate_invoke is TRUE */
 };
 typedef struct _NNStreamer_custom_class NNStreamer_custom_class;
 


### PR DESCRIPTION
It will handle the data pointer after GstMemory being destoryed.
If there is no specific method, it will be g_free() as a default.

This method will be useful to remove `memcpy` at tensorflow.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


Signed-off-by: Hyoung Joo Ahn <hello.ahnn@gmail.com>
