### PR TITLE
Improve build instructions and make nnstreamer_example to work

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -7,26 +7,82 @@ The following dependencies are needed to compile/build/run.
 * glib 2.0
 * cmake >= 2.8
 
+### Install via PPA repository (Debian/Ubuntu)
+
+The nnstreamer releases are at a PPA repository. In order to install it, use:
+
+```bash
+$ sudo apt-add-repository ppa:nnstreamer
+$ sudo apt install nnstreamer
+```
+
 ### Linux Self-Hosted Build
 
-**Approach 1.** Build with debian tools
+**Approach 1.** Build with Debian/Ubuntu tools
 
-* How to use mk-build-deps
-```bash
-$ mk-build-deps --install debian/control
-$ dpkg -i nnstreamer-build-deps_2018.6.16_all.deb
-```
-Note that the version name may change. Please check your local directory after excecuting ```mk-build-deps```.
+***Clone the needed repositories***
 
-* How to use debuild
 ```bash
-$ export DEB_BUILD_OPTIONS="parallel=8"
-$ time debuild -us -uc
-$ export DEB_BUILD_OPTIONS=""
+$ git clone https://github.com/myungjoo/SSAT ssat
+$ git clone https://git.tizen.org/cgit/platform/upstream/tensorflow
+$ git clone https://github.com/nnsuite/nnstreamer
 ```
+
+***Fix tensorflow for it to build properly***
+
+There is a shell script call at tensorflow/contrib/lite/Makefile that may
+fail, depending on the shell you're using. The best is to replace
+the ARCH detection macro (it is named renamed to HOST_ARCH on tensorflow
+upstream) from:
+
+```makefile
+ARCH := $(shell if [[ $(shell uname -m) =~ i[345678]86 ]]; then echo x86_32; else echo $(shell uname -m); fi)
+```
+
+to:
+
+```makefile
+ARCH := $(shell uname -m | sed -e 's/i[3-8]86/x86_32/')
+```
+
+***Build .deb packages***
+
+Installing required depencencies:
+
+```bash
+$ for i in ssat tensorflow nnstreamer; do \
+  (cd $i && sudo mk-build-deps --install debian/control && sudo dpkg -i *.deb || break); \
+  done
+```
+
+Creating the .deb packages:
+
+```bash
+$ export DEB_BUILD_OPTIONS="parallel=$(($(cat /proc/cpuinfo |grep processor|wc -l) + 1))"
+$ for i in ssat tensorflow nnstreamer; do \
+  (cd $i && time debuild -us -uc || break); \
+  done
+```
+
 If there is a missing package, debuild will tell you which package is missing.
 If you haven't configured debuild properly, yet, you will need to add ```-uc -us``` options to ```debuild```.
 
+***Install the generated \*.deb files***
+
+The files will be there at the parent dir. E. g. at nnbuilder/.. directory.
+
+In order to install them (should run as root):
+
+```bash
+$ sudo apt install ./ssat_*.deb ./tensorflow-lite-dev_*.deb ./tensorflow-dev_*.deb
+$ sudo apt install ./nnstreamer_0.1.0-1rc1_amd64.deb
+```
+
+If you need nnstreamer development package:
+
+```bash
+#apt install ./nnstreamer-dev_0.1.0-1rc1_amd64.deb
+```
 
 **Approach 2.** Build with Cmake
 


### PR DESCRIPTION
The Debian/Ubuntu build instructions are incomplete, as tensorflow-dev, tensorflow-lite-dev and ssat packages are also needed for it to build.

Update the instructions.

While here, make the nnstreamer_example/example_cam to also work.

With that, it works fine with two cameras:
   - HD Pro Webcam C920 (fourcc: YUYV, H264, MJPG);
   - Sirius USB2.0 Camera (fourcc: YUYV);

I also tested with a sn9c20x SDK camera, with uses fourcc: GREY.
With this one, on my i7-5557U test machine, the pipeline works, but it gives:
    "There may be a timestamping problem, or this computer is too slow."

