### PR TITLE
[Filter/Tensorflow] remove memcpy of the output tensor - @open sesame 1/21 10:26

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -148,10 +148,21 @@ tf_getOutputDim (const GstTensorFilter * filter, void **private_data,
   return ret;
 }
 
+/**
+ * @brief The optional callback for GstTensorFilterFramework
+ * @param[in] data The data element.
+ */
+static void
+tf_destroyNotify (void *data)
+{
+  tf_core_destroyNotify (data);
+}
+
 GstTensorFilterFramework NNS_support_tensorflow = {
   .name = "tensorflow",
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = FALSE,
+  .allocate_in_invoke = TRUE,
+  .destroyNotify = tf_destroyNotify,
   .invoke_NN = tf_run,
   .getInputDimension = tf_getInputDim,
   .getOutputDimension = tf_getOutputDim,

--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -76,6 +76,8 @@ public:
   int getOutputTensorDim (GstTensorsInfo * info);
   int run (const GstTensorMemory * input, GstTensorMemory * output);
 
+  static std::map<void*, Tensor> outputTensorMap;
+
 private:
 
   const char *model_path;
@@ -92,8 +94,6 @@ private:
   DataType getTensorTypeToTF (tensor_type tType);
   int setTensorProp (GstTensorsInfo * dest, const GstTensorsInfo * src);
   int inputTensorValidation (const std::vector<const NodeDef*> &placeholders);
-  /*TODO*/
-  // int outputTensorValidation ();
 };
 
 /**
@@ -111,6 +111,7 @@ extern "C"
   extern int tf_core_getOutputDim (void *tf, GstTensorsInfo * info);
   extern int tf_core_run (void *tf, const GstTensorMemory * input,
       GstTensorMemory * output);
+  extern void tf_core_destroyNotify (void * data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. get the data pointer directly from tensor rather than copy each data.
2. to use data pointer properly, increase ref counter of Tensor by storing it in the map.
3. maintain the output tensors for a while and erase it from the map when `destroyNotify()` is called.

it closes #1016 and closes #973

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyoung Joo Ahn <hello.ahnn@gmail.com>
