### PR TITLE
[CI Fix] Temporarily Disable App Test - @open sesame 1/21 16:44

### DIFF
--- a/.TAOS-CI/taos/config/config-plugins-audit.sh
+++ b/.TAOS-CI/taos/config/config-plugins-audit.sh
@@ -61,9 +61,10 @@ echo "[MODULE] plugins-staging: Plugin group that does not have evaluation and a
 # $module_name
 # echo "[DEBUG] $module_name is done."
 
-audit_plugins[++idx]="pr-audit-nnstreamer-ubuntu-apptest"
-echo "[DEBUG] TAOS/${audit_plugins[idx]}: Check nnstreamer sample app"
-echo "[DEBUG] ${audit_plugins[idx]} is started."
-echo "[DEBUG] Current path: $(pwd)."
-source ${REFERENCE_REPOSITORY}/ci/taos/plugins-staging/${audit_plugins[idx]}.sh
+#audit_plugins[++idx]="pr-audit-nnstreamer-ubuntu-apptest"
+# @todo Fixme. AppTest with Meson!
+#echo "[DEBUG] TAOS/${audit_plugins[idx]}: Check nnstreamer sample app"
+#echo "[DEBUG] ${audit_plugins[idx]} is started."
+#echo "[DEBUG] Current path: $(pwd)."
+#source ${REFERENCE_REPOSITORY}/ci/taos/plugins-staging/${audit_plugins[idx]}.sh
 


### PR DESCRIPTION
With recent updates on app test and build script,
we no longer have example applications in nnstreamer.git
It should be migrated to nnstreamer-example.git

We should build nnstreamer-example.git for app test, not
example directory in nnstreamer.git

This is an emergency fix for #1047

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

