### PR TITLE
[Filter] fix the memory leak at filter - @open sesame 1/23 17:50

### DIFF
--- a/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
+++ b/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
@@ -75,14 +75,17 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
+  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 3;
-  info->info[0] = data->info[0];
-  info->info[1] = data->info[1];
-  info->info[2] = data->info[2];
+  for (i = 0; i < info->num_tensors; ++i) {
+    memcpy (info->info[i].dimension, data->info[i].dimension,
+        sizeof (tensor_dim));
+    info->info[i].type = data->info[i].type;
+  }
   return 0;
 }
 
@@ -94,13 +97,17 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
+  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 2;
-  info->info[0] = data->info[0];
-  info->info[1] = data->info[1];
+  for (i = 0; i < info->num_tensors; ++i) {
+    memcpy (info->info[i].dimension, data->info[i].dimension,
+        sizeof (tensor_dim));
+    info->info[i].type = data->info[i].type;
+  }
   return 0;
 }
 

--- a/nnstreamer_example/custom_example_RNN/dummy_RNN.c
+++ b/nnstreamer_example/custom_example_RNN/dummy_RNN.c
@@ -73,13 +73,17 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
+  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 2;
-  info->info[0] = data->info[0];
-  info->info[1] = data->info[1];
+  for (i = 0; i < info->num_tensors; ++i) {
+    memcpy (info->info[i].dimension, data->info[i].dimension,
+        sizeof (tensor_dim));
+    info->info[i].type = data->info[i].type;
+  }
   return 0;
 }
 
@@ -91,12 +95,17 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
+  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  info->info[0] = data->info[0];
+  for (i = 0; i < info->num_tensors; ++i) {
+    memcpy (info->info[i].dimension, data->info[i].dimension,
+        sizeof (tensor_dim));
+    info->info[i].type = data->info[i].type;
+  }
   return 0;
 }
 

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
@@ -96,7 +96,8 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  info->info[0] = data->info;
+  memcpy (info->info[0].dimension, data->info.dimension, sizeof (tensor_dim));
+  info->info[0].type = data->info.type;
   return 0;
 }
 
@@ -113,7 +114,8 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  info->info[0] = data->info;
+  memcpy (info->info[0].dimension, data->info.dimension, sizeof (tensor_dim));
+  info->info[0].type = data->info.type;
   return 0;
 }
 


### PR DESCRIPTION
this pr solves the memory leak problem about the `model_file` and the `name` of input/output tensor

* test command
```bash
./tests/nnstreamer_filter_tensorflow/
---------------------------------------------------------------------------------
$ valgrind \
--leak-check=full --log-file=out_valgrind2.log -v --error-limit=no \
gst-launch-1.0 filesrc location=data/9.raw ! application/octet-stream ! \
tensor_converter input-dim=784:1 input-type=uint8 ! tensor_transform mode=arithmetic \
option=typecast:float32,add:-127.5,div:127.5 ! tensor_filter framework=tensorflow \
model=../test_models/models/mnist.pb input=784:1:1:1 inputtype=float32 inputname=input \
output=10:1:1:1 outputtype=float32 outputname=softmax ! filesink location=tensorfilter.out.log
```

* previous state
```bash
...
==27680== LEAK SUMMARY:
==27680==    definitely lost: 45 bytes in 3 blocks
==27680==    indirectly lost: 0 bytes in 0 blocks
==27680==      possibly lost: 13,492 bytes in 120 blocks
==27680==    still reachable: 7,468,404 bytes in 106,988 blocks
==27680==                       of which reachable via heuristic:
==27680==                         length64           : 240 bytes in 6 blocks
==27680==                         newarray           : 10,304 bytes in 48 blocks
==27680==         suppressed: 0 bytes in 0 blocks
==27680== Reachable blocks (those to which a pointer was found) are not shown.
==27680== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

* after this pr
```bash
...
==16413== LEAK SUMMARY:
==16413==    definitely lost: 0 bytes in 0 blocks
==16413==    indirectly lost: 0 bytes in 0 blocks
==16413==      possibly lost: 14,484 bytes in 120 blocks
==16413==    still reachable: 7,471,500 bytes in 106,989 blocks
==16413==                       of which reachable via heuristic:
==16413==                         length64           : 240 bytes in 6 blocks
==16413==                         newarray           : 10,304 bytes in 48 blocks
==16413==         suppressed: 0 bytes in 0 blocks
==16413== Reachable blocks (those to which a pointer was found) are not shown.
==16413== To see them, rerun with: --leak-check=full --show-leak-kinds=all
```

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped


Signed-off-by: Hyoung Joo Ahn <hello.ahnn@gmail.com>