### PR TITLE
 [Repo] Implement Dynamic Property(slot_id) Change of Repo 

### DIFF
--- a/gst/nnstreamer/tensor_repo.h
+++ b/gst/nnstreamer/tensor_repo.h
@@ -85,6 +85,11 @@ typedef struct
   GCond cond_pull;
   GMutex lock;
   gboolean eos;
+  gboolean src_changed;
+  guint src_id;
+  gboolean sink_changed;
+  guint sink_id;
+  gboolean pushed;
 } GstTensorRepoData;
 
 /**
@@ -110,13 +115,13 @@ gst_tensor_repo_get_repodata (guint nth);
  */
 /* guint */
 gboolean
-gst_tensor_repo_add_repodata (guint myid);
+gst_tensor_repo_add_repodata (guint myid, gboolean is_sink);
 
 /**
  * @brief push GstBuffer into repo
  */
 gboolean
-gst_tensor_repo_set_buffer (guint nth, GstBuffer * buffer, GstCaps * caps);
+gst_tensor_repo_set_buffer (guint nth, guint o_nth, GstBuffer * buffer, GstCaps * caps);
 
 /**
  * @brief get EOS
@@ -130,11 +135,17 @@ gst_tensor_repo_check_eos(guint nth);
 gboolean
 gst_tensor_repo_set_eos(guint nth);
 
+gboolean
+gst_tensor_repo_set_changed(guint o_nth, guint nth, gboolean is_sink);
+
 /**
  * @brief Get GstTensorRepoData from repo
  */
 GstBuffer *
-gst_tensor_repo_get_buffer (guint nth);
+gst_tensor_repo_get_buffer (guint nth, guint o_nth, gboolean *eos, guint *newid);
+
+gboolean
+gst_tensor_repo_check_changed (guint nth, guint *newid, gboolean is_sink);
 
 /**
  * @brief remove nth GstTensorRepoData from GstTensorRepo

--- a/gst/nnstreamer/tensor_reposink/tensor_reposink.h
+++ b/gst/nnstreamer/tensor_reposink/tensor_reposink.h
@@ -59,7 +59,9 @@ struct _GstTensorRepoSink
   guint signal_rate;
   GstClockTime last_render_time;
   GstCaps *in_caps;
+  gboolean set_startid;
   guint myid;
+  guint o_myid;
 };
 
 /**

--- a/gst/nnstreamer/tensor_reposrc/tensor_reposrc.h
+++ b/gst/nnstreamer/tensor_reposrc/tensor_reposrc.h
@@ -56,10 +56,12 @@ struct _GstTensorRepoSrc
   GstTensorsConfig config;
   gboolean silent;
   guint myid;
+  guint o_myid;
   GstCaps *caps;
   gboolean ini;
   gint fps_n, fps_d;
   gboolean negotiation;
+  gboolean set_startid;
 };
 
 /**


### PR DESCRIPTION
# PR Description

Implement Dynamic slot_id property change of tensor_reposrc and
tensor_reposink. In order to check the status of current repo,
sink_changed(gboolean), sink_id(guint) and src_changed (gboolean),
src_id(guint) variables are added. While waiting buffer from
repo_sink, repo check if this variables are changed using
gst_tensor_repo_check_chagned call, and if it changed, it trys to get
buffer from new slot id. The changing status of repo is set when slot
id property changed using tensor_repo_set_changed.

**Changes proposed in this PR:**
- Added function calls to check and set the changing status of repo.
- Added variables to control flow in each repo.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>