### PR TITLE
[Repo] Add test case for repo dynamicity

### DIFF
--- a/gst/nnstreamer/tensor_repo.h
+++ b/gst/nnstreamer/tensor_repo.h
@@ -85,6 +85,11 @@ typedef struct
   GCond cond_pull;
   GMutex lock;
   gboolean eos;
+  gboolean src_changed;
+  guint src_id;
+  gboolean sink_changed;
+  guint sink_id;
+  gboolean pushed;
 } GstTensorRepoData;
 
 /**
@@ -110,13 +115,13 @@ gst_tensor_repo_get_repodata (guint nth);
  */
 /* guint */
 gboolean
-gst_tensor_repo_add_repodata (guint myid);
+gst_tensor_repo_add_repodata (guint myid, gboolean is_sink);
 
 /**
  * @brief push GstBuffer into repo
  */
 gboolean
-gst_tensor_repo_set_buffer (guint nth, GstBuffer * buffer, GstCaps * caps);
+gst_tensor_repo_set_buffer (guint nth, guint o_nth, GstBuffer * buffer, GstCaps * caps);
 
 /**
  * @brief get EOS
@@ -130,11 +135,17 @@ gst_tensor_repo_check_eos(guint nth);
 gboolean
 gst_tensor_repo_set_eos(guint nth);
 
+gboolean
+gst_tensor_repo_set_changed(guint o_nth, guint nth, gboolean is_sink);
+
 /**
  * @brief Get GstTensorRepoData from repo
  */
 GstBuffer *
-gst_tensor_repo_get_buffer (guint nth);
+gst_tensor_repo_get_buffer (guint nth, guint o_nth, gboolean *eos, guint *newid);
+
+gboolean
+gst_tensor_repo_check_changed (guint nth, guint *newid, gboolean is_sink);
 
 /**
  * @brief remove nth GstTensorRepoData from GstTensorRepo

--- a/gst/nnstreamer/tensor_reposink/tensor_reposink.h
+++ b/gst/nnstreamer/tensor_reposink/tensor_reposink.h
@@ -59,7 +59,9 @@ struct _GstTensorRepoSink
   guint signal_rate;
   GstClockTime last_render_time;
   GstCaps *in_caps;
+  gboolean set_startid;
   guint myid;
+  guint o_myid;
 };
 
 /**

--- a/gst/nnstreamer/tensor_reposrc/tensor_reposrc.h
+++ b/gst/nnstreamer/tensor_reposrc/tensor_reposrc.h
@@ -56,10 +56,12 @@ struct _GstTensorRepoSrc
   GstTensorsConfig config;
   gboolean silent;
   guint myid;
+  guint o_myid;
   GstCaps *caps;
   gboolean ini;
   gint fps_n, fps_d;
   gboolean negotiation;
+  gboolean set_startid;
 };
 
 /**

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -72,3 +72,10 @@ if gtest_dep.found()
 
   test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
 endif
+
+# unittest_repo_dynamic
+unittest_repo = executable('unittest_repo',
+join_paths('nnstreamer_repo_dynamicity', 'tensor_repo_dynamic_test.c'),
+dependencies: [nnstreamer_dep, gst_dep, glib_dep],
+install: false
+)

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+##
+## @file runTest.sh
+## @author MyungJoo Ham <myungjoo.ham@gmail.com>
+## @date Nov 01 2018
+## @brief SSAT Test Cases for NNStreamer
+##
+if [[ "$SSATAPILOADED" != "1" ]]
+then
+	SILENT=0
+	INDEPENDENT=1
+	search="ssat-api.sh"
+	source $search
+	printf "${Blue}Independent Mode${NC}
+"
+fi
+
+# This is compatible with SSAT (https://github.com/myungjoo/SSAT)
+testInit $1
+
+PATH_TO_PLUGIN="../../build"
+
+if [ "$SKIPGEN" == "YES" ]
+then
+  echo "Test Case Generation Skipped"
+  sopath=$2
+else
+  echo "Test Case Generation Started"
+  python ../nnstreamer_converter/generateGoldenTestResult.py 12
+  sopath=$1
+fi
+convertBMP2PNG
+
+../../build/tests/unittest_repo --gst-plugin-path=../../build
+
+callCompareTest testsequence_1.golden tensorsequence01_1.log 1-1 "Compare 1-1" 1 0
+callCompareTest testsequence_2.golden tensorsequence01_2.log 1-2 "Compare 1-2" 1 0
+callCompareTest testsequence_3.golden tensorsequence01_3.log 1-3 "Compare 1-3" 1 0
+callCompareTest testsequence_4.golden tensorsequence01_4.log 1-4 "Compare 1-4" 1 0
+callCompareTest testsequence_5.golden tensorsequence01_5.log 1-5 "Compare 1-5" 1 0
+callCompareTest testsequence_6.golden tensorsequence01_6.log 1-6 "Compare 1-6" 1 0
+callCompareTest testsequence_7.golden tensorsequence01_7.log 1-7 "Compare 1-7" 1 0
+callCompareTest testsequence_8.golden tensorsequence01_8.log 1-8 "Compare 1-8" 1 0
+callCompareTest testsequence_9.golden tensorsequence01_9.log 1-9 "Compare 1-9" 1 0
+callCompareTest testsequence_10.golden tensorsequence01_10.log 1-10 "Compare 1-10" 1 0
+
+
+report

--- a/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
+++ b/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
@@ -1,0 +1,173 @@
+/**
+ * @file    tensor_repo_dynamic_test.c
+ * @date    03 Dec 2018
+ * @brief   test case to test tensor repo plugin dynamism
+ * @see     https://github.com/nnsuite/nnstreamer
+ * @author  Jijoong Moon <jijoong.moon@samsung.com>
+ * @bug     No known bugs except NYI.
+ *
+ *                                  repository
+ * +------------+   +----------+        +-----------------+
+ * | Multi-sink |<--| repo_src |<---+---|     slot 0      |<---+--+
+ * +------------+   +----------+    |   +-----------------+    |  |
+ *                                  +---|     slot 1      |<---+  |
+ *                                      +-----------------+       |
+ *                                                                |
+ * +-----------+   +--------+   +-----------+   +-----------+     |
+ * | Multi-src |-->| pngdec |-->| converter |-->| repo_sink |-----+
+ * +-----------+   +--------+   +-----------+   +-----------+
+ *
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <gst/gst.h>
+#include <tensor_common.h>
+#include <tensor_repo.h>
+
+static GMainLoop *loop = NULL;
+
+#ifndef DBG
+#define DBG FALSE
+#endif
+
+#define _print_log(...) if (DBG) g_message (__VA_ARGS__)
+
+/**
+ * @brief Bus Call Back Function
+ */
+static gboolean
+my_bus_callback (GstBus * bus, GstMessage * message, gpointer data)
+{
+  _print_log ("Got %s message\n", GST_MESSAGE_TYPE_NAME (message));
+
+  switch (GST_MESSAGE_TYPE (message)) {
+    case GST_MESSAGE_ERROR:{
+      GError *err;
+      gchar *debug;
+
+      gst_message_parse_error (message, &err, &debug);
+      _print_log ("Error: %s\n", err->message);
+      g_error_free (err);
+      g_free (debug);
+
+      g_main_loop_quit (loop);
+      break;
+    }
+    case GST_MESSAGE_EOS:
+      g_main_loop_quit (loop);
+      break;
+    default:
+      break;
+  }
+
+  return TRUE;
+}
+
+/**
+ * @brief Switch slot index
+ */
+static gboolean
+switch_slot_index (GstElement * tensor_repo)
+{
+  guint active_slot, new_slot;
+
+  _print_log ("switching");
+  g_object_get (G_OBJECT (tensor_repo), "slot-index", &active_slot, NULL);
+
+  new_slot = active_slot ? 0 : 1;
+
+  g_object_set (G_OBJECT (tensor_repo), "slot-index", new_slot, NULL);
+
+  _print_log ("current active memory slot is  : %d and it is changed to %d\n",
+      active_slot, new_slot);
+
+  return (GST_STATE (GST_ELEMENT (tensor_repo)) == GST_STATE_PLAYING);
+}
+
+
+/**
+ * @brief Main function to evalute tensor_repo dynamicity
+ */
+int
+main (int argc, char *argv[])
+{
+  GstElement *pipeline, *multifilesrc, *pngdec, *tensor_converter,
+      *tensor_reposink;
+  GstElement *tensor_reposrc, *multifilesink;
+  GstBus *bus;
+  GstCaps *msrc_cap, *reposrc_cap;
+
+  gst_init (&argc, &argv);
+
+  loop = g_main_loop_new (NULL, FALSE);
+
+  pipeline = gst_pipeline_new ("pipeline");
+  multifilesrc = gst_element_factory_make ("multifilesrc", "multifilesrc");
+  g_object_set (G_OBJECT (multifilesrc), "location", "testsequence_%1d.png",
+      NULL);
+  msrc_cap =
+      gst_caps_new_simple ("image/png", "framerate", GST_TYPE_FRACTION, 30, 1,
+      NULL);
+  g_object_set (G_OBJECT (multifilesrc), "caps", msrc_cap, NULL);
+  gst_caps_unref (msrc_cap);
+
+  pngdec = gst_element_factory_make ("pngdec", "pngdec");
+
+  tensor_converter =
+      gst_element_factory_make ("tensor_converter", "tensor_converter");
+
+  tensor_reposink =
+      gst_element_factory_make ("tensor_reposink", "tensor_reposink");
+  g_object_set (G_OBJECT (tensor_reposink), "silent", FALSE, NULL);
+  g_object_set (G_OBJECT (tensor_reposink), "slot-index", 0, NULL);
+
+  tensor_reposrc =
+      gst_element_factory_make ("tensor_reposrc", "tensor_reposrc");
+  g_object_set (G_OBJECT (tensor_reposrc), "silent", FALSE, NULL);
+  g_object_set (G_OBJECT (tensor_reposrc), "slot-index", 0, NULL);
+
+  reposrc_cap = gst_caps_new_simple ("other/tensor",
+      "dimension", G_TYPE_STRING, "3:16:16:1",
+      "type", G_TYPE_STRING, "uint8",
+      "framerate", GST_TYPE_FRACTION, 30, 1, NULL);
+
+  g_object_set (G_OBJECT (tensor_reposrc), "caps", reposrc_cap, NULL);
+  gst_caps_unref (reposrc_cap);
+
+  multifilesink = gst_element_factory_make ("multifilesink", "multifilesink");
+  g_object_set (G_OBJECT (multifilesink), "location",
+      "tensorsequence01_%1d.log", NULL);
+
+  gst_bin_add_many (GST_BIN (pipeline), multifilesrc, pngdec, tensor_converter,
+      tensor_reposink, tensor_reposrc, multifilesink, NULL);
+
+  gst_element_link (multifilesrc, pngdec);
+  gst_element_link (pngdec, tensor_converter);
+  gst_element_link (tensor_converter, tensor_reposink);
+  gst_element_link (tensor_reposrc, multifilesink);
+
+  bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));
+
+  gst_bus_add_watch (bus, my_bus_callback, NULL);
+  gst_object_unref (bus);
+  gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_PLAYING);
+
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposink);
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposrc);
+
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposink);
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposrc);
+
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposink);
+  g_timeout_add (100, (GSourceFunc) switch_slot_index, tensor_reposrc);
+
+
+  g_main_loop_run (loop);
+
+  gst_element_set_state (GST_ELEMENT (pipeline), GST_STATE_READY);
+
+  gst_object_unref (GST_OBJECT (pipeline));
+
+  exit (0);
+}


### PR DESCRIPTION
# PR Description

In this PR, added repo test application. It constructs pipeline and
change slot id from 0 to 1 after spending time waiting for 200 micro
second.
```
                                         repository
+------------+   +----------+        +-----------------+
| Multi-sink |<--| repo_src |<---+---|     slot 0      |<---+--+
+------------+   +----------+    |   +-----------------+    |  |
                                 +---|     slot 1      |<---+  |
                                     +-----------------+       |
                                                               |
+-----------+   +--------+   +-----------+   +-----------+     |
| Multi-src |-->| pngdec |-->| converter |-->| repo_sink |-----+
+-----------+   +--------+   +-----------+   +-----------+
```
**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>