### PR TITLE
[Filter/Tensorflow] getting rid of memcpy from input tensor @open sesame 02/01 10:21

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -37,6 +37,8 @@
 #include <algorithm>
 #include <vector>
 
+#include <tensorflow/c/c_api.h>
+#include <tensorflow/c/c_api_internal.h>
 #include <tensorflow/cc/ops/const_op.h>
 #include <tensorflow/cc/ops/image_ops.h>
 #include <tensorflow/cc/ops/standard_ops.h>
@@ -92,6 +94,7 @@ private:
 
   tensor_type getTensorTypeFromTF (DataType tfType);
   DataType getTensorTypeToTF (tensor_type tType);
+  TF_DataType getTensorTypeToTF_Capi (tensor_type tType);
   int setTensorProp (GstTensorsInfo * dest, const GstTensorsInfo * src);
   int inputTensorValidation (const std::vector<const NodeDef*> &placeholders);
 };


### PR DESCRIPTION
by creating `tensorflow::Tensor` through c_api, we can change the data pointer of input tensor in person

it resolves #1038

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyoung Joo Ahn <hello.ahnn@gmail.com>