### PR TITLE
[Common] common function to copy tensor info

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -157,6 +157,26 @@ gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2)
 }
 
 /**
+ * @brief Copy tensor info
+ * @note GstTensorInfo::name should be freed with g_free()
+ */
+void
+gst_tensor_info_copy (GstTensorInfo * dest, const GstTensorInfo * src)
+{
+  guint i;
+
+  g_return_if_fail (dest != NULL);
+  g_return_if_fail (src != NULL);
+
+  dest->name = (src->name) ? g_strdup (src->name) : NULL;
+  dest->type = src->type;
+
+  for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
+    dest->dimension[i] = src->dimension[i];
+  }
+}
+
+/**
  * @brief Get data size of single tensor
  * @param info tensor info structure
  * @return data size
@@ -241,6 +261,25 @@ gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2)
 
   /** matched all */
   return TRUE;
+}
+
+/**
+ * @brief Copy tensor info
+ * @note GstTensorInfo::name should be freed with g_free()
+ */
+void
+gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src)
+{
+  guint i;
+
+  g_return_if_fail (dest != NULL);
+  g_return_if_fail (src != NULL);
+
+  dest->num_tensors = src->num_tensors;
+
+  for (i = 0; i < src->num_tensors; i++) {
+    gst_tensor_info_copy (&dest->info[i], &src->info[i]);
+  }
 }
 
 /**

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -249,6 +249,13 @@ extern gboolean
 gst_tensor_info_is_equal (const GstTensorInfo * i1, const GstTensorInfo * i2);
 
 /**
+ * @brief Copy tensor info
+ * @note GstTensorInfo::name should be freed with g_free()
+ */
+extern void
+gst_tensor_info_copy (GstTensorInfo * dest, const GstTensorInfo * src);
+
+/**
  * @brief Get data size of single tensor
  * @param info tensor info structure
  * @return data size
@@ -277,6 +284,13 @@ gst_tensors_info_validate (const GstTensorsInfo * info);
  */
 extern gboolean
 gst_tensors_info_is_equal (const GstTensorsInfo * i1, const GstTensorsInfo * i2);
+
+/**
+ * @brief Copy tensor info
+ * @note GstTensorInfo::name should be freed with g_free()
+ */
+extern void
+gst_tensors_info_copy (GstTensorsInfo * dest, const GstTensorsInfo * src);
 
 /**
  * @brief Parse the string of dimensions

--- a/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
+++ b/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
@@ -42,6 +42,9 @@ pt_init (const GstTensorFilterProperties * prop)
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
   int i;
 
+  assert (data);
+  memset (data, 0, sizeof (pt_data));
+
   data->id = 0;
   data->counter = 0;
   data->info[0].dimension[0] = TSIZE;
@@ -75,17 +78,15 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
-  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 3;
-  for (i = 0; i < info->num_tensors; ++i) {
-    memcpy (info->info[i].dimension, data->info[i].dimension,
-        sizeof (tensor_dim));
-    info->info[i].type = data->info[i].type;
-  }
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info[0];
+  info->info[1] = data->info[1];
+  info->info[2] = data->info[2];
   return 0;
 }
 
@@ -97,17 +98,14 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
-  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 2;
-  for (i = 0; i < info->num_tensors; ++i) {
-    memcpy (info->info[i].dimension, data->info[i].dimension,
-        sizeof (tensor_dim));
-    info->info[i].type = data->info[i].type;
-  }
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info[0];
+  info->info[1] = data->info[1];
   return 0;
 }
 

--- a/nnstreamer_example/custom_example_RNN/dummy_RNN.c
+++ b/nnstreamer_example/custom_example_RNN/dummy_RNN.c
@@ -41,6 +41,9 @@ pt_init (const GstTensorFilterProperties * prop)
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
   int i;
 
+  assert (data);
+  memset (data, 0, sizeof (pt_data));
+
   data->id = 0;
   data->counter = 0;
   data->info[0].dimension[0] = TSIZE;
@@ -73,17 +76,14 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
-  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 2;
-  for (i = 0; i < info->num_tensors; ++i) {
-    memcpy (info->info[i].dimension, data->info[i].dimension,
-        sizeof (tensor_dim));
-    info->info[i].type = data->info[i].type;
-  }
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info[0];
+  info->info[1] = data->info[1];
   return 0;
 }
 
@@ -95,17 +95,13 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
     GstTensorsInfo * info)
 {
   pt_data *data = private_data;
-  int i;
 
   assert (data);
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  for (i = 0; i < info->num_tensors; ++i) {
-    memcpy (info->info[i].dimension, data->info[i].dimension,
-        sizeof (tensor_dim));
-    info->info[i].type = data->info[i].type;
-  }
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info[0];
   return 0;
 }
 

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
@@ -61,6 +61,9 @@ pt_init (const GstTensorFilterProperties * prop)
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
   int i;
 
+  assert (data);
+  memset (data, 0, sizeof (pt_data));
+
   data->id = 0;
   data->info.dimension[0] = D1;
   data->info.dimension[1] = D2;
@@ -96,8 +99,8 @@ get_inputDim (void *private_data, const GstTensorFilterProperties * prop,
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  memcpy (info->info[0].dimension, data->info.dimension, sizeof (tensor_dim));
-  info->info[0].type = data->info.type;
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info;
   return 0;
 }
 
@@ -114,8 +117,8 @@ get_outputDim (void *private_data, const GstTensorFilterProperties * prop,
   assert (NNS_TENSOR_RANK_LIMIT >= 3);
 
   info->num_tensors = 1;
-  memcpy (info->info[0].dimension, data->info.dimension, sizeof (tensor_dim));
-  info->info[0].type = data->info.type;
+  /** @todo use common function to copy tensor info */
+  info->info[0] = data->info;
   return 0;
 }
 

--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -253,6 +253,73 @@ TEST (common_get_tensor_dimension, case4)
 }
 
 /**
+ * @brief Test to copy tensor info.
+ */
+TEST (common_tensor_info, copy_tensor)
+{
+  GstTensorInfo src, dest;
+  gchar *test_name = g_strdup ("test-tensor");
+
+  gst_tensor_info_init (&src);
+  gst_tensor_info_init (&dest);
+
+  src = { test_name, _NNS_FLOAT32, { 1, 2, 3, 4 } };
+  gst_tensor_info_copy (&dest, &src);
+
+  EXPECT_TRUE (dest.name != src.name);
+  EXPECT_TRUE (g_str_equal (dest.name, test_name));
+  EXPECT_EQ (dest.type, src.type);
+  EXPECT_EQ (dest.dimension[0], src.dimension[0]);
+  EXPECT_EQ (dest.dimension[1], src.dimension[1]);
+  EXPECT_EQ (dest.dimension[2], src.dimension[2]);
+  EXPECT_EQ (dest.dimension[3], src.dimension[3]);
+
+  src = { NULL, _NNS_INT32, { 5, 6, 7, 8 } };
+  gst_tensor_info_copy (&dest, &src);
+
+  EXPECT_TRUE (dest.name == NULL);
+  EXPECT_EQ (dest.type, src.type);
+  EXPECT_EQ (dest.dimension[0], src.dimension[0]);
+  EXPECT_EQ (dest.dimension[1], src.dimension[1]);
+  EXPECT_EQ (dest.dimension[2], src.dimension[2]);
+  EXPECT_EQ (dest.dimension[3], src.dimension[3]);
+
+  g_free (test_name);
+}
+
+/**
+ * @brief Test to copy tensor info.
+ */
+TEST (common_tensor_info, copy_tensors)
+{
+  GstTensorsInfo src, dest;
+  gchar *test_name = g_strdup ("test-tensors");
+  guint i;
+
+  gst_tensors_info_init (&src);
+  gst_tensors_info_init (&dest);
+
+  src.num_tensors = 2;
+  src.info[0] = { test_name, _NNS_INT32, { 1, 2, 3, 4 } };
+  src.info[1] = { test_name, _NNS_FLOAT32, { 5, 6, 7, 8 } };
+  gst_tensors_info_copy (&dest, &src);
+
+  EXPECT_EQ (dest.num_tensors, src.num_tensors);
+
+  for (i = 0; i < src.num_tensors; i++) {
+    EXPECT_TRUE (dest.info[i].name != src.info[i].name);
+    EXPECT_TRUE (g_str_equal (dest.info[i].name, test_name));
+    EXPECT_EQ (dest.info[i].type, src.info[i].type);
+    EXPECT_EQ (dest.info[i].dimension[0], src.info[i].dimension[0]);
+    EXPECT_EQ (dest.info[i].dimension[1], src.info[i].dimension[1]);
+    EXPECT_EQ (dest.info[i].dimension[2], src.info[i].dimension[2]);
+    EXPECT_EQ (dest.info[i].dimension[3], src.info[i].dimension[3]);
+  }
+
+  g_free (test_name);
+}
+
+/**
  * @brief Test for dimensions string in tensors info.
  */
 TEST (common_tensors_info_string, dimensions)


### PR DESCRIPTION
add common function to copy tensor info

TODO:
1. seperate util-functions for developer (custom filter and plugins)
2. update custom examples and nnstreamer plugins with these functions

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
