### PR TITLE
Release NNStreamer 0.1.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,22 @@
-nnstreamer (0.1.0-1rc1) stable; urgency=medium
+nnstreamer (0.1.0-2) unstable xenial bionic; urgency=medium
+
+  * 0.1.0 release
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Thu, 24 Jan 2019 15:33:33 +0900
+
+nnstreamer (0.1.0-1rc1) unstable; urgency=medium
 
   * Start of 0.1.0 development
 
  -- MyungJoo Ham <myungjoo.ham@samsung.com>  Mon, 03 Dec 2018 15:32:01 +0900
 
-nnstreamer (0.0.3-2) stable; urgency=medium
+nnstreamer (0.0.3-2) unstable; urgency=medium
 
   * 0.0.3 release
 
  -- MyungJoo Ham <myungjoo.ham@samsung.com>  Mon, 03 Dec 2018 14:45:10 +0900
 
-nnstreamer (0.0.3-1rc1) stable; urgency=medium
+nnstreamer (0.0.3-1rc1) unstable; urgency=medium
 
   * Start of 0.0.3 development
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc, ninja-build, meson (>=0.40), libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
+Build-Depends: gcc (>=5), ninja-build, meson (>=0.40), libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  libgtest-dev,
  debhelper (>=9),
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -6,9 +6,7 @@
 Name:		nnstreamer
 Summary:	gstremaer plugins for neural networks
 Version:	0.1.0
-Release:	1rc1
-# From 0.0.3, don't put letters as the first character of release. Use "1.rc1" instead of "rc1".
-# We are using "stable-1" because we've been using "rc#" for 0.0.2
+Release:	2
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1
@@ -189,6 +187,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %endif
 
 %changelog
+* Thu Jan 24 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 0.1.0
+
 * Mon Dec 03 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.0.3
 


### PR DESCRIPTION
- Build system migration cmake --> meson
- Support Tensorflow without input/output tensor memcpy
- other/tensor stream format updated
    - From 0.1.0, a single property, "dimension", describes the whole dimension instead of "dim1", "dim2", ...
    - Objective 1: in the future, we may support tensors with more than 4 dimensions without updating the protocol.
    - Objective 2: it was just too ugly.
- Example applications migrated to other git repo to make this repo ready for upstreaming in the fugure and to ensure buildability for third party developers.
- Support run-time attaching subplugins (filter and decoder)
- Support "ini" and envvar configurations for subplugin locations
- Dynamic external recurrences
- Subplugin API sets (draft. do not expect backward compatibility)
- Bug fixes (memory leaks, incorrect logs, type checks, ...)

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

