### PR TITLE
[Decoder/Boundingbox] make decoder possible to handle tensorflow ssd model

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -455,7 +455,7 @@ gst_tensor_filter_init (GstTensorFilter * self)
  * @brief deallocate the name of each GstTensorInfo.
  * @param The GstTensorsInfo object
  */
-inline void
+static void
 gst_tensor_filter_deallocate_tensor_name (GstTensorsInfo * info)
 {
   guint i;


### PR DESCRIPTION
make it available to process the output tensors of tensorflow ssd model.
the example script using `tensordec_boundingbox` is included at [this pr](https://github.com/nnsuite/nnstreamer-example/pull/8).

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Hyoung Joo Ahn <hello.ahnn@gmail.com>