### PR TITLE
[Filter/subplugin] Follow the subplugin naming rule.

### DIFF
--- a/gst/nnstreamer/tensor_filter/meson.build
+++ b/gst/nnstreamer/tensor_filter/meson.build
@@ -6,7 +6,7 @@ tensor_filter_sources = [
 if have_tensorflow
   tensor_filter_sources += ['tensor_filter_tensorflow.c']
 
-  tensor_filter_tfcore_lib_shared = shared_library('tensor_filter_tfcore',
+  tensor_filter_tfcore_lib_shared = shared_library('tensor_filter_tensorflow',
     ['tensor_filter_tensorflow_core.cc'],
     cpp_args: ['-Wno-sign-compare'],
     dependencies: [tf_dep, protobuf_dep, glib_dep, gst_dep],
@@ -15,7 +15,7 @@ if have_tensorflow
     install_dir: subplugins_install_dir
   )
 
-  tensor_filter_tfcore_lib_static = static_library('tensor_filter_tfcore',
+  tensor_filter_tfcore_lib_static = static_library('tensor_filter_tensorflow',
     ['tensor_filter_tensorflow_core.cc'],
     cpp_args: ['-Wno-sign-compare'],
     dependencies: [tf_dep, protobuf_dep, glib_dep, gst_dep],
@@ -36,7 +36,7 @@ endif
 if have_tensorflow_lite
   tensor_filter_sources += ['tensor_filter_tensorflow_lite.c']
 
-  tensor_filter_tflitecore_lib_shared = shared_library('tensor_filter_tflitecore',
+  tensor_filter_tflitecore_lib_shared = shared_library('tensor_filter_tensorflow-lite',
     ['tensor_filter_tensorflow_lite_core.cc'],
     cpp_args: ['-Wno-sign-compare'],
     dependencies: [tflite_dep, thread_dep, libdl_dep, glib_dep, gst_dep],
@@ -45,7 +45,7 @@ if have_tensorflow_lite
     install_dir: subplugins_install_dir
   )
 
-  tensor_filter_tflitecore_lib_static = static_library('tensor_filter_tflitecore',
+  tensor_filter_tflitecore_lib_static = static_library('tensor_filter_tensorflow-lite',
     ['tensor_filter_tensorflow_lite_core.cc'],
     cpp_args: ['-Wno-sign-compare'],
     dependencies: [tflite_dep, thread_dep, libdl_dep, glib_dep, gst_dep],

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -160,10 +160,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %license LICENSE
-%{_libdir}/libtensor_filter_tflitecore.so
-%ifarch x86_64 aarch64
-%{_libdir}/libtensor_filter_tfcore.so
-%endif
+%{_libdir}/libtensor_filter_*.so
 %{gstlibdir}/*.so
 %{_libdir}/libnnstreamer_plugin_api.so
 
@@ -182,10 +179,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %defattr(-,root,root,-)
 %license LICENSE
 %{_libdir}/*.so
-%exclude %{_libdir}/libtensor_filter_tflitecore.so
-%ifarch x86_64 aarch64
-%exclude %{_libdir}/libtensor_filter_tfcore.so
-%endif
+%exclude %{_libdir}/libtensor_filter_*.so
 
 %changelog
 * Thu Jan 24 2019 MyungJoo Ham <myungjoo.ham@samsung.com>


### PR DESCRIPTION
Subplugin name rule (described at gst/nnstreamer/nnstreamer_subplugin.h)
states:

The filename should be subplugin_prefixes[type]${name}.so

The subplugins should be follow the rule to be recognized by runtime
plug-and-play mechanism of nnstreamer_subplugin.h

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped


This is passing the test only because libnnstreamer.so includes libtensor_filter_*.so in it.
In the later commits, I will remove such inclusion and make them independent plugins.
We will need to configure plugin-search paths appropriately for unit-testing as well as installed systems.