### PR TITLE
[Subplugin] Do not dlsym if it's already probed.

### DIFF
--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -41,6 +41,50 @@ static GHashTable *subplugins[NNS_SUBPLUGIN_END] = { 0 };
 
 G_LOCK_DEFINE_STATIC (splock);
 
+
+typedef struct
+{
+  char *name;
+  const void *data;
+} holdplugins;
+static GHashTable *held_subplugins[NNS_SUBPLUGIN_END] = { 0 };
+
+/**
+ * @brief Private function for g_hash_table data destructor, GDestroyNotify
+ */
+static void
+_heldsp_destroy (gpointer _data)
+{
+  holdplugins *data = _data;
+  g_free (data->name);
+  /* do not free data here */
+  g_free (data);
+}
+
+/**
+ * @brief API to notify subplugin-manager that this subplugin is handled already.
+ */
+void
+hold_register_subplugin (subpluginType type, const char *name, void *data)
+{
+  if (held_subplugins[type] == NULL)
+    held_subplugins[type] =
+        g_hash_table_new_full (g_str_hash, g_str_equal, g_free,
+        _heldsp_destroy);
+  g_hash_table_insert (held_subplugins[type], g_strdup (name), data);
+}
+
+/**
+ * @brief Check if this subplugin is held by hold_register_subplugin()
+ */
+static const void *
+check_held_subplugin (subpluginType type, const char *name)
+{
+  if (held_subplugins[type] == NULL)
+    return NULL;
+  return g_hash_table_lookup (held_subplugins[type], name);
+}
+
 /** @brief Private function for g_hash_table data destructor, GDestroyNotify */
 static void
 _spdata_destroy (gpointer _data)
@@ -60,6 +104,8 @@ get_subplugin (subpluginType type, const char *name)
   subpluginData *data;
   void *handle;
 
+  nnsconf_loadconf (FALSE);
+
   G_LOCK (splock);
 
   if (subplugins[type] == NULL)
@@ -74,6 +120,7 @@ get_subplugin (subpluginType type, const char *name)
     /* Search and register if found with the conf */
     const gchar *fullpath = nnsconf_get_fullpath (name, type);
     char *dlsym_error;
+    const void *held;
     nnstreamer_subplugin_data *nsdata;
 
     if (fullpath == NULL)
@@ -83,6 +130,13 @@ get_subplugin (subpluginType type, const char *name)
     if (NULL == handle) {
       GST_ERROR ("Cannot dlopen %s (%s).", name, fullpath);
       goto error;
+    }
+
+    /* If a plugin calls "probe()" at this step, stop here and return "OK" */
+    held = check_held_subplugin (type, name);
+    if (held) {
+      G_UNLOCK (splock);
+      return held;
     }
 
     nsdata = (nnstreamer_subplugin_data *)

--- a/gst/nnstreamer/nnstreamer_subplugin.h
+++ b/gst/nnstreamer/nnstreamer_subplugin.h
@@ -87,4 +87,9 @@ register_subplugin (subpluginType type, const char *name, const void *data);
 extern gboolean
 unregister_subplugin (subpluginType type, const char *name);
 
+/**
+ * @brief Call this at subplugin probe to avoid duplicated registration
+ */
+extern void hold_register_subplugin (subpluginType type, const char *name, void *data);
+
 #endif /* __GST_NNSTREAMER_SUBPLUGIN_H__ */

--- a/gst/nnstreamer/tensor_decoder/tensordec-plugins.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec-plugins.c
@@ -82,6 +82,8 @@ tensordec_probe (TensorDecDef * decoder)
   GST_INFO ("A new subplugin, \"%s\" is registered for tensor_decoder.\n",
       decoder->modename);
 
+  /** @todo @buf unregister at exit */
+  hold_register_subplugin (NNS_SUBPLUGIN_DECODER, decoder->modename, decoder);
   return TRUE;
 }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -158,6 +158,10 @@ tensor_filter_probe (GstTensorFilterFramework * tfsp)
 
   GST_INFO ("A new sub-plugin, \"%s\" is registered for tensor_filter.\n",
       tfsp->name);
+
+  /** @todo @bug unregister at exit */
+  hold_register_subplugin (NNS_SUBPLUGIN_FILTER, tfsp->name, tfsp);
+
   return TRUE;
 }
 


### PR DESCRIPTION
With dlopen, consturctor function is loaded, which
may call subplugin-probe.

If it has called subplugin-probe, registering the
subplugin to an element (filter/decoder) specific
internal list, we do not need to register it with
nnstreamer_subplugin structure.

- Add an internal API, "hold_register_subplugin", that
notified nnstremer_subplugin that it has probed already.
- Call "hold_register_subplugin" at probe function.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

