### PR TITLE
[DIST] Install path changes, add symlink

### DIFF
--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -2,4 +2,3 @@
 /usr/lib/*/pkgconfig/*.pc
 /usr/lib/*/libnnstreamer.a
 /usr/lib/*/libnnstreamer_filter*.a
-/usr/lib/*/libnnstreamer_plugin_api.a

--- a/debian/nnstreamer.install
+++ b/debian/nnstreamer.install
@@ -1,4 +1,3 @@
 /usr/lib/nnstreamer/filters/libnnstreamer_filter_*.so
 /usr/lib/*/gstreamer-1.0/*.so
-/usr/lib/*/libnnstreamer_plugin_api.so
 /etc/nnstreamer.ini

--- a/debian/rules
+++ b/debian/rules
@@ -39,6 +39,8 @@ override_dh_auto_build:
 override_dh_auto_test:
 	export LD_LIBRARY_PATH=${ROOT_DIR}/build/gst/nnstreamer:${ROOT_DIR}/build/gst/nnstreamer/tensor_filter
 	export GST_PLUGIN_PATH=${ROOT_DIR}/build
+	export NNSTREAMER_FILTERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_filter
+	export NNSTREAMER_DECODERS=${ROOT_DIR}/build/gst/nnstreamer/tensor_decoder
 	ls -l
 	cd build && ./tests/unittest_common && cd ..
 	cd build && ./tests/unittest_sink --gst-plugin-path=. && cd ..
@@ -50,4 +52,5 @@ override_dh_auto_install:
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
+	ln -s /usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/
 # Add --fail-missing option after adding *.install files for all subpackages.

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -15,14 +15,6 @@ nnstreamer_base_deps = [
   thread_dep
 ]
 
-# Dependencies
-nnstreamer_plugin_api_base_deps = [
-  glib_dep,
-  gst_dep,
-  gst_video_dep,
-  gst_audio_dep,
-]
-
 if have_orcc
   nnstreamer_base_deps += [orc_dep]
 endif
@@ -109,22 +101,6 @@ nnstreamer_lib = nnstreamer_shared
 if get_option('default_library') == 'static'
   nnstreamer_lib = nnstreamer_static
 endif
-
-nnstreamer_plugin_api_shared = shared_library('nnstreamer_plugin_api',
-  nnst_plugin_api_sources,
-  dependencies: [nnstreamer_plugin_api_base_deps],
-  include_directories: nnstreamer_inc,
-  install: true,
-  install_dir: libs_install_dir
-)
-
-nnstreamer_plugin_api_static = static_library('nnstreamer_plugin_api',
-  nnst_plugin_api_sources,
-  dependencies: [nnstreamer_plugin_api_base_deps],
-  include_directories: nnstreamer_inc,
-  install: true,
-  install_dir: libs_install_dir
-)
 
 nnstreamer_dep = declare_dependency(link_with: nnstreamer_lib,
   dependencies: nnstreamer_base_deps,

--- a/nnstreamer.pc.in
+++ b/nnstreamer.pc.in
@@ -6,8 +6,8 @@ libdir=@LIB_INSTALL_DIR@
 includedir=@INCLUDE_INSTALL_DIR@
 
 Name: nnstreamer
-Description: Custom Plugin Dev Kit of Neural Network Suite for GStreamer
+Description: Dev Kit of Neural Network Suite (NNStreamer) for GStreamer
 Version: @VERSION@
 Requires:
-Libs: -L${libdir} -lnnstreamer_plugin_api
+Libs: -L${libdir} -lnnstreamer
 Cflags: -I${includedir}/nnstreamer

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -154,8 +154,16 @@ mkdir -p %{buildroot}%{_datadir}/nnstreamer/unittest/
 cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %endif
 
-%post -p /sbin/ldconfig
+%post
+pushd %{_libdir}
+ln -s %{gstlibdir}/libnnstreamer.so libnnstreamer.so
+popd
+/sbin/ldconfig
+
 %postun -p /sbin/ldconfig
+pushd %{_libdir}
+rm libnnstreamer.so
+popd
 
 %files
 %manifest nnstreamer.manifest
@@ -163,7 +171,6 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %license LICENSE
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_*.so
 %{gstlibdir}/*.so
-%{_libdir}/libnnstreamer_plugin_api.so
 %{_sysconfdir}/nnstreamer.ini
 
 %files devel


### PR DESCRIPTION
    
1. Add symlink to libnnstreamer.so at _libdir
2. Install tensor-filter subplugins to the tensor-filter
configuration directory, not _libdir.
3. Do not generate api library. We can use libnnstreamer.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
