### PR TITLE
[Conf] Bugfix: if no path is given, use current dir.

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -173,8 +173,13 @@ _fill_in_vstr (gchar *** fullpath_vstr, gchar *** basename_vstr,
   counterF = 0;
   counterB = 0;
   for (i = 0; i < CONF_SOURCES; i++) {
-    lstF = _get_fullpath_filenames (searchpath[i], lstF, &counterF);
-    lstB = _get_basenames (searchpath[i], lstB, &counterB);
+    if (searchpath[i]) {
+      lstF = _get_fullpath_filenames (searchpath[i], lstF, &counterF);
+      lstB = _get_basenames (searchpath[i], lstB, &counterB);
+    } else {
+      lstF = _get_fullpath_filenames ("./", lstF, &counterF);
+      lstB = _get_basenames ("./", lstB, &counterB);
+    }
   }
   g_assert (counterF == counterB);
 


### PR DESCRIPTION
If path is NULL, don't give it to glib path library.
Use "./" instead.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
