### PR TITLE
[API] Filter/Decoder subplugin API headers

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -26,7 +26,7 @@
  *
  */
 
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
 #include "tensor_filter_tensorflow_core.h"
 #include <glib.h>
 #include <string.h>

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -26,7 +26,7 @@
  *
  */
 
-#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
 #include "tensor_filter_tensorflow_lite_core.h"
 #include <glib.h>
 #include <string.h>

--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -40,6 +40,8 @@ endforeach
 nnst_common_headers = [
   'tensor_typedef.h',
   'tensor_filter_custom.h',
+  'nnstreamer_plugin_api_filter.h',
+  'nnstreamer_plugin_api_decoder.h',
   'nnstreamer_plugin_api.h'
 ]
 

--- a/gst/nnstreamer/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api.h
@@ -17,7 +17,7 @@
 /**
  * @file  nnstreamer_plugin_api.h
  * @date  24 Jan 2019
- * @brief Header file that contains typedefed data types and APIs for NNStreamer plug-ins
+ * @brief Optional/Addtional NNStreamer APIs for sub-plugin writers. (Need Glib)
  * @see https://github.com/nnsuite/nnstreamer
  * @author  MyungJoo Ham <myungjoo.ham@samsung.com> and Wook Song <wook16.song@samsung.com>
  * @bug No known bugs except for NYI items
@@ -193,21 +193,6 @@ extern size_t get_tensor_element_count (const tensor_dim dim);
  * @param typestr The string type name, supposed to be one of tensor_element_typename[]
  */
 extern tensor_type get_tensor_type (const gchar * typestr);
-
-
-
-/* extern functions for subplugin management, exist in tensor_filter.c */
-/**
- * @brief Filter subplugin should call this to register itself
- * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered
- * @return TRUE if registered. FALSE is failed or duplicated.
- */
-extern int tensor_filter_probe (GstTensorFilterFramework *tfsp);
-/**
- * @brief filter sub-plugin may call this to unregister itself
- * @param[in] name the name of filter sub-plugin
- */
-extern void tensor_filter_exit (const char *name);
 
 G_END_DECLS
 #endif /* __NNS_PLUGIN_API_H__ */

--- a/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
@@ -1,0 +1,87 @@
+/**
+ * NNStreamer API for Tensor_Decoder Sub-Plugins
+ * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file  nnstreamer_plugin_api_filters.h
+ * @date  30 Jan 2019
+ * @brief Mandatory APIs for NNStreamer Decoder sub-plugins (Need Gst Devel)
+ * @see https://github.com/nnsuite/nnstreamer
+ * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __NNS_PLUGIN_API_DECODER_H__
+#define __NNS_PLUGIN_API_DECODER_H__
+
+#include "tensor_typedef.h"
+#include <gst/gst.h>
+
+/**
+ * @brief Tensor Decoder Output type.
+ */
+typedef enum
+{
+  OUTPUT_VIDEO,
+  OUTPUT_AUDIO,
+  OUTPUT_TEXT,
+  OUTPUT_UNKNOWN
+} GstDecMediaType;
+
+/**
+ * @brief Decoder definitions for different semantics of tensors
+ *        This allows developers to create their own decoders.
+ */
+typedef struct _TensorDecDef
+{
+  char *modename;
+      /**< Unique decoder name. GST users choose decoders with mode="modename". */
+  GstDecMediaType type;
+      /**< Output media type. VIDEO/AUDIO/TEXT are supported */
+  int (*init) (void **private_data);
+      /**< Object initialization for the decoder */
+  void (*exit) (void **private_data);
+      /**< Object destruction for the decoder */
+  int (*setOption) (void **private_data, int opNum, const char *param);
+      /**< Process with the given options. It can be called repeatedly */
+  GstCaps *(*getOutCaps) (void **private_data, const GstTensorsConfig *config);
+      /**< The caller should unref the returned GstCaps
+        * Current implementation supports single-tensor only.
+        * @todo WIP: support multi-tensor for input!!!
+        */
+  GstFlowReturn (*decode) (void **private_data, const GstTensorsConfig *config,
+      const GstTensorMemory *input, GstBuffer *outbuf);
+      /**< outbuf must be allocated but empty (gst_buffer_get_size (outbuf) == 0).
+        * Note that we support single-tensor (other/tensor) only!
+        * @todo WIP: support multi-tensor for input!!!
+        */
+  size_t (*getTransformSize) (void **private_data, const GstTensorsConfig *config,
+      GstCaps *caps, size_t size, GstCaps *othercaps,
+      GstPadDirection direction);
+      /**< EXPERIMENTAL! @todo We are not ready to use this. This should be NULL or return 0 */
+} TensorDecDef;
+
+/* extern functions for subplugin management, exist in tensor_decoder.c */
+/**
+ * @brief decoder's subplugins should call this function to register
+ * @param[in] decoder The decoder subplugin instance
+ */
+extern gboolean tensordec_probe (TensorDecDef * decoder);
+/**
+ * @brief decoder's subplugin may call this to unregister
+ * @param[in] name the name of decoder (modename)
+ */
+extern void tensordec_exit (const gchar * name);
+
+
+#endif /* __NNS_PLUGIN_API_DECODER_H__ */

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -1,0 +1,42 @@
+/**
+ * NNStreamer API for Tensor_Filter Sub-Plugins
+ * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file  nnstreamer_plugin_api_filters.h
+ * @date  30 Jan 2019
+ * @brief Mandatory APIs for NNStreamer Filter sub-plugins (No External Dependencies)
+ * @see https://github.com/nnsuite/nnstreamer
+ * @author  MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+#ifndef __NNS_PLUGIN_API_FILTER_H__
+#define __NNS_PLUGIN_API_FILTER_H__
+
+#include "tensor_typedef.h"
+
+/* extern functions for subplugin management, exist in tensor_filter.c */
+/**
+ * @brief Filter subplugin should call this to register itself
+ * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered
+ * @return TRUE if registered. FALSE is failed or duplicated.
+ */
+extern int tensor_filter_probe (GstTensorFilterFramework *tfsp);
+/**
+ * @brief filter sub-plugin may call this to unregister itself
+ * @param[in] name the name of filter sub-plugin
+ */
+extern void tensor_filter_exit (const char *name);
+
+#endif /* __NNS_PLUGIN_API_FILTER_H__ */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -26,8 +26,9 @@
  *
  */
 
-#include "tensor_filter.h"
+#include <gst/gst.h>
 #include "tensor_filter_custom.h"
+#include <nnstreamer_plugin_api_filter.h>
 #include <glib.h>
 #include <dlfcn.h>
 


### PR DESCRIPTION
    
Before:
- nnstreamer_plugin_api.h had mandatory filter APIs and optional APIs for filter/decoder, depend on glib, not supporting decoder mandatory APIs.
    
After:
- nnstreamer_plugin_api.h has optional APIs only / depend on glib
- nnstreamer_plugin_api_filter.h has mandatory Filter APIs / no dependencies
- nnstremaer_plugin_api_decoder.h has mandatory Decoder APIs / depend on gst
    
With this, we can completely cut the dependencies on glib for nnstreamer sub-plugin writers.
Besides, "ext-nizing" decoders requires this as well.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped


Wait for #1090 #1091 #1098 #1099

Fixes #761, #786 