### PR TITLE
[Conf] Bugfix of array out of bound

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -185,6 +185,9 @@ _fill_in_vstr (gchar *** fullpath_vstr, gchar *** basename_vstr,
   *fullpath_vstr = g_malloc_n (counterF + 1, sizeof (gchar *));
   *basename_vstr = g_malloc_n (counterB + 1, sizeof (gchar *));
 
+  (*fullpath_vstr)[counterF] = NULL;
+  (*basename_vstr)[counterB] = NULL;
+
   vstrF.vstr = *fullpath_vstr;
   vstrB.vstr = *basename_vstr;
   vstrF.size = counterF;


### PR DESCRIPTION
The last element of vstr should be NULL.
Set NULL for such elements

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
