### PR TITLE
[Meson] dependency for generated files

### DIFF
--- a/gst/nnstreamer/meson.build
+++ b/gst/nnstreamer/meson.build
@@ -1,7 +1,6 @@
 nnstreamer_inc = include_directories('.')
 nnstreamer_sources = []
 nnstreamer_headers = []
-nnstreamer_generated = []
 
 # Dependencies
 nnstreamer_base_deps = [
@@ -29,7 +28,11 @@ if have_orcc
 endif
 
 # For extra dependencies (subplugins, filters)
+# Remove this after ext subplugins migration
 nnstreamer_extra_deps = []
+
+# Internal dependencies
+nnstreamer_internal_deps = []
 
 # Add nnstreamer registerer and common sources
 nnst_common_sources = [
@@ -85,9 +88,6 @@ foreach p : nnst_plugins
   subdir(p)
 endforeach
 
-# Add generated
-nnstreamer_sources += nnstreamer_generated
-
 # Build libraries ("both_libraries" are supported from 0.46.)
 nnstreamer_shared = shared_library('nnstreamer',
   nnstreamer_sources,
@@ -102,7 +102,7 @@ nnstreamer_static = static_library('nnstreamer',
   dependencies: [nnstreamer_base_deps, nnstreamer_extra_deps],
   include_directories: nnstreamer_inc,
   install: true,
-  install_dir: libs_install_dir
+  install_dir: nnstreamer_libdir
 )
 
 nnstreamer_lib = nnstreamer_shared
@@ -127,7 +127,6 @@ nnstreamer_plugin_api_static = static_library('nnstreamer_plugin_api',
 )
 
 nnstreamer_dep = declare_dependency(link_with: nnstreamer_lib,
-  sources: nnstreamer_generated,
   dependencies: nnstreamer_base_deps,
   include_directories: nnstreamer_inc)
 

--- a/gst/nnstreamer/tensor_transform/meson.build
+++ b/gst/nnstreamer/tensor_transform/meson.build
@@ -15,7 +15,8 @@ if have_orcc
     output: orcsrc + '.c',
     command: orcc_args + ['--implementation', '-o', '@OUTPUT@', '@INPUT@'])
 
-  nnstreamer_generated += [orc_c, orc_h]
+  nnstreamer_sources += [orc_c, orc_h]
+  nnstreamer_internal_deps += declare_dependency(sources: orc_h)
 endif
 
 foreach s : tensor_transform_sources

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,10 +42,19 @@ if libpng_dep.found()
   )
 endif
 
+# ssat repo_dynamic
+executable('unittest_repo',
+  join_paths('nnstreamer_repo_dynamicity', 'tensor_repo_dynamic_test.c'),
+  dependencies: [nnstreamer_dep, gst_dep, glib_dep],
+  install: false
+)
+
+# gtest
 gtest_dep = dependency('gtest', required: false)
 if gtest_dep.found()
   nnstreamer_unittest_deps = [
     nnstreamer_dep,
+    nnstreamer_internal_deps,
     gst_app_dep,
     gst_check_dep,
     gtest_dep
@@ -78,10 +87,3 @@ if gtest_dep.found()
 
   test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
 endif
-
-# unittest_repo_dynamic
-unittest_repo = executable('unittest_repo',
-join_paths('nnstreamer_repo_dynamicity', 'tensor_repo_dynamic_test.c'),
-dependencies: [nnstreamer_dep, gst_dep, glib_dep],
-install: false
-)


### PR DESCRIPTION
Remove orc-generated files in nnstreamer plugin dep and clean up meson script.

If declares dependency with orc-gen files, it will compile generated file with this dep.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
