### PR TITLE
[Filter] common functions in filter-subplugins

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -68,11 +68,6 @@ public:
   int init(const GstTensorFilterProperties * prop);
   int loadModel ();
   const char* getModelPath();
-  int setInputTensorProp ();
-  int setOutputTensorProp ();
-
-  int getInputTensorSize ();
-  int getOutputTensorSize ();
   int getInputTensorDim (GstTensorsInfo * info);
   int getOutputTensorDim (GstTensorsInfo * info);
   int run (const GstTensorMemory * input, GstTensorMemory * output);
@@ -93,7 +88,6 @@ private:
 
   tensor_type getTensorTypeFromTF (DataType tfType);
   DataType getTensorTypeToTF (tensor_type tType);
-  int setTensorProp (GstTensorsInfo * dest, const GstTensorsInfo * src);
   int inputTensorValidation (const std::vector <const NodeDef*> &placeholders);
 };
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -63,8 +63,6 @@ private:
   std::unique_ptr <tflite::Interpreter> interpreter;
   std::unique_ptr <tflite::FlatBufferModel> model;
 
-  int getInputTensorSize ();
-  int getOutputTensorSize ();
   tensor_type getTensorType (TfLiteType tfType);
   int getTensorDim (int tensor_idx, tensor_dim dim);
 };

--- a/gst/nnstreamer/tensor_filter/tensor_filter.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.h
@@ -64,8 +64,8 @@ struct _GstTensorFilter
   GstTensorFilterProperties prop; /**< NNFW plugin's properties */
   const GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
 
-  /** internal properties for tensor-filter */
-  int silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
+  /* internal properties for tensor-filter */
+  gboolean silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
   gboolean configured; /**< True if already successfully configured tensor metadata */
   GstTensorsConfig in_config; /**< input tensor info */
   GstTensorsConfig out_config; /**< output tensor info */


### PR DESCRIPTION
use common functions to load tf/tf-lite model

1. remove unnecessary functions in sub-plugins (tf/tf-lite)
2. copy and free tensor info to load tf model during the caps negotiation
3. print additional logs when loading model info

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
