### PR TITLE
[Wait for other PR]  [Transform] Change reaction for the invalid option string @open sesame 2/15 13:45

### DIFF
--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -192,7 +192,8 @@ gst_tensor_transform_mode_get_type (void)
       {GTT_TRANSPOSE, "Mode for transposing shape of tensor, "
             "option=D1\':D2\':D3\':D4 (fixed to 3)",
           "transpose"},
-      {GTT_STAND, "Mode for statistical standardization of tensor",
+      {GTT_STAND, "Mode for statistical standardization of tensor, "
+            "option=default",
           "stand"},
       {GTT_UNKNOWN, "Unknown or not-implemented-yet mode",
           "unknown"},
@@ -891,7 +892,13 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
     {
       filter->data_stand.mode =
           gst_tensor_transform_get_stand_mode (filter->option);
-      g_assert (filter->data_stand.mode != STAND_END);
+      if (filter->data_stand.mode == STAND_END) {
+        g_critical ("%s: stand: "
+            "\'%s\' is not valid option string: "
+            "it should be \'default\', currently the only supported mode.\n",
+            gst_object_get_name ((GstObject *) filter), filter->option);
+        break;
+      }
       filter->loaded = TRUE;
       break;
     }

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -734,10 +734,9 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_DIMCHG_OPTION, filter->option, 0, 0)) {
-        g_critical ("%s: dimchg: "
-            "\'%s\' is not valid option string: "
-            "it should be in the form of IDX_DIM_FROM:IDX_DIM_TO: "
-            "with a regex, " REGEX_DIMCHG_OPTION "\n",
+        g_critical
+            ("%s: dimchg: \'%s\' is not valid option string: it should be in the form of IDX_DIM_FROM:IDX_DIM_TO: with a regex, "
+            REGEX_DIMCHG_OPTION "\n",
             gst_object_get_name ((GstObject *) filter), filter->option);
         break;
       }
@@ -756,9 +755,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
         filter->data_typecast.to = gst_tensor_get_type (filter->option);
         filter->loaded = TRUE;
       } else {
-        g_critical ("%s: typecast: "
-            "\'%s\' is not valid data type for tensor: "
-            "data type of tensor should be one of %s\n",
+        g_critical
+            ("%s: typecast: \'%s\' is not valid data type for tensor: data type of tensor should be one of %s\n",
             gst_object_get_name ((GstObject *) filter),
             filter->option, GST_TENSOR_TYPE_ALL);
       }
@@ -797,9 +795,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
               1, 0, NULL, NULL)) {
         str_option = g_regex_replace (regex_option_tc, filter->option, -1, 1,
             "", 0, 0);
-        g_critical ("%s: arithmetic: [typecast:TYPE,] should be located "
-            "at the first to prevent memory re-allocation: "
-            "typecast(s) in the middle of \'%s\' will be ignored\n",
+        g_critical
+            ("%s: arithmetic: [typecast:TYPE,] should be located at the first to prevent memory re-allocation: typecast(s) in the middle of \'%s\' will be ignored\n",
             gst_object_get_name ((GstObject *) filter), filter->option);
       } else {
         str_option = g_strdup (filter->option);
@@ -807,9 +804,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       g_regex_unref (regex_option_tc);
 
       if (!g_regex_match_simple (REGEX_ARITH_OPTION, str_option, 0, 0)) {
-        g_critical ("%s: arithmetic: "
-            "\'%s\' is not valid option string: "
-            "it should be in the form of [typecast:TYPE,]add|mul|div:NUMBER..., ...\n",
+        g_critical
+            ("%s: arithmetic: \'%s\' is not valid option string: it should be in the form of [typecast:TYPE,]add|mul|div:NUMBER..., ...\n",
             gst_object_get_name ((GstObject *) filter), str_option);
         g_free (str_option);
         break;
@@ -892,10 +888,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_TRANSPOSE_OPTION, filter->option, 0, 0)) {
-        g_critical ("%s: transpose: "
-            "\'%s\' is not valid option string: "
-            "it should be in the form of NEW_IDX_DIM0:NEW_IDX_DIM1:NEW_IDX_DIM2:3 "
-            "(note that the index of the last dim is alwayes fixed to 3)\n",
+        g_critical
+            ("%s: transpose: \'%s\' is not valid option string: it should be in the form of NEW_IDX_DIM0:NEW_IDX_DIM1:NEW_IDX_DIM2:3 (note that the index of the last dim is alwayes fixed to 3)\n",
             gst_object_get_name ((GstObject *) filter), filter->option);
         break;
       }
@@ -915,9 +909,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       filter->data_stand.mode =
           gst_tensor_transform_get_stand_mode (filter->option);
       if (filter->data_stand.mode == STAND_END) {
-        g_critical ("%s: stand: "
-            "\'%s\' is not valid option string: "
-            "it should be \'default\', currently the only supported mode.\n",
+        g_critical
+            ("%s: stand: \'%s\' is not valid option string: it should be \'default\', currently the only supported mode.\n",
             gst_object_get_name ((GstObject *) filter), filter->option);
         break;
       }

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -862,7 +862,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
     }
     case GTT_TRANSPOSE:
     {
-      int a, i;
+      int i;
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_TRANSPOSE_OPTION, filter->option, 0, 0)) {
@@ -876,11 +876,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
 
       strv = g_strsplit (filter->option, ":", NNS_TENSOR_RANK_LIMIT);
       for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
-        if (strv[i] != NULL)
-          a = g_ascii_strtoull (strv[i], NULL, 10);
-        else
-          a = 0;
-        filter->data_transpose.trans_order[i] = a;
+        filter->data_transpose.trans_order[i] =
+            g_ascii_strtoull (strv[i], NULL, 10);
       }
 
       filter->loaded = TRUE;
@@ -1266,8 +1263,6 @@ gst_tensor_transform_transpose (GstTensorTransform * filter,
   indexI = filter->data_transpose.trans_order[0];
   indexJ = filter->data_transpose.trans_order[1];
   SL = fromDim[3], SI = fromDim[0], SJ = fromDim[1], SK = fromDim[2];
-
-  g_assert (filter->data_transpose.trans_order[3] == 3);
 
   switch (indexI) {
     case 0:

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -830,23 +830,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
           switch (op_s->op) {
             case GTT_OP_TYPECAST:
               if (num_op > 1 && str_op[1]) {
-                if (i > 0) {
-                  GST_WARNING_OBJECT (filter,
-                      "To prevent memory re-allocation, tensor-transform limits the typecast during the sequence. "
-                      "Please set the typecast in the first.");
-                  op_s->op = GTT_OP_UNKNOWN;
-                  break;
-                }
-
                 op_s->value.type = gst_tensor_get_type (str_op[1]);
-
-                if (op_s->value.type == _NNS_END) {
-                  GST_WARNING_OBJECT (filter, "Unknown tensor type %s",
-                      str_op[1]);
-                  op_s->op = GTT_OP_UNKNOWN;
-                } else {
-                  filter->data_arithmetic.out_type = op_s->value.type;
-                }
+                filter->data_arithmetic.out_type = op_s->value.type;
               } else {
                 GST_WARNING_OBJECT (filter, "Invalid option for typecast %s",
                     str_operators[i]);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -726,7 +726,6 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
   switch (filter->mode) {
     case GTT_DIMCHG:
     {
-      int a, b;
       gchar **strv = NULL;
 
       if (!g_regex_match_simple (REGEX_DIMCHG_OPTION, filter->option, 0, 0)) {
@@ -740,18 +739,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
 
       strv = g_strsplit (filter->option, ":", 2);
 
-      if (strv[0] != NULL)
-        a = g_ascii_strtoull (strv[0], NULL, 10);
-      else
-        a = 0;
-
-      if (strv[1] != NULL)
-        b = g_ascii_strtoull (strv[1], NULL, 10);
-      else
-        b = 0;
-
-      filter->data_dimchg.from = a;
-      filter->data_dimchg.to = b;
+      filter->data_dimchg.from = g_ascii_strtoull (strv[0], NULL, 10);
+      filter->data_dimchg.to = g_ascii_strtoull (strv[1], NULL, 10);
       filter->loaded = TRUE;
       g_strfreev (strv);
       break;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.h
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.h
@@ -53,15 +53,15 @@ G_BEGIN_DECLS
 typedef struct _GstTensorTransform GstTensorTransform;
 typedef struct _GstTensorTransformClass GstTensorTransformClass;
 
-typedef enum
+typedef enum _tensor_transform_mode
 {
-  GTT_DIMCHG = 0,               /* Dimension Change. "dimchg" */
-  GTT_TYPECAST = 1,             /* Type change. "typecast" */
-  GTT_ARITHMETIC = 2,           /* Arithmetic. "arithmetic" */
-  GTT_TRANSPOSE = 3,            /* Transpose. "transpose" */
-  GTT_STAND = 4,                /* Standardization. "stand" */
+  GTT_DIMCHG = 0,     /* Dimension Change. "dimchg" */
+  GTT_TYPECAST,       /* Type change. "typecast" */
+  GTT_ARITHMETIC,     /* Arithmetic. "arithmetic" */
+  GTT_TRANSPOSE,      /* Transpose. "transpose" */
+  GTT_STAND,          /* Standardization. "stand" */
 
-  GTT_END,
+  GTT_UNKNOWN = -1,   /* Unknown/Not-implemented-yet Mode. "unknown" */
 } tensor_transform_mode;
 
 typedef enum

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -15,6 +15,8 @@
 #include <gst/check/gstharness.h>
 #include <tensor_common.h>
 
+#include "../gst/nnstreamer/tensor_transform/tensor_transform.h"
+
 /**
  * @brief Macro for debug mode.
  */
@@ -45,7 +47,7 @@ TEST (test_tensor_transform, typecast_1)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "uint32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "uint32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -118,7 +120,7 @@ TEST (test_tensor_transform, typecast_1_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "uint32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "uint32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -191,7 +193,7 @@ TEST (test_tensor_transform, typecast_2)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float64", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float64", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -264,7 +266,7 @@ TEST (test_tensor_transform, typecast_2_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float64", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float64", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -337,7 +339,7 @@ TEST (test_tensor_transform, typecast_3)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -410,7 +412,7 @@ TEST (test_tensor_transform, typecast_3_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -483,7 +485,7 @@ TEST (test_tensor_transform, typecast_4)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -556,7 +558,7 @@ TEST (test_tensor_transform, typecast_4_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -629,7 +631,7 @@ TEST (test_tensor_transform, typecast_5)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -702,7 +704,7 @@ TEST (test_tensor_transform, typecast_5_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -775,7 +777,7 @@ TEST (test_tensor_transform, typecast_6)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -848,7 +850,7 @@ TEST (test_tensor_transform, typecast_6_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -921,7 +923,7 @@ TEST (test_tensor_transform, typecast_7)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -994,7 +996,7 @@ TEST (test_tensor_transform, typecast_7_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "typecast", "option", "float32", NULL);
+  g_object_set (h->element, "mode", GTT_TYPECAST, "option", "float32", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -1067,7 +1069,7 @@ TEST (test_tensor_transform, arithmetic_1)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic", "option", "add:.5", NULL);
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:.5", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -1137,7 +1139,7 @@ TEST (test_tensor_transform, arithmetic_1_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic", "option", "add:.5", NULL);
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "add:.5", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -1207,7 +1209,7 @@ TEST (test_tensor_transform, arithmetic_2)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic", "option", "mul:.5", NULL);
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "mul:.5", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
   /* input tensor info */
@@ -1277,7 +1279,7 @@ TEST (test_tensor_transform, arithmetic_2_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic", "option", "mul:.5", NULL);
+  g_object_set (h->element, "mode", GTT_ARITHMETIC, "option", "mul:.5", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
   /* input tensor info */
@@ -1347,7 +1349,7 @@ TEST (test_tensor_transform, arithmetic_3)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:float32,add:.5,mul:0.2", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
@@ -1421,7 +1423,7 @@ TEST (test_tensor_transform, arithmetic_3_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:float32,add:.5,mul:0.2", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
@@ -1495,7 +1497,7 @@ TEST (test_tensor_transform, arithmetic_4)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:float64,add:0.2,add:0.1,typecast:uint16", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
@@ -1569,7 +1571,7 @@ TEST (test_tensor_transform, arithmetic_4_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:float64,add:0.2,add:0.1,typecast:uint16", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 
@@ -1643,7 +1645,7 @@ TEST (test_tensor_transform, arithmetic_5)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:int32,mul:2,div:2,add:-1", NULL);
   g_object_set (h->element, "acceleration", (gboolean) FALSE, NULL);
 
@@ -1717,7 +1719,7 @@ TEST (test_tensor_transform, arithmetic_5_accel)
 
   h = gst_harness_new ("tensor_transform");
 
-  g_object_set (h->element, "mode", "arithmetic",
+  g_object_set (h->element, "mode", GTT_ARITHMETIC,
       "option", "typecast:int32,mul:2,div:2,add:-1", NULL);
   g_object_set (h->element, "acceleration", (gboolean) TRUE, NULL);
 


### PR DESCRIPTION
Resolves #946 

This PR mainly addresses the issue related with reaction for the invalid option string of each transform mode. 
- Using regex, each option string is verified before the pipeline starts. 
- When the option string is invalid, the plug-in explicitly displays error messages using g_critical,
- and then, the pipeline is terminated.
- For the arguments of the 'mode' property, the parameter spec is changed from string to enum so that  the gst-inspect-1.0 command can show the supported modes now.
- Format of the valid option strings for each mode is also added to the description of each mode property.

FYI, after this PR,
```bash
$ gst-inspect-1.0 tensor_transform
Factory Details:
  Rank                     none (0)
  Long-name                TensorTransform
  Klass                    Converter/Filter/Tensor
  Description              Transforms other/tensor dimensions for different models or frameworks
  Author                   MyungJoo Ham <myungjoo.ham@samsung.com>

...omission...
  mode                : Mode used for transforming tensor
                        flags: readable, writable
                        Enum "gtt_mode_type" Default: -1, "unknown"
                           (0): dimchg           - Mode for changing tensor dimensions, option=FROM_DIM:TO_DIM (with a regex, ^([0-3]):([0-3])$, where NNS_TENSOR_RANK_LIMIT is 4)
                           (1): typecast         - Mode for casting type of tensor, option=(^[u]?int(8|16|32|64)$|^float(32|64)$)
                           (2): arithmetic       - Mode for arithmetic operations with tensor, option=[typecast:TYPE,]add|mul|div:NUMBER..., ...
                           (3): transpose        - Mode for transposing shape of tensor, option=D1':D2':D3':D4 (fixed to 3)
                           (4): stand            - Mode for statistical standardization of tensor, option=default
                           (-1): unknown          - Unknown or not-implemented-yet mode
  option              : Option for the tensor transform mode ?
                        flags: readable, writable
                        String. Default: null
...omission...
```
**Changes in this PR**
- v2
  - rebased onto https://github.com/nnsuite/nnstreamer/pull/1119
  - updated error messages to allow breaking 80col rule

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>