### PR TITLE
[Converter] data size of text input

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -804,7 +804,8 @@ gst_tensor_config_from_text_info (GstTensorConfig * config,
   }
 
   /* [size][frames] */
-  config->info.dimension[0] = GST_TENSOR_STRING_SIZE;
+  /* Fixed size of string, we cannot get the size from caps. */
+  config->info.dimension[0] = 0;
   /* Supposed 1 frame in tensor, change this if tensor contains N frames. */
   config->info.dimension[1] = 1;
 

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -1161,7 +1161,7 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
             "Failed to get tensor info, need to update string size.");
 
         g_critical ("Please set the property input-dim to convert stream.\n"
-            "For example, input-dim=30 to handle fixed 30 bytes of string.");
+            "For example, input-dim=30 to handle up to 30 bytes of string per frame.");
         return FALSE;
       }
 
@@ -1174,9 +1174,8 @@ gst_tensor_converter_parse_caps (GstTensorConverter * self,
         GST_ERROR_OBJECT (self,
             "Failed to get tensor info, need to update dimension and type.");
 
-        g_critical ("Please set the properties input-dim and input-type "
-            "to convert stream.\nFor example, input-dim=30:1 input-type=unit8 "
-            "to handle 30 bytes of bin data.");
+        g_critical ("Please set the properties input-dim and input-type to convert stream.\n"
+            "For example, input-dim=30:1 input-type=unit8 to handle 30 bytes of bin data.");
         return FALSE;
       }
 

--- a/gst/nnstreamer/tensor_typedef.h
+++ b/gst/nnstreamer/tensor_typedef.h
@@ -31,6 +31,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define NNS_TENSOR_RANK_LIMIT	(4)
+#define NNS_TENSOR_SIZE_LIMIT	(16)
+#define NNS_TENSOR_SIZE_LIMIT_STR	"16"
+#define NNS_TENSOR_DIM_NULL ({0, 0, 0, 0})
+
 /**
  * @brief This value, 16, can be checked with gst_buffer_get_max_memory(),
  * which is GST_BUFFER_MEM_MAX in gstreamer/gstbuffer.c.
@@ -40,15 +45,11 @@
  */
 #define GST_TENSOR_NUM_TENSORS_RANGE "(int) [ 1, " NNS_TENSOR_SIZE_LIMIT_STR " ]"
 #define GST_TENSOR_RATE_RANGE "(fraction) [ 0, max ]"
-/**
- * @brief Fixed size of string type
- */
-#define GST_TENSOR_STRING_SIZE (1024)
-#define NNS_TENSOR_RANK_LIMIT	(4)
-#define NNS_TENSOR_SIZE_LIMIT	(16)
-#define NNS_TENSOR_SIZE_LIMIT_STR	"16"
-#define NNS_TENSOR_DIM_NULL ({0, 0, 0, 0})
 
+/**
+ * @brief Possible tensor element types
+ */
+#define GST_TENSOR_TYPE_ALL "{ float32, float64, int64, uint64, int32, uint32, int16, uint16, int8, uint8 }"
 
 /**
  * @brief Default static capibility for other/tensor
@@ -101,8 +102,6 @@
     GST_TENSOR_AUDIO_CAPS_STR "; " \
     GST_TENSOR_TEXT_CAPS_STR "; " \
     GST_TENSOR_OCTET_CAPS_STR
-
-#define GST_TENSOR_TYPE_ALL "{ float32, float64, int64, uint64, int32, uint32, int16, uint16, int8, uint8 }"
 
 /**
  * @brief Possible data element types of other/tensor.

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -587,14 +587,14 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
-          "tensor_converter ! tensor_sink name=test_sink");
+          "tensor_converter input-dim=20 ! tensor_sink name=test_sink");
       break;
     case TEST_TYPE_TEXT_3F:
       /** text stream 3 frames */
       str_pipeline =
           g_strdup_printf
           ("appsrc name=appsrc caps=text/x-raw,format=utf8,framerate=(fraction)100/1 ! "
-          "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink");
+          "tensor_converter input-dim=30 frames-per-tensor=3 ! tensor_sink name=test_sink");
       break;
     case TEST_TYPE_OCTET_CUR_TS:
       /** byte stream, timestamp current time */
@@ -742,7 +742,7 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
-          "tensor_converter ! tensor_transform mode=typecast option=%s ! tensor_sink name=test_sink",
+          "tensor_converter input-dim=10 ! tensor_transform mode=typecast option=%s ! tensor_sink name=test_sink",
           tensor_element_typename[option.t_type]);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_1:
@@ -2286,7 +2286,7 @@ TEST (tensor_stream_test, text_utf8)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.received_size, 20);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2297,8 +2297,7 @@ TEST (tensor_stream_test, text_utf8)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 20);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -2332,7 +2331,7 @@ TEST (tensor_stream_test, text_utf8_3f)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * 3);
+  EXPECT_EQ (g_test_data.received_size, 30 * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2343,8 +2342,7 @@ TEST (tensor_stream_test, text_utf8_3f)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 30);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 3);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -2839,7 +2837,7 @@ TEST (tensor_stream_test, typecast_int32)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2850,8 +2848,7 @@ TEST (tensor_stream_test, typecast_int32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -2887,7 +2884,7 @@ TEST (tensor_stream_test, typecast_uint32)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2898,8 +2895,7 @@ TEST (tensor_stream_test, typecast_uint32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -2935,7 +2931,7 @@ TEST (tensor_stream_test, typecast_int16)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2946,8 +2942,7 @@ TEST (tensor_stream_test, typecast_int16)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -2983,7 +2978,7 @@ TEST (tensor_stream_test, typecast_uint16)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2994,8 +2989,7 @@ TEST (tensor_stream_test, typecast_uint16)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -3031,7 +3025,7 @@ TEST (tensor_stream_test, typecast_float64)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3042,8 +3036,7 @@ TEST (tensor_stream_test, typecast_float64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -3079,7 +3072,7 @@ TEST (tensor_stream_test, typecast_float32)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3090,8 +3083,7 @@ TEST (tensor_stream_test, typecast_float32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -3127,7 +3119,7 @@ TEST (tensor_stream_test, typecast_int64)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3138,8 +3130,7 @@ TEST (tensor_stream_test, typecast_int64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
@@ -3175,7 +3166,7 @@ TEST (tensor_stream_test, typecast_uint64)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
   EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, GST_TENSOR_STRING_SIZE * t_size);
+  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3186,8 +3177,7 @@ TEST (tensor_stream_test, typecast_uint64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0],
-      GST_TENSOR_STRING_SIZE);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);


### PR DESCRIPTION
Remove definition for text size.
Instead, set dimension for text input with the property input-dim in tensor-converter.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
