### PR TITLE
[DIST/Debian] Create a symbolic link to libnnstreamer

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,10 +45,12 @@ override_dh_auto_test:
 	cd build && ./tests/unittest_plugins --gst-plugin-path=. && cd ..
 	cd tests && ssat -n && cd ..
 
+override_dh_link:
+	dh_link /usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so  /usr/lib/$(DEB_HOST_MULTIARCH)/libnnstreamer.so
+
 override_dh_auto_install:
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C build install
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
-	ln -s /usr/lib/$(DEB_HOST_MULTIARCH)/gstreamer-1.0/libnnstreamer.so $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/
 # Add --fail-missing option after adding *.install files for all subpackages.


### PR DESCRIPTION
See also: https://github.com/nnsuite/nnstreamer-ros/pull/7

This patch creates a symbolic link to libnnstreamer using dh_link.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Before this PR, 
```bash
$ dpkg-deb --contents /home/wook/Downloads/nnstreamer_0.1.1.0-0_201902150620_ubuntu16.04.1_amd64.deb 
drwxr-xr-x root/root         0 2019-02-15 18:32 ./
drwxr-xr-x root/root         0 2019-02-15 18:32 ./etc/
-rw-r--r-- root/root       145 2019-02-15 18:26 ./etc/nnstreamer.ini
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/share/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/share/doc/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/share/doc/nnstreamer/
-rw-r--r-- root/root       407 2019-02-15 18:16 ./usr/share/doc/nnstreamer/changelog.Debian.gz
-rw-r--r-- root/root        64 2019-02-15 18:16 ./usr/share/doc/nnstreamer/copyright
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/x86_64-linux-gnu/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/x86_64-linux-gnu/gstreamer-1.0/
-rw-r--r-- root/root    248240 2019-02-15 18:32 ./usr/lib/x86_64-linux-gnu/gstreamer-1.0/libnnstreamer.so
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/nnstreamer/
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/nnstreamer/decoders/
-rw-r--r-- root/root     14560 2019-02-15 18:32 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_labeling.so
-rw-r--r-- root/root     10368 2019-02-15 18:32 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
-rw-r--r-- root/root     28184 2019-02-15 18:32 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_bounding_boxes.so
drwxr-xr-x root/root         0 2019-02-15 18:32 ./usr/lib/nnstreamer/filters/
-rw-r--r-- root/root     47824 2019-02-15 18:32 ./usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow.so
-rw-r--r-- root/root   1537792 2019-02-15 18:32 ./usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so
```
After this PR,
```bash
$ dpkg-deb --contents /var/cache/pbuilder/result/nnstreamer_0.1.1.0_amd64.deb 
drwxr-xr-x root/root         0 2019-02-19 08:55 ./
drwxr-xr-x root/root         0 2019-02-19 08:55 ./etc/
-rw-r--r-- root/root       145 2019-02-19 08:53 ./etc/nnstreamer.ini
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/nnstreamer/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/nnstreamer/filters/
-rw-r--r-- root/root     47824 2019-02-19 08:55 ./usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow.so
-rw-r--r-- root/root   1537792 2019-02-19 08:55 ./usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/nnstreamer/decoders/
-rw-r--r-- root/root     14560 2019-02-19 08:55 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_image_labeling.so
-rw-r--r-- root/root     10368 2019-02-19 08:55 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_direct_video.so
-rw-r--r-- root/root     28184 2019-02-19 08:55 ./usr/lib/nnstreamer/decoders/libnnstreamer_decoder_bounding_boxes.so
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/x86_64-linux-gnu/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/lib/x86_64-linux-gnu/gstreamer-1.0/
-rw-r--r-- root/root    248240 2019-02-19 08:55 ./usr/lib/x86_64-linux-gnu/gstreamer-1.0/libnnstreamer.so
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/share/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/share/doc/
drwxr-xr-x root/root         0 2019-02-19 08:55 ./usr/share/doc/nnstreamer/
-rw-r--r-- root/root       319 2019-02-13 15:45 ./usr/share/doc/nnstreamer/changelog.gz
-rw-r--r-- root/root        64 2018-11-26 16:07 ./usr/share/doc/nnstreamer/copyright
lrwxrwxrwx root/root         0 2019-02-19 08:55 ./usr/lib/x86_64-linux-gnu/libnnstreamer.so -> gstreamer-1.0/libnnstreamer.so
```