### PR TITLE
[Filter/Decoder] Exception handling of not found subplugin

### DIFF
--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -668,6 +668,10 @@ gst_tensordec_transform_caps (GstBaseTransform * trans,
 
   self = GST_TENSORDEC_CAST (trans);
 
+  /* Not ready */
+  if (self->decoder == NULL)
+    return NULL;
+
   silent_debug ("Direction = %d\n", direction);
   silent_debug_caps (caps, "from");
   silent_debug_caps (filter, "filter");

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -1161,6 +1161,11 @@ gst_tensor_filter_transform_caps (GstBaseTransform * trans,
   GstStructure *structure;
 
   self = GST_TENSOR_FILTER_CAST (trans);
+
+  /* Not ready */
+  if (self->fw == NULL)
+    return NULL;
+
   gst_tensors_config_init (&config);
 
   silent_debug ("Direction = %d\n", direction);
@@ -1352,6 +1357,10 @@ gst_tensor_filter_start (GstBaseTransform * trans)
   GstTensorFilter *self;
 
   self = GST_TENSOR_FILTER_CAST (trans);
+
+  /* If it is not configured properly, don't allow to start! */
+  if (self->fw == NULL)
+    return FALSE;
 
   gst_tensor_filter_open_fw (self);
 


### PR DESCRIPTION
If subplugin is not found or not configured,
do not proceed with GSTCAP negotiation or STREAM-START.

Fixes #1092

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
