### PR TITLE
Release of 0.1.1 / Start of 0.1.2-RC

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,16 @@
+0.1.0 -> 0.1.1:
+	- Full "Plug & Play" capability of subplugins (tensor_filter, tensor_filter::custom, tensor_decoder)
+		- Fully configurable subplugin locations
+		- Capability to build subplungins wihtout the dependencies on nnstreamer sources
+	- Revert Tensorflow input-memcpy-less-ness for multi-tensor support. (Will support memcpy-less-ness later)
+	- Support "String" type of tensors
+	- API sets updated (still not "stable")
+	- Code location refactored.
+	- Yocto/Openembedded Layer Registered (not tested): "meta-neural-network"
+	- No more additional shared libraries.
+	- Better error handling and messages for a few plugins
+	- Android support (N / arm64)
+
 0.0.3 -> 0.1.0:
 	- Build system migration cmake --> meson
 	- Support Tensorflow without input/output tensor memcpy

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (0.1.1.1) unstable xenial bionic; urgency=medium
+
+  * 0.1.1 Release
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Mon, 25 Feb 2019 12:00:00 +0900
+
 nnstreamer (0.1.1.0) unstable xenial bionic; urgency=medium
 
   * 0.1.1 RC Development Started

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (0.1.2.0) unstable xenial bionic; urgency=medium
+
+  * 0.1.2 RC Development Started
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Tue, 26 Feb 2019 20:00:00 +0900
+
 nnstreamer (0.1.1.1) unstable xenial bionic; urgency=medium
 
   * 0.1.1 Release

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -6,7 +6,7 @@
 Name:		nnstreamer
 Summary:	gstremaer plugins for neural networks
 Version:	0.1.1
-Release:	0
+Release:	1
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1
@@ -194,6 +194,9 @@ popd
 %{_prefix}/lib/nnstreamer/customfilters/*.so
 
 %changelog
+* Mon Feb 25 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 0.1.1
+
 * Thu Jan 24 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.1.0
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -5,8 +5,8 @@
 
 Name:		nnstreamer
 Summary:	gstremaer plugins for neural networks
-Version:	0.1.1
-Release:	1
+Version:	0.1.2
+Release:	0
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1


### PR DESCRIPTION
Along with Mini Summit #4, nnstreamer 0.1.1 is released.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
