### PR TITLE
[CI] Add /ext/* to unit-test-coverage scope

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -134,7 +134,7 @@ DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
 # Intentionally excluded directories are:
 #
 # tests: We are not going to show testcoverage of the test code itself or example applications
-    $(pwd)/tests/unittestcoverage.py module $(pwd)/gst
+    $(pwd)/tests/unittestcoverage.py module $(pwd)/gst $(pwd)/ext
 
 # Get commit info
     VCS=`cat ${RPM_SOURCE_DIR}/nnstreamer.spec | grep "^VCS:" | sed "s|VCS:\\W*\\(.*\\)|\\1|"`


### PR DESCRIPTION
The files in /ext/* are officially released code.
Publish the lcov result.

This prepares #1153

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
