### PR TITLE
[Android] ARM64: Added supported API level of NDK r12b

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,8 @@
+# Android NDK r12b supports API level as following:
+# - From 8 (Fryoyo, 2.2) to 24 (Nougat, 7.0)
+# - https://developer.android.com/ndk/guides/stable_apis#a24
+
 LIBCXX_USE_GABIXX := true
-APP_ABI           :=arm64-v8a
+APP_ABI           := arm64-v8a
 APP_STL           := c++_shared
 APP_PLATFORM      := android-24


### PR DESCRIPTION
This commit is to comment the limitation of NDK r12b when developers
try to run NNstreamer on their Android target device.

**Changes
1. Updated coding style of Application.mk
2. Added annotation on NDK r12b

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---
