### PR TITLE
[Decoder] Bugfix: get_property/tensorseg format error

### DIFF
--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -645,7 +645,17 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
         strings = (gchar **) g_ptr_array_free (arr, FALSE);
         p = g_strjoinv (":", strings);
         g_free (strings);
-        strv = g_strjoin (",", strv, p, NULL);
+        if (i > 0) {
+          /** if i = 1, this is previous p.
+            * otherwise, it's previous g_strjoin result */
+          gchar *oldstrv = strv;
+
+          strv = g_strjoin (",", strv, p, NULL);
+          g_free (oldstrv);
+          g_free (p);
+        } else {
+          strv = p;
+        }
       }
       g_value_set_string (value, strv);
       break;


### PR DESCRIPTION
1. Do not print "," as the first character: write "seg1,seg2,seg3" instead of ",seg1,seg2,seg3".
2. Free memory!

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
