### PR TITLE
Android/ARM64: Improve how to specify CPU architecture(ABI)

### DIFF
--- a/jni/Android-app.mk
+++ b/jni/Android-app.mk
@@ -17,7 +17,10 @@ LOCAL_PATH := $(call my-dir)
 # target#> ./{your-test-app}
 
 NNSTREAMER_VERSION := 0.1.1
-TARGET_ARCH_ABI    := arm64-v8a
+
+
+# Do not specify "TARGET_ARCH_ABI" in this file. If you want to append additional architecture,
+# Please append an architecture name behind "APP_ABI" in Application.mk file.
 
 ifeq ($(TARGET_ARCH_ABI),armeabi)
 GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/arm

--- a/jni/Android-nnstreamer.mk
+++ b/jni/Android-nnstreamer.mk
@@ -28,7 +28,9 @@ LOCAL_PATH := $(call my-dir)
 #
 
 NNSTREAMER_VERSION := 0.1.1
-TARGET_ARCH_ABI    := arm64-v8a
+
+# Do not specify "TARGET_ARCH_ABI" in this file. If you want to append additional architecture,
+# Please append an architecture name behind "APP_ABI" in Application.mk file.
 
 ifeq ($(TARGET_ARCH_ABI),armeabi)
 GSTREAMER_ROOT        := $(GSTREAMER_ROOT_ANDROID)/arm

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,8 +1,14 @@
+# @note About Android NDK
 # Android NDK r12b supports API level as following:
 # - From 8 (Fryoyo, 2.2) to 24 (Nougat, 7.0)
 # - https://developer.android.com/ndk/guides/stable_apis#a24
+#
+# @note About Application ABI
+# If you want to generate a binary file for all architectures, please append additional architech name
+# such as "arm64-v8a armeabi-v7a x86 x86_64" as following:
+# APP_ABI = armeabi armeabi-v7a arm64-v8a x86 x86_64
 
-LIBCXX_USE_GABIXX := true
 APP_ABI           := arm64-v8a
+LIBCXX_USE_GABIXX := true
 APP_STL           := c++_shared
 APP_PLATFORM      := android-24


### PR DESCRIPTION
This commit is to improve the writing style of the existing ABI
(CPU architecture) with a method that is described at the documentation
website of the Android NDK toolkit.
* https://developer.android.com/ndk/guides

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---