### PR TITLE
[Android/ARM64] linker64: added a variable to maintain custom linker64

### DIFF
--- a/jni/Android-app.mk
+++ b/jni/Android-app.mk
@@ -17,6 +17,7 @@ LOCAL_PATH := $(call my-dir)
 # target#> ./{your-test-app}
 
 NNSTREAMER_VERSION := 0.1.1
+CUSTOM_LINKER64    := -fPIE -pie -Wl,-dynamic-linker,/data/nnstreamer/libandroid/linker64
 
 
 # Do not specify "TARGET_ARCH_ABI" in this file. If you want to append additional architecture,
@@ -86,7 +87,7 @@ LOCAL_MODULE    := tensor_repo_dynamic_test
 LOCAL_CFLAGS    += -O0 -DVERSION=\"$(NNSTREAMER_VERSION)\"
 LOCAL_SRC_FILES += ../tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c 
 LOCAL_CXXFLAGS  += -std=c++11
-LOCAL_LDFLAGS   := -fPIE -pie -Wl,-dynamic-linker,/data/nnstreamer/libandroid/linker64
+LOCAL_LDFLAGS   := $(CUSTOM_LINKER64)
 
 NNSTREAMER_GST_HOME    := ../gst/nnstreamer
 


### PR DESCRIPTION

This commit is to specify a variable to maintain the custom linker64.
This build script handles how to run the NNstreamer-based 64bit application
on Android 32bit platform. If the tart device is based on Android 64bit platform,
We do not need to use the custom linker64 repeatedly on the device.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---