### PR TITLE
[Test] exclude orc file in coverage

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -168,8 +168,10 @@ DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
     #find . -path "/build/*.j
     # Generate report
     lcov -t 'NNStreamer Unit Test Coverage' -o unittest.info -c -d . -b $(pwd) --no-external
+    # Exclude generated files (Orc)
+    lcov -r unittest.info "*/*-orc.*" -o unittest-filtered.info
     # Visualize the report
-    genhtml -o result unittest.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
+    genhtml -o result unittest-filtered.info -t "nnstreamer %{version}-%{release} ${VCS}" --ignore-errors source -p ${RPM_BUILD_DIR}
 %endif
 
 %if 0%{?testcoverage}


### PR DESCRIPTION
-orc file generated while building nnstreamer.
Exclude this in unittest coverage report.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
