### PR TITLE
[Decoder/DirectVideo] 0/1 framerate

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -104,7 +104,7 @@ dv_getOutCaps (void **pdata, const GstTensorsConfig * config)
     gst_caps_set_simple (caps, "height", G_TYPE_INT, height, NULL);
   }
 
-  if (fn > 0 && fd > 0) {
+  if (fn >= 0 && fd > 0) {
     gst_caps_set_simple (caps, "framerate", GST_TYPE_FRACTION, fn, fd, NULL);
   }
 


### PR DESCRIPTION
Allow 0/1 framerate in decoder-direct video mode

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
