### PR TITLE
[demux/split] memory leak

### DIFF
--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -581,8 +581,8 @@ gst_tensor_demux_get_property (GObject * object, guint prop_id,
       g_ptr_array_add (arr, NULL);
       strings = (gchar **) g_ptr_array_free (arr, FALSE);
       p = g_strjoinv (",", strings);
-      g_free (strings);
-      g_value_set_string (value, p);
+      g_strfreev (strings);
+      g_value_take_string (value, p);
       break;
     }
     default:

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -624,8 +624,8 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
       g_ptr_array_add (arr, NULL);
       strings = (gchar **) g_ptr_array_free (arr, FALSE);
       p = g_strjoinv (",", strings);
-      g_free (strings);
-      g_value_set_string (value, p);
+      g_strfreev (strings);
+      g_value_take_string (value, p);
       break;
     }
     case PROP_TENSORSEG:
@@ -644,7 +644,7 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
         g_ptr_array_add (arr, NULL);
         strings = (gchar **) g_ptr_array_free (arr, FALSE);
         p = g_strjoinv (":", strings);
-        g_free (strings);
+        g_strfreev (strings);
         if (i > 0) {
           /** if i = 1, this is previous p.
             * otherwise, it's previous g_strjoin result */
@@ -657,7 +657,7 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
           strv = p;
         }
       }
-      g_value_set_string (value, strv);
+      g_value_take_string (value, strv);
       break;
     }
     default:


### PR DESCRIPTION
remove memory corresponding to get_property
replacing g_value_set_string() with g_value_take_string() to release ownership of strings.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
