### PR TITLE
Build: synchronize vesion info among platforms

### DIFF
--- a/jni/Android-nnstreamer.mk
+++ b/jni/Android-nnstreamer.mk
@@ -27,7 +27,7 @@ LOCAL_PATH := $(call my-dir)
 # cp ./libs/arm64-v8a/libnnstreamer.so $GSTREAMER_ROOT_ANDROID/arm64/lib/gstreamer-1.0/
 #
 
-NNSTREAMER_VERSION := 0.1.1
+NNSTREAMER_VERSION := 0.1.2
 
 # Do not specify "TARGET_ARCH_ABI" in this file. If you want to append additional architecture,
 # Please append an architecture name behind "APP_ABI" in Application.mk file.

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
 
 project('nnstreamer', 'c', 'cpp',
-  version: '0.1.1',
+  version: '0.1.2',
   license: ['LGPL'],
   meson_version: '>=0.40.0',
   default_options: [

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -5,6 +5,11 @@
 
 Name:		nnstreamer
 Summary:	gstremaer plugins for neural networks
+# Synchronize the version information among Ubuntu, Tizen, Android, and Meson.
+# 1. Ubuntu : ./debian/changelog
+# 2. Tizen  : ./packaging/nnstreamer.spec
+# 3. Android: ./jni/Android*.mk
+# 4. Meson  : ./meson.build
 Version:	0.1.2
 Release:	0
 Group:		Applications/Multimedia


### PR DESCRIPTION
This commit is to synchronize the version information among Ubuntu,
Tizen, Android, and Meson.



Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---