### PR TITLE
[Workaround] There is no tensorflow deb in the PPA

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Description: NNStreamer plugins for Gstreamer
 Package: nnstreamer-tensorflow
 Architecture: amd64 arm64
 Multi-Arch: same
-Depends: nnstreamer, tensorflow, ${shlibs:Depends}, ${misc:Depends}
+Depends: nnstreamer, tensorflow | tensorflow-dev, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer TensorFlow Support
  This package allows nnstreamer to support tensorflow. Note that users must make sure that they have installed Tensorflow with compatible C-API (recommended to use the same version). However, having different options (e.g., GPU mode) should not affect the compatibility. When we have stable C-API from Tensorflow, we will release corresponding subplugin as well.
 


### PR DESCRIPTION
In Ubuntu PPA, there is tensorflow-dev, not tensorflow, which
includes both devel and libraries.

As a workaround, make it depends on either of the two.

Fixes #1204
Addresses https://github.com/nnsuite/nnstreamer-example/issues/21

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
