### PR TITLE
[Sty]e] It's ANSI C89 without C90. - @open sesame 04/02 16:58

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project('nnstreamer', 'c', 'cpp',
   default_options: [
     'werror=true',
     'warning_level=1',
-    'c_std=gnu89',
+    'c_std=c89',
     'cpp_std=c++11'
   ]
 )


### PR DESCRIPTION
1. Modifying comments of iio code:
According to https://gstreamer.freedesktop.org/documentation/frequently-asked-questions/developing.html
we need to use ANSI C89 and no "//" style comments in the code;
we want to upstream someday.

Note that fixing the next item incurs compiler errors with "//".

2. Updating meson.build cc options
And, according to "man gcc" page,
"std89" actually means means "GNU dialect of ISO C90 (including some C99 features)",
which is not compatible with ANSI C89.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

