### PR TITLE
[Common] Remove unnecessary init function call

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -874,8 +874,6 @@ gst_tensor_config_from_structure (GstTensorConfig * config,
   media_type m_type;
 
   g_return_val_if_fail (config != NULL, FALSE);
-  gst_tensor_config_init (config);
-
   g_return_val_if_fail (structure != NULL, FALSE);
 
   /* update config from tensor stream */
@@ -900,6 +898,7 @@ gst_tensor_config_from_structure (GstTensorConfig * config,
       gst_tensor_config_from_octet_stream_info (config, structure);
       break;
     default:
+      gst_tensor_config_init (config);
       GST_WARNING ("Unsupported type %d\n", m_type);
       return FALSE;
   }


### PR DESCRIPTION
This patch removes the unnecessary gst_tensor_config_init() function call
since init function of each type (i.g. gst_tensor_config_from_[TYPE]_info())
calls gst_tensor_config_init() internally.


**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>
