### PR TITLE
[Tizen/API] Add unittest skeleton for Tizen-CAPI (TCT candidate) 

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -174,6 +174,7 @@ ninja -C build %{?_smp_mflags}
     ./tests/unittest_common
     ./tests/unittest_sink --gst-plugin-path=.
     ./tests/unittest_plugins --gst-plugin-path=.
+    LD_LIBRARY_PATH=tizen-api ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=.
     popd
     pushd tests
     ssat -n

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -87,3 +87,8 @@ if gtest_dep.found()
 
   test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
 endif
+
+# Tizen C-API
+if get_option('enable-tizen-capi')
+  subdir('tizen_capi')
+endif

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -1,0 +1,13 @@
+tizen_apptest_deps = [
+  capi_base_common_dep,
+  dlog_dep,
+  tizen_capi_dep,
+  gtest_dep
+]
+
+unittest_tizen_capi = executable('unittest_tizen_capi',
+  'unittest_tizen_capi.cpp',
+  dependencies: [tizen_apptest_deps],
+  install: false
+)
+test('unittest_tizen_capi', unittest_tizen_capi, args: ['--gst-plugin-path=../..'])

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file        unittest_tizen_capi.cpp
+ * @date        13 Mar 2019
+ * @brief       Unit test for Tizen CAPI of NNStreamer. Basis of TCT in the future.
+ * @see         https://github.com/nnsuite/nnstreamer
+ * @author      MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <tizen-api.h>
+#include <gtest/gtest.h>
+
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_construct_destruct, dummy_01)
+{
+  const char *pipeline = "videotestsrc num_buffers=2 ! fakesink";
+  nns_pipeline_h handle;
+  int status = nns_pipeline_construct (pipeline, &handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_destroy (handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+}
+
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_construct_destruct, dummy_02)
+{
+  const char *pipeline = "videotestsrc num_buffers=2 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! fakesink";
+  nns_pipeline_h handle;
+  int status = nns_pipeline_construct (pipeline, &handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_destroy (handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+}
+
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_construct_destruct, dummy_03)
+{
+  const char *pipeline = "videotestsrc num_buffers=2 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! valve name=valvex ! tensor_sink name=sinkx";
+  nns_pipeline_h handle;
+  int status = nns_pipeline_construct (pipeline, &handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_destroy (handle);
+
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+}
+
+/**
+ * @brief Main gtest
+ */
+int main (int argc, char **argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+
+  return RUN_ALL_TESTS ();
+}

--- a/tizen-api/meson.build
+++ b/tizen-api/meson.build
@@ -39,7 +39,7 @@ tizen_deps = [
 ]
 gst_app_dep = dependency('gstreamer-app-1.0')
 
-shared_library ('capi-nnstreamer',
+tizen_capi_lib = shared_library ('capi-nnstreamer',
   capi_main,
   dependencies: [nnstreamer_dep, glib_dep, gst_dep, gst_app_dep, tizen_deps],
   include_directories: [
@@ -59,6 +59,13 @@ static_library ('capi-nnstreamer',
   ],
   install: true,
   install_dir: nnstreamer_libdir,
+)
+
+tizen_capi_dep = declare_dependency(link_with: tizen_capi_lib,
+  include_directories: [
+    inc,
+    nninc
+  ]
 )
 
 configure_file(input: 'capi-nnstreamer.pc.in', output: 'capi-nnstreamer.pc',


### PR DESCRIPTION
This is to be the basis of TCT (Tizen Compliance Test) in the future.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
