### PR TITLE
[Test/Transform/Arithmetic] Add more test cases @open sesame 3/14 20:36

### DIFF
--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1385,7 +1385,8 @@ gst_tensor_transform_transform (GstBaseTransform * trans,
   uint8_t *inptr, *outptr;
   GstMapInfo inInfo, outInfo;
 
-  g_assert (filter->loaded);
+  g_return_val_if_fail (filter->loaded, GST_FLOW_ERROR);
+
   g_assert (gst_buffer_map (inbuf, &inInfo, GST_MAP_READ));
   g_assert (gst_buffer_map (outbuf, &outInfo, GST_MAP_WRITE));
 

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -25,6 +25,15 @@
 #endif
 
 /**
+ * @brief Macro for default value of the transform's 'acceleration' property
+ */
+#ifdef HAVE_ORC
+#define DEFAULT_VAL_PROP_ACCELERATION TRUE
+#else
+#define DEFAULT_VAL_PROP_ACCELERATION FALSE
+#endif
+
+/**
  * @brief Macro for debug message.
  */
 #define _print_log(...) if (DBG) g_message (__VA_ARGS__)
@@ -105,7 +114,7 @@
 TEST (test_tensor_transform, properties)
 {
   const gboolean default_silent = TRUE;
-  const gboolean default_accl = TRUE;
+  const gboolean default_accl = DEFAULT_VAL_PROP_ACCELERATION;
   const gint default_mode = 1; /* typecast */
   const gchar default_option[] = "uint32";
   gchar *str_launch_line;
@@ -134,7 +143,10 @@ TEST (test_tensor_transform, properties)
   g_object_get (transform, "silent", &res_silent, NULL);
   EXPECT_EQ (!default_silent, res_silent);
 
-  /** default acceleration is TRUE */
+  /**
+   * If HAVE_ORC is set, default acceleration is TRUE.
+   * Otherwise the default value is FALSE.
+   */
   g_object_get (transform, "acceleration", &accl, NULL);
   EXPECT_EQ (default_accl, accl);
 

--- a/tests/transform_arithmetic/checkResult.py
+++ b/tests/transform_arithmetic/checkResult.py
@@ -14,6 +14,17 @@ import sys
 import struct
 
 ##
+# @brief Get value of proper type corresponding to the unpack format string
+#
+def getValue (val, unpack_format):
+    if unpack_format in ['b', 'B', 'h', 'H', 'i', 'I', 'q', 'Q']:
+        return int(val)
+    elif unpack_format in ['f', 'd']:
+        return float(val)
+    else:
+        return None
+
+##
 # @brief Check typecast from typea to typeb with file fna/fnb
 #
 def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, value1, value2):
@@ -27,23 +38,28 @@ def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, v
     return 11
   limitb = 2 ** (8 * typebsize)
   maskb = limitb - 1
+  value1 = getValue(value1, typeapack)
+  value2 = getValue(value2, typebpack)
+  if value1 is None or value2 is None:
+      return 12
+
   for x in range(0, num):
     vala = struct.unpack(typeapack, fna[x * typeasize: x * typeasize + typeasize])[0]
     valb = struct.unpack(typebpack, fnb[x * typebsize: x * typebsize + typebsize])[0]
     if (mode == 'add'):
-      diff = vala + float(value1) - valb
+      diff = vala  + value1 - valb
       if diff > 0.01 or diff < -0.01:
         return 20
     elif (mode == 'mul'):
-      diff = vala * float(value1) - valb
+      diff = vala * value1 - valb
       if diff > 0.01 or diff < -0.01:
         return 20
     elif (mode == 'add-mul'):
-      diff = (vala + float(value1)) * float(value2) - valb
+      diff = (vala + value1) * value2 - valb
       if diff > 0.01 or diff < -0.01:
         return 20
     elif (mode == 'mul-add'):
-      diff = (vala * float(value1)) + float(value2) - valb
+      diff = (vala * value1) + value2 - valb
       if diff > 0.01 or diff < -0.01:
         return 20
     else:

--- a/tests/transform_arithmetic/checkResult.py
+++ b/tests/transform_arithmetic/checkResult.py
@@ -36,8 +36,6 @@ def testArithmetic (fna, fnb, typeasize, typebsize,typeapack, typebpack, mode, v
   num = lena / typeasize
   if num != (lenb / typebsize):
     return 11
-  limitb = 2 ** (8 * typebsize)
-  maskb = limitb - 1
   value1 = getValue(value1, typeapack)
   value2 = getValue(value2, typebpack)
   if value1 is None or value2 is None:

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -82,4 +82,55 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 testResult $? 6 "Golden test comparison" 0 1
 python checkResult.py arithmetic testcase06.direct.log testcase06.arithmetic.log 8 8 d d add-mul -50.0987e+003 15.3
 
+# Test for mul with tensors typecasted to int8 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:int8,mul:-3 acceleration=false ! filesink location=\"testcase07.arithmetic.1.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=int8 acceleration=false ! filesink location=\"testcase07.direct.1.log\" sync=true" 7-1 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.1.log testcase07.arithmetic.1.log 1 1 b b mul -3 0
+testResult $? 7-1 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to uint8 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:uint8,mul:1 acceleration=false ! filesink location=\"testcase07.arithmetic.2.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=uint8 acceleration=false ! filesink location=\"testcase07.direct.2.log\" sync=true" 7-2 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.2.log testcase07.arithmetic.2.log 1 1 B B mul 1 0
+testResult $? 7-2 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to int16 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:int16,mul:-16 acceleration=false ! filesink location=\"testcase07.arithmetic.3.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=int16 acceleration=false ! filesink location=\"testcase07.direct.3.log\" sync=true" 7-3 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.3.log testcase07.arithmetic.3.log 2 2 h h mul -16 0
+testResult $? 7-3 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to uint16 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:uint16,mul:16 acceleration=false ! filesink location=\"testcase07.arithmetic.4.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=uint16 acceleration=false ! filesink location=\"testcase07.direct.4.log\" sync=true" 7-4 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.4.log testcase07.arithmetic.4.log 2 2 H H mul 16 0
+testResult $? 7-4 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to int32 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:int32,mul:-255 acceleration=false ! filesink location=\"testcase07.arithmetic.5.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=int32 acceleration=false ! filesink location=\"testcase07.direct.5.log\" sync=true" 7-5 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.5.log testcase07.arithmetic.5.log 4 4 i i mul -255 0
+testResult $? 7-5 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to uint32 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:uint32,mul:255 acceleration=false ! filesink location=\"testcase07.arithmetic.6.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=uint32 acceleration=false ! filesink location=\"testcase07.direct.6.log\" sync=true" 7-6 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.6.log testcase07.arithmetic.6.log 4 4 I I mul 255 0
+testResult $? 7-6 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to int64 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:int64,mul:-65535 acceleration=false ! filesink location=\"testcase07.arithmetic.7.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=int64 acceleration=false ! filesink location=\"testcase07.direct.7.log\" sync=true" 7-7 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.7.log testcase07.arithmetic.7.log 8 8 q q mul -65535 0
+testResult $? 7-7 "Golden test comparison" 0 1
+
+# Test for mul with tensors typecasted to uint64 (acceleration=false)
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=arithmetic option=typecast:uint64,mul:65535 acceleration=false ! filesink location=\"testcase07.arithmetic.8.log\" sync=true t. ! queue ! tensor_transform mode=typecast option=uint64 acceleration=false ! filesink location=\"testcase07.direct.8.log\" sync=true" 7-8 0 0 $PERFORMANCE
+
+python checkResult.py arithmetic testcase07.direct.8.log testcase07.arithmetic.8.log 8 8 Q Q mul 65535 0
+testResult $? 7-8 "Golden test comparison" 0 1
+
+# Fail Test for the option string is wrong
+gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_transform mode=arithmetic option=casttype:uint64,mul:65535 acceleration=false ! fakesink sync=true " 8 0 1 $PERFORMANCE
+
 report


### PR DESCRIPTION
Related issue: #1153

In order to cover mode code by various unit test cases, this patch adds more test cases for the 'arithmetic' mode of the 'tensor_transform' element.

### Details ###
- Update checkResult.py to support test results of integer number type
- Add test cases that increase code coverage
- Replaces assertion code for handling wrong option string in tensor_transform with the code returning error code in order to gracefully terminate the pipeline with proper error messages

### Changes in this PR ###
- [v2] checkResult.py: Add missing doxygen tag
- [v2] checkResult.py: Eliminate the duplicate statement
- [v2] add test for dynamically changing option string
- [v3] Set the default value for 'acceleration' to FALSE when HAVE_ORC is not set

### Result ###
- Before this PR: 

| Filename  | Line Coverage  | Functions |
| ------------- |:--------------------:| --------------:|
| tensor_transform.c | 83.1% (518/623)  | 100% (25/25) |

- After this PR: 

| Filename  | Line Coverage  | Functions |
| ------------- |:--------------------:| --------------:|
| tensor_transform.c | 86.3% (535/622)  | 100% (25/25) |

Signed-off-by: Wook Song <wook16.song@samsung.com>