### PR TITLE
[Tizen/API] Implement start/stop/getstate/destroy with testcases

### DIFF
--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -2,7 +2,8 @@ tizen_apptest_deps = [
   capi_base_common_dep,
   dlog_dep,
   tizen_capi_dep,
-  gtest_dep
+  gtest_dep,
+  glib_dep
 ]
 
 unittest_tizen_capi = executable('unittest_tizen_capi',

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -9,6 +9,7 @@
 
 #include <tizen-api.h>
 #include <gtest/gtest.h>
+#include <glib.h>
 
 /**
  * @brief Test NNStreamer pipeline construct & destruct
@@ -18,11 +19,9 @@ TEST (nnstreamer_capi_construct_destruct, dummy_01)
   const char *pipeline = "videotestsrc num_buffers=2 ! fakesink";
   nns_pipeline_h handle;
   int status = nns_pipeline_construct (pipeline, &handle);
-
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   status = nns_pipeline_destroy (handle);
-
   EXPECT_EQ (status, NNS_ERROR_NONE);
 }
 
@@ -34,11 +33,9 @@ TEST (nnstreamer_capi_construct_destruct, dummy_02)
   const char *pipeline = "videotestsrc num_buffers=2 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! fakesink";
   nns_pipeline_h handle;
   int status = nns_pipeline_construct (pipeline, &handle);
-
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   status = nns_pipeline_destroy (handle);
-
   EXPECT_EQ (status, NNS_ERROR_NONE);
 }
 
@@ -50,11 +47,44 @@ TEST (nnstreamer_capi_construct_destruct, dummy_03)
   const char *pipeline = "videotestsrc num_buffers=2 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! valve name=valvex ! tensor_sink name=sinkx";
   nns_pipeline_h handle;
   int status = nns_pipeline_construct (pipeline, &handle);
-
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   status = nns_pipeline_destroy (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+}
 
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_playstop, dummy_01)
+{
+  const char *pipeline = "videotestsrc is-live=true num-buffers=30 framerate=60/1 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
+  nns_pipeline_h handle;
+  nns_pipeline_state state;
+  int status = nns_pipeline_construct (pipeline, &handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_start (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
+  EXPECT_NE (state, NNS_PIPELINE_NULL);
+
+  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_EQ (state, NNS_PIPELINE_PLAYING);
+
+  status = nns_pipeline_stop (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  g_usleep(50000); /* 50ms. Let a few frames flow. */
+
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
+
+  status = nns_pipeline_destroy (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 }
 

--- a/tizen-api/include/tizen-api-private.h
+++ b/tizen-api/include/tizen-api-private.h
@@ -61,7 +61,7 @@ typedef struct _nns_pipeline nns_pipeline;
 typedef struct _element {
   GstElement *element; /**< The Sink/Src/Valve/Switch element */
   nns_pipeline *pipe; /**< The main pipeline */
-  const char *name;
+  char *name;
   elementType type;
   GstPad *src;
   GstPad *sink; /**< Unref this at destroy */

--- a/tizen-api/include/tizen-api.h
+++ b/tizen-api/include/tizen-api.h
@@ -76,7 +76,7 @@ typedef enum {
   NNS_ERROR_NONE				= TIZEN_ERROR_NONE, /**< Success! */
   NNS_ERROR_INVALID_PARAMETER			= TIZEN_ERROR_INVALID_PARAMETER, /**< Invalid parameter */
   NNS_ERROR_NOT_SUPPORTED			= TIZEN_ERROR_NOT_SUPPORTED, /**< The feature is not supported */
-  NNS_ERROR_PIPELINE_FAIL			= TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create Gstreamer pipeline. */
+  NNS_ERROR_PIPELINE_FAIL			= TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create or access Gstreamer pipeline. */
 } nns_error_e;
 
 /**
@@ -165,6 +165,8 @@ int nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h *pi
  * @param[in] pipe The pipeline to be destroyed.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
+ * @retval #NNS_ERROR_PIPELINE_FAIL Fail. Cannot access the pipeline status.
+ * @retval #NNS_ERROR_INVALID_PARAMETER Fail. The parameter is invalid (pipe is NULL?)
  */
 int nns_pipeline_destroy (nns_pipeline_h pipe);
 
@@ -176,6 +178,8 @@ int nns_pipeline_destroy (nns_pipeline_h pipe);
  * @param[out] state The pipeline state.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
+ * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
+ * @retval #NNS_ERROR_PIPELINE_FAIL Failed to get state from the pipeline.
  */
 int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state *state);
 
@@ -185,20 +189,24 @@ int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state *state);
 /**
  * @brief Start the pipeline
  * @detail The pipeline handle returned by nns_construct_pipeline (pipe) is started.
+ *         Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be started.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
+ * @retval #NNS_ERROR_PIPELINE_FAIL Failed to start.
  */
 int nns_pipeline_start (nns_pipeline_h pipe);
 
 /**
  * @brief Stop the pipeline
  * @detail The pipeline handle returned by nns_construct_pipeline (pipe) is stopped.
+ *         Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be stopped.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
+ * @retval #NNS_ERROR_PIPELINE_FAIL Failed to start.
  */
 int nns_pipeline_stop (nns_pipeline_h pipe);
 


### PR DESCRIPTION


Implement Tizen-CAPI, "start/stop/getstate/destroy" for a nnstreamer pipeline.
Add testcases for them.


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
