### PR TITLE
[YOCTO] Add enable-opencv-test meson option to remove opencv dep

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('enable-test', type: 'boolean', value: true)
+option('enable-opencv-test', type: 'boolean', value: true)
 option('enable-tensorflow-lite', type: 'boolean', value: true)
 option('enable-tensorflow', type: 'boolean', value: true)
 option('install-example', type: 'boolean', value: false)

--- a/nnstreamer_example/meson.build
+++ b/nnstreamer_example/meson.build
@@ -1,6 +1,8 @@
 subdir('custom_example_passthrough')
 subdir('custom_example_scaler')
 subdir('custom_example_average')
-subdir('custom_example_opencv')
+if get_option('enable-opencv-test')
+   subdir('custom_example_opencv')
+endif
 subdir('custom_example_RNN')
 subdir('custom_example_LSTM')


### PR DESCRIPTION
# PR Descriptions

The only place which has opencv dependency is
custom_example_opencv. In order to manage more efficient,
enable-opencv-test meson option is added. If it is true, opencv
example is enabled or disabled, if not.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
