### PR TITLE
[IIO] added scale and offset

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.h
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.h
@@ -88,6 +88,8 @@ typedef struct _GstTensorSrcIIOChannelProperties
   guint storage_bits; /**< exact bit size for the data */
   guint shift; /**< shift to be applied on the read data */
   guint location; /**< location of channel data in buffer */
+  gfloat offset; /**< offset applied on raw data read from device */
+  gfloat scale; /**< scale applied on offset-ed data read from device */
 } GstTensorSrcIIOChannelProperties;
 
 /**


### PR DESCRIPTION
Added scale and offset to process raw data.
First get channel specific scale/offset, if available. Secondly, try
generic scale/offset, else use default values.

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>