### PR TITLE
[Filter/Tensorflow] remove memcpy by getting conf

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -30,6 +30,7 @@
 #include "tensor_filter_tensorflow_core.h"
 #include <glib.h>
 #include <string.h>
+#include <nnstreamer_conf.h>
 
 /**
  * @brief internal data of tensorflow
@@ -77,8 +78,12 @@ tf_loadModelFile (const GstTensorFilterProperties * prop, void **private_data)
   tf = g_new0 (tf_data, 1); /** initialize tf Fill Zero! */
   *private_data = tf;
   tf->tf_private_data = tf_core_new (prop->model_file);
+
+  const gboolean tf_mem_optmz =
+      nnsconf_get_value_bool (NNSCONF_VAL_TF_MEM_OPTMZ);
+
   if (tf->tf_private_data) {
-    if (tf_core_init (tf->tf_private_data, prop)) {
+    if (tf_core_init (tf->tf_private_data, prop, tf_mem_optmz)) {
       g_printerr ("failed to initailize the object: tensorflow");
       return -2;
     }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -27,18 +27,20 @@
 #define TENSOR_FILTER_TENSORFLOW_CORE_H
 
 #include <tensor_typedef.h>
-
-#ifdef __cplusplus
 #include <glib.h>
 #include <gst/gst.h>
 #include <setjmp.h>
 #include <stdio.h>
 #include <string.h>
+
+#ifdef __cplusplus
 #include <iostream>
 #include <fstream>
 #include <algorithm>
 #include <vector>
 
+#include <tensorflow/c/c_api.h>
+#include <tensorflow/c/c_api_internal.h>
 #include <tensorflow/core/public/session.h>
 
 using namespace tensorflow;
@@ -64,7 +66,7 @@ public:
   TFCore (const char * _model_path);
    ~TFCore ();
 
-  int init(const GstTensorFilterProperties * prop);
+  int init (const GstTensorFilterProperties * prop, const gboolean tf_mem_optmz);
   int loadModel ();
   const char* getModelPath();
   int getInputTensorDim (GstTensorsInfo * info);
@@ -76,6 +78,7 @@ public:
 private:
 
   const char *model_path;
+  gboolean mem_optmz;
 
   GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
   GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
@@ -87,6 +90,7 @@ private:
   Session *session;
 
   tensor_type getTensorTypeFromTF (DataType tfType);
+  TF_DataType getTensorTypeToTF_Capi (tensor_type tType);
   int validateInputTensor (const GraphDef &graph_def);
   int validateOutputTensor (const std::vector <Tensor> &outputs);
 };
@@ -100,7 +104,8 @@ extern "C"
 
   void *tf_core_new (const char *_model_path);
   void tf_core_delete (void * tf);
-  int tf_core_init (void * tf, const GstTensorFilterProperties * prop);
+  int tf_core_init (void * tf, const GstTensorFilterProperties * prop,
+      const gboolean tf_mem_optmz);
   const char *tf_core_getModelPath (void * tf);
   int tf_core_getInputDim (void * tf, GstTensorsInfo * info);
   int tf_core_getOutputDim (void * tf, GstTensorsInfo * info);

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -134,6 +134,7 @@ ninja -C build %{?_smp_mflags}
     export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
     %ifarch x86_64 aarch64
     export TEST_TENSORFLOW=1
+    export NNSTREAMER_TF_MEM_OPTMZ=0
     %endif
     ./tests/unittest_common
     ./tests/unittest_sink --gst-plugin-path=.


### PR DESCRIPTION
Through conf, we can avoid unexpected errors in the specific environment by turning on/off the option(memory optimization).

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped