### PR TITLE
Release of 0.1.2 & Start of 0.1.3 RC.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,15 @@
+0.1.1 -> 0.1.2:
+	- Tizen Public C-API Draft Prototype
+	- Yocto/Openembedded Layer Tested.
+	- ROS sink/src supported and partially tested.
+	- IIO support draft
+	- Custom filter codegen
+	- Capability to cut the dependencies on audio/video plugins for minimal memory footprint.
+	- More clear error messages when the pipeline cannot be initiated.
+	- Increased unit test coverages with additional unit test cases.
+	- Minor feature adds on elements.
+	- A series of bug fixes.
+
 0.1.0 -> 0.1.1:
 	- Full "Plug & Play" capability of subplugins (tensor_filter, tensor_filter::custom, tensor_decoder)
 		- Fully configurable subplugin locations

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (0.1.3.0) unstable xenial bionic; urgency=medium
+
+  * 0.1.3 RC Development Started
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Wed, 20 Mar 2019 15:01:00 +0900
+
 nnstreamer (0.1.2.1) unstable xenial bionic; urgency=medium
 
   * 0.1.2 Release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (0.1.2.1) unstable xenial bionic; urgency=medium
+
+  * 0.1.2 Release
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Wed, 20 Mar 2019 15:00:00 +0900
+
 nnstreamer (0.1.2.0) unstable xenial bionic; urgency=medium
 
   * 0.1.2 RC Development Started

--- a/jni/Android-app.mk
+++ b/jni/Android-app.mk
@@ -16,7 +16,7 @@ LOCAL_PATH := $(call my-dir)
 # target#> cd /data/nnstreamer/
 # target#> ./{your-test-app}
 
-NNSTREAMER_VERSION := 0.1.1
+NNSTREAMER_VERSION := 0.1.3
 CUSTOM_LINKER64    := -fPIE -pie -Wl,-dynamic-linker,/data/nnstreamer/libandroid/linker64
 
 NO_AUDIO := false

--- a/jni/Android-nnstreamer.mk
+++ b/jni/Android-nnstreamer.mk
@@ -27,7 +27,7 @@ LOCAL_PATH := $(call my-dir)
 # cp ./libs/arm64-v8a/libnnstreamer.so $GSTREAMER_ROOT_ANDROID/arm64/lib/gstreamer-1.0/
 #
 
-NNSTREAMER_VERSION := 0.1.2
+NNSTREAMER_VERSION := 0.1.3
 NO_AUDIO := false
 
 # Do not specify "TARGET_ARCH_ABI" in this file. If you want to append additional architecture,

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
 
 project('nnstreamer', 'c', 'cpp',
-  version: '0.1.2',
+  version: '0.1.3',
   license: ['LGPL'],
   meson_version: '>=0.40.0',
   default_options: [

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -11,7 +11,7 @@ Summary:	gstremaer plugins for neural networks
 # 3. Android: ./jni/Android*.mk
 # 4. Meson  : ./meson.build
 Version:	0.1.2
-Release:	0
+Release:	1
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1
@@ -231,6 +231,9 @@ popd
 %{_prefix}/lib/nnstreamer/customfilters/*.so
 
 %changelog
+* Wed Mar 20 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 0.1.2
+
 * Mon Feb 25 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.1.1
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -10,8 +10,8 @@ Summary:	gstremaer plugins for neural networks
 # 2. Tizen  : ./packaging/nnstreamer.spec
 # 3. Android: ./jni/Android*.mk
 # 4. Meson  : ./meson.build
-Version:	0.1.2
-Release:	1
+Version:	0.1.3
+Release:	0
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1


### PR DESCRIPTION
This is a release of nnstreamer 0.1.2 per NNStreamer Summit 5, https://github.com/nnsuite/nnstreamer/wiki/NNStreamer-Mini-Summit-%235

After this, nnstreamer 0.1.3 RC development starts.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>