### PR TITLE
[Test/RepoRnn] handle the uninitialized output buffer

### DIFF
--- a/nnstreamer_example/custom_example_RNN/dummy_RNN.c
+++ b/nnstreamer_example/custom_example_RNN/dummy_RNN.c
@@ -135,6 +135,8 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
   if (!in0 || !in1 || !out)
     return -EINVAL;
 
+  memset (out, 0, output[0].size);
+
   for (h = 0; h < 4; h++) {
     w = 0;
     memcpy (&(out[location (0, w, h)]), &(in0[location (0, w, h)]), TSIZE);


### PR DESCRIPTION
In Tizen, this uninitialized output buffer sometimes causes a wrong result

It fixes #1247 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

