### PR TITLE
[Dist] Do not depend on ssat if it's not needed.

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -66,7 +66,9 @@ BuildRequires:	gst-plugins-base-devel
 %endif
 
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
+%if 0%{?unit_test}
 BuildRequires: ssat
+%endif
 
 # For ORC (Oil Runtime Compiler)
 BuildRequires: orc-devel


### PR DESCRIPTION
ssat is required only when unit_test is enabled.
We are not going to enable auto-unit-test in Tizen:Unified.

We will execute auto-unit-test only in Github-CI and
personal gbs for now.
We will enable auto-unit-test in Tizen:Unified after
we submit ssat to tizen.org

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
