### PR TITLE
[Tizen/API] Add testcases for "valve", fix newly-found bugs from the new testcases.

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -200,7 +200,14 @@ DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
 # Intentionally excluded directories are:
 #
 # tests: We are not going to show testcoverage of the test code itself or example applications
-    $(pwd)/tests/unittestcoverage.py module $(pwd)/gst $(pwd)/ext
+
+%if %{with tizen}
+%define testtarget $(pwd)/tizen-api
+%else
+%define testtarget
+%endif
+
+    $(pwd)/tests/unittestcoverage.py module $(pwd)/gst $(pwd)/ext %testtarget
 
 # Get commit info
     VCS=`cat ${RPM_SOURCE_DIR}/nnstreamer.spec | grep "^VCS:" | sed "s|VCS:\\W*\\(.*\\)|\\1|"`

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -10,6 +10,7 @@
 #include <tizen-api.h>
 #include <gtest/gtest.h>
 #include <glib.h>
+#include <glib/gstdio.h> /* GStatBuf */
 
 /**
  * @brief Test NNStreamer pipeline construct & destruct
@@ -58,7 +59,7 @@ TEST (nnstreamer_capi_construct_destruct, dummy_03)
  */
 TEST (nnstreamer_capi_playstop, dummy_01)
 {
-  const char *pipeline = "videotestsrc is-live=true num-buffers=30 framerate=60/1 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
+  const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
   nns_pipeline_h handle;
   nns_pipeline_state state;
   int status = nns_pipeline_construct (pipeline, &handle);
@@ -86,6 +87,125 @@ TEST (nnstreamer_capi_playstop, dummy_01)
 
   status = nns_pipeline_destroy (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
+}
+
+
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_playstop, dummy_02)
+{
+  const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
+  nns_pipeline_h handle;
+  nns_pipeline_state state;
+  int status = nns_pipeline_construct (pipeline, &handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_start (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
+  EXPECT_NE (state, NNS_PIPELINE_NULL);
+
+  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_EQ (state, NNS_PIPELINE_PLAYING);
+
+  status = nns_pipeline_stop (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  g_usleep(50000); /* 50ms. Let a few frames flow. */
+
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
+
+  /* Resume playing */
+  status = nns_pipeline_start (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
+  EXPECT_NE (state, NNS_PIPELINE_NULL);
+
+  g_usleep(50000); /* 50ms. Enough to empty the queue */
+  status = nns_pipeline_stop (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+  EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
+
+  status = nns_pipeline_destroy (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+}
+
+/**
+ * @brief Test NNStreamer pipeline construct & destruct
+ */
+TEST (nnstreamer_capi_valve, test01)
+{
+  const gchar *_tmpdir = g_get_tmp_dir();
+  const gchar *_dirname = "nns-tizen-XXXXXX";
+  gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
+  gchar *dir = g_mkdtemp((gchar *) fullpath);
+  gchar *file1 = g_build_path("/", dir, "valve1", NULL);
+  gchar *pipeline = g_strdup_printf("videotestsrc is-live=true num-buffers=20 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=60/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
+    file1);
+  GStatBuf buf;
+
+  nns_pipeline_h handle;
+  nns_pipeline_state state;
+  nns_valve_h valve1;
+
+  int status = nns_pipeline_construct (pipeline, &handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  EXPECT_TRUE (dir != NULL);
+
+  status = nns_pipeline_valve_gethandle (handle, "valve1", &valve1);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_start (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_valve_control (valve1, 1); /* close */
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_getstate(handle, &state);
+  EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
+  EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
+  EXPECT_NE (state, NNS_PIPELINE_NULL);
+
+  g_usleep(100000); /* 100ms. Let a few frames flow. */
+  status = nns_pipeline_stop (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = g_lstat (file1, &buf);
+  EXPECT_EQ (status, 0);
+  EXPECT_EQ (buf.st_size, 0);
+
+  status = nns_pipeline_start (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_valve_control (valve1, 0); /* open */
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+
+  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  status = nns_pipeline_stop (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = nns_pipeline_destroy (handle);
+  EXPECT_EQ (status, NNS_ERROR_NONE);
+
+  status = g_lstat (file1, &buf);
+  EXPECT_EQ (status, 0);
+  EXPECT_GE (buf.st_size, 2048); /* At least two frames during 50ms */
+  EXPECT_LE (buf.st_size, 4096); /* At most four frames during 50ms */
+
+  g_free (fullpath);
+  g_free (file1);
+  g_free (pipeline);
 }
 
 /**

--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -437,9 +437,7 @@ nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state * state)
     return NNS_ERROR_INVALID_PARAMETER;
 
   g_mutex_lock (&p->lock);
-  scret =
-      gst_element_get_state (p->element, &_state, &pending,
-      GST_CLOCK_TIME_NONE);
+  scret = gst_element_get_state (p->element, &_state, &pending, 100000UL);      /* Do it within 100us! */
   g_mutex_unlock (&p->lock);
 
   if (scret == GST_STATE_CHANGE_FAILURE)


### PR DESCRIPTION
>   [Test/Unit-test-coverage] Add Tizen/API into unittest coverage
    
    Count test-coverage of Tizen/API.
    
>   [Test:Tizen/API] Test "valve" control Tizen APIs
    
    Test if frames flow only when valve is opened.
    

>   [Tizen/API] Bugfix on object unref, get_state
    
    1. Unref'ing caps should use gst_caps_unref, not gst_object_unref/g_object_unref.
    2. gst_state should not wait indefinitely. Let's give 100us as the "deadline".
    


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
