### PR TITLE
[YOCTO] Modified unittest directory for installation & runn @open sesame 04/01 10:54

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,8 @@ subplugin_install_prefix = join_paths(nnstreamer_prefix, 'lib', 'nnstreamer')
 filter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'filters')
 decoder_subplugin_install_dir = join_paths(subplugin_install_prefix, 'decoders')
 customfilter_install_dir = join_paths(subplugin_install_prefix, 'customfilters')
+unittest_install_dir = join_paths(subplugin_install_prefix, 'unittest')
+
 
 nnstreamer_conf.set('PREFIX', nnstreamer_prefix)
 nnstreamer_conf.set('EXEC_PREFIX', nnstreamer_bindir)
@@ -106,6 +108,7 @@ endif
 
 # Tensorflow-lite
 have_tensorflow_lite = false
+install_test=false
 
 if get_option('enable-tensorflow-lite')
   tflite_dep = dependency('tensorflow-lite', required: true)
@@ -136,6 +139,9 @@ endif
 
 # Build unittests
 if get_option('enable-test')
+  if get_option('install-test')
+    install_test=true
+  endif
   subdir('tests')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('enable-test', type: 'boolean', value: true)
+option('install-test', type: 'boolean', value: false)
 option('enable-opencv-test', type: 'boolean', value: true)
 option('enable-tensorflow-lite', type: 'boolean', value: true)
 option('enable-tensorflow', type: 'boolean', value: true)

--- a/nnstreamer_example/meson.build
+++ b/nnstreamer_example/meson.build
@@ -3,6 +3,17 @@ subdir('custom_example_scaler')
 subdir('custom_example_average')
 if get_option('enable-opencv-test')
    subdir('custom_example_opencv')
+   sed=find_program('sed')
+   r = run_command(sed,'-i', 's|^TEST_OPENCV=.*|TEST_OPENCV=\"YES\"|g', meson.source_root()+'/tests/nnstreamer_filter_custom/runTest.sh')
+   if r.returncode() != 0
+      message('ERROR: Cannot Convert ${TEST_OEPNCV} to "YES"')
+   endif
+else
+   sed=find_program('sed')
+   r = run_command(sed,'-i', 's|^TEST_OPENCV=.*|TEST_OPENCV=\"NO\"|g', meson.source_root()+'/tests/nnstreamer_filter_custom/runTest.sh')
+   if r.returncode() != 0
+      message('ERROR: Cannot Convert ${TEST_OEPNCV} to "NO"')
+   endif
 endif
 subdir('custom_example_RNN')
 subdir('custom_example_LSTM')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -15,13 +15,15 @@ library('tensorscheck',
 library('nnscustom_framecounter',
   join_paths('nnstreamer_sink', 'nnscustom_framecounter.c'),
   dependencies: [glib_dep, nnstreamer_dep],
-  install: false
+  install: install_test,
+  install_dir: customfilter_install_dir
 )
 
 library('nnscustom_drop_buffer',
   join_paths('nnstreamer_sink', 'nnscustom_drop_buffer.c'),
   dependencies: [nnstreamer_dep],
-  install: false
+  install: install_test,
+  install_dir: customfilter_install_dir
 )
 
 # Build and copy exe for ssat
@@ -30,7 +32,8 @@ if libpng_dep.found()
   b2p = executable('bmp2png',
     'bmp2png.c',
     dependencies: [libpng_dep],
-    install: false
+    install: install_test,
+    install_dir: unittest_install_dir
   )
 
   copy = find_program('cp')
@@ -46,7 +49,8 @@ endif
 executable('unittest_repo',
   join_paths('nnstreamer_repo_dynamicity', 'tensor_repo_dynamic_test.c'),
   dependencies: [nnstreamer_dep, gst_dep, glib_dep],
-  install: false
+  install: install_test,
+  install_dir: unittest_install_dir
 )
 
 # gtest
@@ -64,7 +68,8 @@ if gtest_dep.found()
   unittest_common = executable('unittest_common',
     join_paths('common', 'unittest_common.cpp'),
     dependencies: [nnstreamer_unittest_deps],
-    install: false
+    install: install_test,
+    install_dir: unittest_install_dir
   )
 
   test('unittest_common', unittest_common)
@@ -73,7 +78,8 @@ if gtest_dep.found()
   unittest_sink = executable('unittest_sink',
     join_paths('nnstreamer_sink', 'unittest_sink.cpp'),
     dependencies: [nnstreamer_unittest_deps],
-    install: false
+    install: install_test,
+    install_dir: unittest_install_dir
   )
 
   test('unittest_sink', unittest_sink, args: ['--gst-plugin-path=..'])
@@ -82,7 +88,8 @@ if gtest_dep.found()
   unittest_plugins = executable('unittest_plugins',
     join_paths('nnstreamer_plugins', 'unittest_plugins.cpp'),
     dependencies: [nnstreamer_unittest_deps],
-    install: false
+    install: install_test,
+    install_dir: unittest_install_dir
   )
 
   test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
@@ -91,7 +98,8 @@ if gtest_dep.found()
   unittest_src_iio = executable('unittest_src_iio',
     join_paths('nnstreamer_source', 'unittest_src_iio.cpp'),
     dependencies: [nnstreamer_unittest_deps],
-    install: false
+    install: install_test,
+    install_dir: unittest_install_dir
   )
 
   test('unittest_src_iio', unittest_src_iio, args: ['--gst-plugin-path=..'])

--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -20,6 +20,8 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
+TEST_OPENCV="NO"
+
 if [ "$SKIPGEN" == "YES" ]
 then
   echo "Test Case Generation Skipped"
@@ -34,7 +36,12 @@ gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40
 
 
 # Test constant passthrough custom filter (1, 2)
-PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so"
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so"
+else
+    PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough.so"
+fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" input=\"3:280:40\" inputtype=\"uint8\" output=\"3:280:40\" outputtype=\"uint8\" ! filesink location=\"testcase01.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase01.direct.log\" sync=true" 1 0 0 $PERFORMANCE
 
@@ -46,7 +53,12 @@ callCompareTest testcase02.direct.log testcase02.passthrough.log 2 "Compare 2" 0
 
 
 # Test variable-dim passthrough custom filter (3, 4)
-PATH_TO_MODEL_V="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so"
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    PATH_TO_MODEL_V="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so"
+else
+    PATH_TO_MODEL_V="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough_variable.so"
+fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_V}\" input=\"3:640:480\" inputtype=\"uint8\" output=\"3:640:480\" outputtype=\"uint8\" ! filesink location=\"testcase03.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.log\" sync=true" 3 0 0 $PERFORMANCE
 
@@ -63,8 +75,12 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tee name=t ! 
 callCompareTest testcase04.tensors.direct.log testcase04.tensors.passthrough.log 4-4 "Compare 4-4" 0 0
 
 # Test scaler (5, 6, 7)
-PATH_TO_MODEL_S="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler.so"
-
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    PATH_TO_MODEL_S="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler.so"
+else
+    PATH_TO_MODEL_S="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler.so"
+fi
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_S}\" ! filesink location=\"testcase05.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5 0 0 $PERFORMANCE
 callCompareTest testcase05.direct.log testcase05.passthrough.log 5 "Compare 5" 0 0
 
@@ -77,7 +93,13 @@ python checkScaledTensor.py testcase07.direct.log 640 480 testcase07.scaled.log 
 testResult $? 7 "Golden test comparison" 0 1
 
 # Test average (8)
-PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+else
+    PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
+fi
+
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase08.average.log\" sync=true t. ! queue ! filesink location=\"testcase08.direct.log\" sync=true" 8 0 0 $PERFORMANCE
 
 # Apply average to stream (9)
@@ -89,34 +111,60 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 
 
 # Test scaler + in-invoke allocator (11)
-PATH_TO_MODEL_SI="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler_allocator.so"
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    PATH_TO_MODEL_SI="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler_allocator.so"
+else
+    PATH_TO_MODEL_SI="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler_allocator.so"
+fi
+
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_SI}\" custom=\"320x240\" ! filesink location=\"testcase11.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase11.direct.log\" sync=true" 11 0 0 $PERFORMANCE
 python checkScaledTensor.py testcase11.direct.log 640 480 testcase11.scaled.log 320 240 3
 testResult $? 11 "Golden test comparison" 0 1
 
 # OpenCV Test
 # Test scaler using OpenCV (12, 13, 14)
-PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.so"
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"640x480\" ! filesink location=\"testcase12.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase12.direct.log\" sync=true" 12 0 0 $PERFORMANCE
-callCompareTest testcase12.direct.log testcase12.passthrough.log 12 "Compare 12" 0 0
+if [ "$TEST_OPENCV" == "YES" ]
+then
+    if [[ -z "${CUSTOMLIB_DIR// }" ]]
+    then
+	PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.so"
+    else
+	PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_scaler.so"
+    fi
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"320x240\" ! filesink location=\"testcase13.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase13.direct.log\" sync=true" 13 0 0 $PERFORMANCE
-python checkScaledTensor.py testcase13.direct.log 640 480 testcase13.scaled.log 320 240 3
-testResult $? 13 "Golden test comparison" 0 1
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"640x480\" ! filesink location=\"testcase12.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase12.direct.log\" sync=true" 12 0 0 $PERFORMANCE
+    callCompareTest testcase12.direct.log testcase12.passthrough.log 12 "Compare 12" 0 0
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"1920x1080\" ! filesink location=\"testcase14.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase14.direct.log\" sync=true" 14 0 0 $PERFORMANCE
-python checkScaledTensor.py testcase14.direct.log 640 480 testcase14.scaled.log 1920 1080 3
-testResult $? 14 "Golden test comparison" 0 1
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"320x240\" ! filesink location=\"testcase13.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase13.direct.log\" sync=true" 13 0 0 $PERFORMANCE
+    python checkScaledTensor.py testcase13.direct.log 640 480 testcase13.scaled.log 320 240 3
+    testResult $? 13 "Golden test comparison" 0 1
 
-# Test average using OpenCV (15)
-# custom version
-PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.average.log\" sync=true" 15 0 0 $PERFORMANCE
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"1920x1080\" ! filesink location=\"testcase14.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase14.direct.log\" sync=true" 14 0 0 $PERFORMANCE
+    python checkScaledTensor.py testcase14.direct.log 640 480 testcase14.scaled.log 1920 1080 3
+    testResult $? 14 "Golden test comparison" 0 1
 
-# OpenCV version
-PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.so"
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.opencv.average.log\" sync=true" 15 0 0 $PERFORMANCE
+    # Test average using OpenCV (15)
+    # custom version
+    if [[ -z "${CUSTOMLIB_DIR// }" ]]
+    then
+	PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+    else
+	PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
+    fi
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.average.log\" sync=true" 15 0 0 $PERFORMANCE
 
-callCompareTest testcase15.opencv.average.log testcase15.average.log 15 "Compare 15" 0 0
+    # OpenCV version
+    if [[ -z "${CUSTOMLIB_DIR// }" ]]
+    then
+	PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.so"
+    else
+	PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_average.so"
+    fi
+
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.opencv.average.log\" sync=true" 15 0 0 $PERFORMANCE
+
+    callCompareTest testcase15.opencv.average.log testcase15.average.log 15 "Compare 15" 0 0
+fi
 
 report

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -121,7 +121,7 @@ TEST (test_tensor_transform, properties)
   gint res_mode;
   gchar *res_option = NULL;
   gboolean silent, res_silent;
-  gboolean accl, res_accl;
+  gboolean accl;
   GstHarness *hrnss;
   GstElement *transform;
 
@@ -150,9 +150,11 @@ TEST (test_tensor_transform, properties)
   g_object_get (transform, "acceleration", &accl, NULL);
   EXPECT_EQ (default_accl, accl);
 
+#ifdef HAVE_ORC
   g_object_set (transform, "acceleration", !default_accl, NULL);
-  g_object_get (transform, "acceleration", &res_accl, NULL);
-  EXPECT_EQ (!default_accl, res_accl);
+  g_object_get (transform, "acceleration", &accl, NULL);
+  EXPECT_EQ (!default_accl, accl);
+#endif
 
   /** We do not need to test setting properties for 'mode' and 'option' */
   g_object_get (transform, "mode", &res_mode, NULL);

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -31,7 +31,14 @@ else
 fi
 convertBMP2PNG
 
-../../build/tests/unittest_repo --gst-plugin-path=../../build
+if [[ -z "${UNITTEST_DIR// }" ]]
+then
+    TESTBINDIR="../../build/tests/"
+else
+    TESTBINDIR="${UNITTEST_DIR}"
+fi
+
+${TESTBINDIR}/unittest_repo --gst-plugin-path=../../build
 
 callCompareTest testsequence_1.golden tensorsequence01_1.log 1-1 "Compare 1-1" 1 0
 callCompareTest testsequence_2.golden tensorsequence01_2.log 1-2 "Compare 1-2" 1 0

--- a/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
+++ b/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
@@ -92,9 +92,8 @@ switch_slot_index (GstElement * tensor_repo)
 int
 main (int argc, char *argv[])
 {
-  GstElement *pipeline, *multifilesrc, *pngdec, *tensor_converter,
-      *tensor_reposink;
-  GstElement *tensor_reposrc, *multifilesink;
+  GstElement *pipeline, *multifilesrc, *pngdec, *tensor_converter;
+  GstElement *tensor_reposrc, *tensor_reposink, *multifilesink, *queue;
   GstBus *bus;
   GstCaps *msrc_cap, *reposrc_cap;
 
@@ -116,6 +115,8 @@ main (int argc, char *argv[])
 
   tensor_converter =
       gst_element_factory_make ("tensor_converter", "tensor_converter");
+
+  queue = gst_element_factory_make ("queue", "queue");
 
   tensor_reposink =
       gst_element_factory_make ("tensor_reposink", "tensor_reposink");
@@ -140,11 +141,12 @@ main (int argc, char *argv[])
       "tensorsequence01_%1d.log", NULL);
 
   gst_bin_add_many (GST_BIN (pipeline), multifilesrc, pngdec, tensor_converter,
-      tensor_reposink, tensor_reposrc, multifilesink, NULL);
+      queue, tensor_reposink, tensor_reposrc, multifilesink, NULL);
 
   gst_element_link (multifilesrc, pngdec);
   gst_element_link (pngdec, tensor_converter);
-  gst_element_link (tensor_converter, tensor_reposink);
+  gst_element_link (tensor_converter, queue);
+  gst_element_link (queue, tensor_reposink);
   gst_element_link (tensor_reposrc, multifilesink);
 
   bus = gst_pipeline_get_bus (GST_PIPELINE (pipeline));

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -35,10 +35,17 @@ then
 fi
 testInit $1 # You may replace this with Test Group Name
 
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    LSTM_DIR="../../build/nnstreamer_example/custom_example_LSTM"
+else
+    LSTM_DIR="${CUSTOMLIB_DIR}"
+fi
+
 # Generate video_4x4xBGRx.xraw & golden
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=../../build/nnstreamer_example/custom_example_LSTM/libdummyLSTM.so ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${LSTM_DIR}/libdummyLSTM.so ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest lstm.golden out_9.log 1-1 "Compare 1-1" 1 0
 

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -17,10 +17,17 @@ then
 fi
 testInit $1 # You may replace this with Test Group Name
 
+if [[ -z "${CUSTOMLIB_DIR// }" ]]
+then
+    RNN_DIR="../../build/nnstreamer_example/custom_example_RNN"
+else
+    RNN_DIR="${CUSTOMLIB_DIR}"
+fi
+
 # Generate video_4x4xBGRx.xraw
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=../../build/nnstreamer_example/custom_example_RNN/libdummyRNN.so ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${RNN_DIR}/libdummyRNN.so ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest rnn.golden out_9.log 1-1 "Compare 1-1" 1 0
 

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -36,6 +36,8 @@
     goto error; \
   }
 
+gchar *custom_dir;
+
 /**
  * @brief Current status.
  */
@@ -659,26 +661,26 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_filter framework=custom model=./nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink",
-          option.num_buffers);
+          "tensor_converter ! tensor_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink",
+	   option.num_buffers, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough");
       break;
     case TEST_TYPE_CUSTOM_TENSORS:
       /** other/tensors with tensormux, passthrough custom filter */
       str_pipeline =
           g_strdup_printf
-          ("tensor_mux name=mux ! tensor_filter framework=custom model=./nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink "
+          ("tensor_mux name=mux ! tensor_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink "
           "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=120,height=80,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_1 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=64,height=48,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_2",
-          option.num_buffers, option.num_buffers, option.num_buffers);
+	   custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough" , option.num_buffers, option.num_buffers, option.num_buffers);
       break;
     case TEST_TYPE_CUSTOM_BUF_DROP:
       /* audio stream to test buffer-drop using custom filter */
       str_pipeline =
           g_strdup_printf
           ("audiotestsrc num-buffers=%d samplesperbuffer=200 ! audioconvert ! audio/x-raw,format=S16LE,rate=16000,channels=1 ! "
-          "tensor_converter frames-per-tensor=200 ! tensor_filter framework=custom model=./tests/libnnscustom_drop_buffer.so ! tensor_sink name=test_sink",
-          option.num_buffers);
+          "tensor_converter frames-per-tensor=200 ! tensor_filter framework=custom model=%s/libnnscustom_drop_buffer.so ! tensor_sink name=test_sink",
+	   option.num_buffers, custom_dir? custom_dir :"./tests");
       break;
     case TEST_TYPE_NEGO_FAILED:
       /** caps negotiation failed */
@@ -750,65 +752,65 @@ _setup_pipeline (TestOption & option)
       /** 4x4 tensor stream, different FPS, tensor_mux them @ slowest */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=slowest name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_mux sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_4:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       /** @todo Because of the bug mentioned in #739, this is not registered as gtest case, yet */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=1:1000000000 name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=1:1000000000 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_1:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ slowest */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=slowest name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=./tests/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-          option.num_buffers * 10, option.num_buffers * 25, option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
       break;
     /** @todo Add tensor_mux policy = more policies! */
     case TEST_TYPE_DECODER_PROPERTY:
@@ -4071,6 +4073,14 @@ int
 main (int argc, char **argv)
 {
   testing::InitGoogleTest (&argc, argv);
+  int optind;
+  for(optind = 1; optind < argc && argv[optind][0] == '-'; optind++){
+    switch(argv[optind][1]){
+    case 'd': custom_dir=g_strdup(argv[optind+1]); break;
+    default:
+      break;
+    }
+  }
 
   gst_init (&argc, &argv);
 


### PR DESCRIPTION
# PR Description
Because there are test cases incluiding absolute path for library, it
is hard to run unit testcases after installation. In this PR, these
testcases and nnstreamer_example libraries are installed
/usr/lib/nnstreamer/unittest. For the nnstreamer_example, libraries
are in /usr/lib/nnstreamer/unittest/nnstreamer_exampls, and For the
tests, they are installed in /usr/lib/nnstreamer/unittest/tests.
Some unittest executions (unittest_repo, unittest_sink,
unittest_common, unittest_plugins) are installed in
/usr/lib/nnstreamer/unittest.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
