### PR TITLE
 [Filter/Tensorflow] fix bug of testcase

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -90,7 +90,7 @@ private:
   Session *session;
 
   tensor_type getTensorTypeFromTF (DataType tfType);
-  TF_DataType getTensorTypeToTF_Capi (tensor_type tType);
+  gboolean getTensorTypeToTF_Capi (tensor_type tType, TF_DataType * tf_type);
   int validateInputTensor (const GraphDef &graph_def);
   int validateOutputTensor (const std::vector <Tensor> &outputs);
 };


### PR DESCRIPTION
Since the `STRING` input tensors should be processed differently(cannot be done with `C_API`),
the logic was fixed.

it resolves #1269 

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

