### PR TITLE
lcov: Changed the default time zone from UTC to KST

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -206,7 +206,9 @@ DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
 %else
 %define testtarget
 %endif
-
+    # 'lcov' generates the date format with UTC time zone by default. Let's replace UTC with KST.
+    # If you ccan get a root privilege, run ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime
+    TZ='Asia/Seoul'; export TZ
     $(pwd)/tests/unittestcoverage.py module $(pwd)/gst $(pwd)/ext %testtarget
 
 # Get commit info


### PR DESCRIPTION
Fixed the issue #1193 and #1275 finally.
https://github.com/nnsuite/nnstreamer/issues/1193#issuecomment-469635177
https://github.com/nnsuite/nnstreamer/issues/1275

This commit is to replace UTC with KST by default in order to display the date format
with Seoul time.  The 'lcov' generates the date format with UTC time zone by default.
So, let's replace UTC with KST.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---