### PR TITLE
[README] Add a badge for displaying status of code coverage @open sesame 3/29 08:30 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NNStreamer
 
-[![Gitter][gitter-image]][gitter-url]
+[![Gitter][gitter-image]][gitter-url] [![Code Coverage](http://nnsuite.mooo.com/nnstreamer/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer/ci/gcov_html/index.html)
 
 Neural Network Support as Gstreamer Plugins.
 


### PR DESCRIPTION
This patch adds a badge that displays code coverage status to the main page of github, i.e., README.md.

Signed-off-by: Wook Song <wook16.song@samsung.com>