### PR TITLE
[IIO] restore iio device on _stop() @open sesame 4/2 15:17

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -383,6 +383,9 @@ gst_tensor_src_iio_init (GstTensorSrcIIO * self)
   self->merge_channels_data = DEFAULT_MERGE_CHANNELS;
   self->is_tensor = FALSE;
   self->tensors_config = NULL;
+  self->default_sampling_frequency = 0;
+  self->default_buffer_capacity = 0;
+  self->default_trigger = NULL;
 
   /**
    * format of the source since IIO device as a source is live and operates
@@ -733,9 +736,11 @@ gst_tensor_src_iio_get_all_channel_info (GstTensorSrcIIO * self,
       g_free (file_contents);
       if (value == 1) {
         channel_prop->enabled = TRUE;
+        channel_prop->pre_enabled = TRUE;
         num_channels_enabled += 1;
       } else if (value == 0) {
         channel_prop->enabled = FALSE;
+        channel_prop->pre_enabled = FALSE;
       } else {
         GST_ERROR_OBJECT
             (self,
@@ -1254,6 +1259,8 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
   gchar *dirname = NULL;
   gchar *filename = NULL;
   gint num_channels_enabled;
+  gchar *file_contents = NULL;
+  gsize length = 0;
 
   /** Find the device */
   id = gst_tensor_src_iio_get_id_by_name (IIO_BASE_DIR, self->device.name,
@@ -1302,6 +1309,14 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
     self->trigger.base_dir = g_build_filename (IIO_BASE_DIR, dirname, NULL);
     g_free (dirname);
 
+    /** get the default trigger, if any */
+    filename =
+        g_build_filename (self->device.base_dir, TRIGGER, CURRENT_TRIGGER,
+        NULL);
+    if (!g_file_get_contents (filename, &self->default_trigger, NULL, NULL)) {
+      GST_WARNING_OBJECT (self, "Unable to read default set trigger.");
+    }
+    g_free (filename);
     /** set the trigger */
     filename = g_build_filename (TRIGGER, CURRENT_TRIGGER, NULL);
     if (G_UNLIKELY (!gst_tensor_write_sysfs_string (self, filename,
@@ -1327,12 +1342,23 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
     /** if sampling frequency file does not exist, no error */
     GST_WARNING_OBJECT (self, "Cannot verify against sampling frequency list.");
   } else {
-    /** check if sampling frequency can be set */
     filename =
         g_build_filename (self->device.base_dir, SAMPLING_FREQUENCY, NULL);
+    /** check if sampling frequency can be set */
     if (!g_file_test (filename, G_FILE_TEST_IS_REGULAR)) {
       GST_WARNING_OBJECT (self, "Cannot set sampling frequency.");
+      g_free (filename);
     } else {
+      /** store the default frequency */
+      if (!g_file_get_contents (filename, &file_contents, &length, NULL)) {
+        GST_WARNING_OBJECT (self, "Unable to read default sampling frequency.");
+      } else if (file_contents != NULL) {
+        self->default_sampling_frequency =
+            g_ascii_strtoull (file_contents, NULL, 10);
+      }
+      g_free (file_contents);
+      g_free (filename);
+
       self->sampling_frequency = sampling_frequency;
       /** interface of frequency is kept long for outside but uint64 inside */
       gchar *sampling_frequency_char =
@@ -1347,11 +1373,19 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
       }
       g_free (sampling_frequency_char);
     }
-    g_free (filename);
   }
 
   /** once all these are set, set the buffer related thingies */
   dirname = g_build_filename (self->device.base_dir, BUFFER, NULL);
+  filename = g_build_filename (dirname, "length", NULL);
+  if (!g_file_get_contents (filename, &file_contents, &length, NULL)) {
+    GST_WARNING_OBJECT (self, "Unable to read default buffer capacity.");
+  } else if (file_contents != NULL && length > 0) {
+    self->default_buffer_capacity = g_ascii_strtoull (file_contents, NULL, 10);
+  }
+  g_free (file_contents);
+  g_free (filename);
+
   if (G_UNLIKELY (!gst_tensor_write_sysfs_int (self, "length", dirname,
               self->buffer_capacity))) {
     GST_ERROR_OBJECT (self,
@@ -1449,7 +1483,9 @@ error_channels_free:
 
 error_trigger_free:
   g_free (self->trigger.base_dir);
+  g_free (self->default_trigger);
   self->trigger.base_dir = NULL;
+  self->default_trigger = NULL;
 
 error_device_free:
   g_free (self->device.base_dir);
@@ -1459,6 +1495,63 @@ error_return:
   /** complete the start of the base src */
   gst_base_src_start_complete (src, GST_FLOW_ERROR);
   return FALSE;
+}
+
+/**
+ * @brief restore the iio device to its original device.
+ */
+static void
+gst_tensor_src_restore_iio_device (GstTensorSrcIIO * self)
+{
+  GList *ch_list;
+  gchar *filename = NULL, *dirname = NULL, *file_contents = NULL;
+  GstTensorSrcIIOChannelProperties *channel_prop = NULL;
+
+  /** disable the buffer */
+  dirname = g_build_filename (self->device.base_dir, BUFFER, NULL);
+  if (G_UNLIKELY (!gst_tensor_write_sysfs_int (self, "enable", dirname, 0))) {
+    GST_ERROR_OBJECT (self,
+        "Error in disabling the IIO device buffer for device: %s.\n",
+        self->device.name);
+  }
+  g_free (dirname);
+
+  /** reset enabled channels */
+  for (ch_list = self->channels; ch_list != NULL; ch_list = ch_list->next) {
+    channel_prop = (GstTensorSrcIIOChannelProperties *) ch_list->data;
+    filename = g_strdup_printf ("%s%s", channel_prop->name, EN_SUFFIX);
+    gst_tensor_write_sysfs_int (self, filename, channel_prop->base_dir,
+        (int) channel_prop->pre_enabled);
+    g_free (filename);
+  }
+
+  /** reset sampling_frequency */
+  if (self->default_sampling_frequency > 0) {
+    /** converting to long as setting interface to device */
+    file_contents =
+        g_strdup_printf ("%lu", (gulong) self->default_sampling_frequency);
+    gst_tensor_write_sysfs_string (self, "sampling_frequency",
+        self->device.base_dir, file_contents);
+    g_free (file_contents);
+  }
+
+  /** reset buffer_capacity */
+  dirname = g_build_filename (self->device.base_dir, BUFFER, NULL);
+  if (self->default_buffer_capacity > 0) {
+    gst_tensor_write_sysfs_int (self, "length", dirname,
+        self->default_buffer_capacity);
+  } else {
+    gst_tensor_write_sysfs_string (self, "length", dirname, "");
+  }
+  g_free (dirname);
+
+  /** reset current trigger */
+  if (self->default_trigger != NULL) {
+    filename = g_build_filename (TRIGGER, CURRENT_TRIGGER, NULL);
+    gst_tensor_write_sysfs_string (self, filename, self->device.base_dir,
+        self->default_trigger);
+    g_free (filename);
+  }
 }
 
 /**
@@ -1473,14 +1566,8 @@ gst_tensor_src_iio_stop (GstBaseSrc * src)
 
   self->configured = FALSE;
 
-  /** disable the buffer */
-  gchar *dirname = g_build_filename (self->device.base_dir, BUFFER, NULL);
-  if (G_UNLIKELY (!gst_tensor_write_sysfs_int (self, "enable", dirname, 0))) {
-    GST_ERROR_OBJECT (self,
-        "Error in disabling the IIO device buffer for device: %s.\n",
-        self->device.name);
-  }
-  g_free (dirname);
+  /** restore the iio device */
+  gst_tensor_src_restore_iio_device (self);
 
   g_free (self->buffer_data_fp);
   fclose (self->buffer_data_file);
@@ -1492,7 +1579,9 @@ gst_tensor_src_iio_stop (GstBaseSrc * src)
   self->channels = NULL;
 
   g_free (self->trigger.base_dir);
+  g_free (self->default_trigger);
   self->trigger.base_dir = NULL;
+  self->default_trigger = NULL;
 
   g_free (self->device.base_dir);
   self->device.base_dir = NULL;

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.h
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.h
@@ -82,6 +82,7 @@ typedef struct _GstTensorSrcIIODeviceProperties
 typedef struct _GstTensorSrcIIOChannelProperties
 {
   gboolean enabled; /**< currently state enabled/disabled */
+  gboolean pre_enabled; /**< already in enabled/disabled state */
   gchar *name; /**< The name of the channel */
   gchar *generic_name; /**< The generic name of the channel */
   gchar *base_dir; /**< The base directory for the channel */
@@ -127,6 +128,10 @@ struct _GstTensorSrcIIO
   gboolean is_tensor; /**< False if tensors is used for data */
   guint buffer_capacity; /**< size of the buffer */
   guint64 sampling_frequency; /**< sampling frequncy for the device */
+
+  guint64 default_sampling_frequency; /**< default set value of sampling frequency */
+  guint default_buffer_capacity; /**< size of the buffer */
+  gchar *default_trigger; /**< default set value of sampling frequency */
 
   /** Only first element is filled when is_tensor is true */
   GstTensorsConfig *tensors_config; /**< tensors for storing data config */


### PR DESCRIPTION
restore the existing values of scan_channels_en, sampling_frequency,
buffer/length and current trigger (if exist) when stopping the element

**Related Issue**
#1199 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>