### PR TITLE
[IIO] Change functions used for byte order conversion

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -1748,11 +1748,11 @@ gst_tensor_src_iio_process_scanned_data (GList * channels, gchar * data,
       {
         guint16 value = *(guint16 *) (data + prop->location);
         if (prop->big_endian) {
-          value = be16toh (value);
+          value = GUINT16_FROM_BE (value);
           /** right shift the extra storage bits for big endian */
           value >>= (16 - prop->storage_bits);
         } else {
-          value = le16toh (value);
+          value = GUINT16_FROM_LE (value);
           /** mask out the extra storage bits for little endian */
           storage_mask = (G_GUINT64_CONSTANT (1) << prop->storage_bits) - 1;
           value &= storage_mask;
@@ -1767,11 +1767,11 @@ gst_tensor_src_iio_process_scanned_data (GList * channels, gchar * data,
       {
         guint32 value = *(guint32 *) (data + prop->location);
         if (prop->big_endian) {
-          value = be32toh (value);
+          value = GUINT32_FROM_BE (value);
           /** right shift the extra storage bits for big endian */
           value >>= (32 - prop->storage_bits);
         } else {
-          value = le32toh (value);
+          value = GUINT32_FROM_LE (value);
           /** mask out the extra storage bits for little endian */
           storage_mask = (G_GUINT64_CONSTANT (1) << prop->storage_bits) - 1;
           value &= storage_mask;
@@ -1790,11 +1790,11 @@ gst_tensor_src_iio_process_scanned_data (GList * channels, gchar * data,
       {
         guint64 value = *(guint64 *) (data + prop->location);
         if (prop->big_endian) {
-          value = be64toh (value);
+          value = GUINT64_FROM_BE (value);
           /** right shift the extra storage bits for big endian */
           value >>= (64 - prop->storage_bits);
         } else {
-          value = le64toh (value);
+          value = GUINT64_FROM_LE (value);
           /** mask out the extra storage bits for little endian */
           storage_mask = (G_GUINT64_CONSTANT (1) << prop->storage_bits) - 1;
           value &= storage_mask;


### PR DESCRIPTION
This PR partially resolves #1293 (the issue related to the byte order conversion functions only)

Without defining _BSD_SOURCE and __USE_BSD macros, the functions such as be16toh, le16toh, be32toh, le32toh, be64toh and le64toh are not compatible with c89. In order to fix this issue, this patch replaces such functions with byte order macros from glib-2.0.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped