### PR TITLE
[IIO] Removing fileno()

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.h
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.h
@@ -114,7 +114,6 @@ struct _GstTensorSrcIIO
   channels_enabled_options channels_enabled; /**< enabling which channels */
   guint scan_size; /**< size for a single scan of buffer length 1 */
   struct pollfd *buffer_data_fp; /**< pollfd for reading data buffer */
-  FILE *buffer_data_file; /**< file pointer for reading data buffer */
   guint num_channels_enabled; /**< channels to be enabled */
   gboolean merge_channels_data; /**< merge channel data with same type/size */
   gboolean is_tensor; /**< False if tensors is used for data */


### PR DESCRIPTION
Removed usage of fileno to file descriptor to compile without error with C89
as fileno() requires _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE

Using open() from fcntl directly instead of fopen() and fileno() combined
Resolves issue #1293

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>