### PR TITLE
[SVACE/414602] Fix 65505007 Warning

### DIFF
--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -242,7 +242,7 @@ main (int argc, char *argv[])
   height = *ptr16;
 
   /** Let's not accept BMP files larger than 10000 x 10000 (Fix Covertify Issue #1029514) */
-  if (width > 10000 || height > 10000) {
+  if (width > 10000 || height > 10000 || width < 4 || height < 4) {
     printf
         ("We do not accept BMP files with height or width larger than 10000.\n");
     fclose (bmpF);


### PR DESCRIPTION
Fix: WID:65505007 Integer value 'width * height' obtained from untrusted source at bmp2png.c:239 by passing as 1st parameter to function 'fread' at bmp2png.c:232 without checking its lower bound is used in a trusted operation at bmp2png.c:254 by calling function 'calloc'.

Add lower limits for height/width.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

