### PR TITLE
[SVACE/414609] Fix 65505016 Warning

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -245,7 +245,7 @@ loadImageLabels (bounding_boxes * data)
     GList *labels = NULL, *cursor;
 
     while ((read = getline (&line, &len, fp)) != -1) {
-      if (line) {
+      if (line && strlen (line) >= 1) {
         if (line[strlen (line) - 1] == '\n') {
           line[strlen (line) - 1] = '\0';
         }


### PR DESCRIPTION
Line 249 of tensordec-boundingbox.c has the following SVACE warning:

Warning Message
Possible integer underflow: left operand is tainted. An integer underflow may occur due to arithmetic operation (unsigned subtraction) between values { [0, 1073741823] } and '1', where the first value comes from the expression 'strlen(line)'

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
