### PR TITLE
[SVACE/414629] Check malloc return value.

### DIFF
--- a/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
+++ b/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
@@ -34,7 +34,7 @@ static void *
 pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
-
+  assert (data);
   data->id = 0;
   return data;
 }


### PR DESCRIPTION
If it's NULL, don't proceed:
Warning Message
Pointer 'data' returned from function 'malloc' at nnstreamer_customfilter_example_average.c:36 may be null, and it is dereferenced at nnstreamer_customfilter_example_average.c:38.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

