### PR TITLE
[SVACE/414655] Fix 65505049 Warning

### DIFF
--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -340,7 +340,7 @@ _push_text_data (const guint num_buffers, const gboolean timestamps = TRUE)
     GstMapInfo info;
 
     gst_buffer_map (buf, &info, GST_MAP_WRITE);
-    sprintf ((char *) info.data, "%d", i);
+    snprintf ((char *) info.data, 10, "%d", i);
     gst_buffer_unmap (buf, &info);
 
     if (timestamps) {


### PR DESCRIPTION
# PR Description

Line 343 of unittest_sink.cpp has svace warning:

WID:65505049 Use of vulnerable function 'sprintf' at
unittest_sink.cpp:343. For better security, VD recommends NOT to use
sprintf. Use snprintf instead.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
