### PR TITLE
[SVACE/414630] Check malloc return value

### DIFF
--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -43,6 +43,7 @@ static void *
 pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
+  assert (data);
 
   if (prop->custom_properties && strlen (prop->custom_properties) > 0)
     data->property = g_strdup (prop->custom_properties);


### PR DESCRIPTION
Do not proceed if malloc returns null:
Warning Message
Pointer 'data' returned from function 'malloc' at nnstreamer_customfilter_example_scaler.c:45 may be null, and it is dereferenced at nnstreamer_customfilter_example_scaler.c:48.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
