### PR TITLE
[SVACE/414631] Check malloc return value

### DIFF
--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
@@ -63,6 +63,7 @@ static void *
 pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
+  assert (data);
 
   if (prop->custom_properties && strlen (prop->custom_properties) > 0)
     data->property = g_strdup (prop->custom_properties);


### PR DESCRIPTION
Do not proceed if malloc returns null:
Warning Message
Pointer 'data' returned from function 'malloc' at nnstreamer_customfilter_example_scaler_allocator.c:65 may be null, and it is dereferenced at nnstreamer_customfilter_example_scaler_allocator.c:68.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
