### PR TITLE
[SVACE/414632] Check malloc return value

### DIFF
--- a/tests/nnstreamer_sink/nnscustom_framecounter.c
+++ b/tests/nnstreamer_sink/nnscustom_framecounter.c
@@ -94,6 +94,7 @@ static void *
 pt_init (const GstTensorFilterProperties * prop)
 {
   pt_data *data = (pt_data *) malloc (sizeof (pt_data));
+  assert (data);
   maxid = maxid + 1;
   data->id = maxid;
   data->counter = 0U;


### PR DESCRIPTION
Do not proceed if malloc returns null:
Warning Message
Pointer 'data' returned from function 'malloc' at nnscustom_framecounter.c:96 may be null, and it is dereferenced at nnscustom_framecounter.c:98.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
