### PR TITLE
[SVACE/414947] Fix 65505014 Warning

### DIFF
--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -355,6 +355,7 @@ nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
         case GST_ITERATOR_ERROR:
           dlog_print (DLOG_WARN, DLOG_TAG,
               "There is an error or a resync-event while inspecting a pipeline. However, we can still execute the pipeline.");
+          break;
         case GST_ITERATOR_DONE:
           done = TRUE;
       }


### PR DESCRIPTION
# PR Description

Line 354 of tizen-api-pipeline.c has svace warning:

WID:65505014 Missing break at the end of case at line 354

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
