### PR TITLE
[SVACE/414633] Check malloc return value

### DIFF
--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
@@ -157,6 +157,7 @@ pt_allocate_invoke (void *private_data,
   size = get_tensor_data_size (&prop->output_meta.info[0]);
 
   output[0].data = malloc (size);
+  assert (output[0].data);
 
   /* This assumes the limit is 4 */
   assert (NNS_TENSOR_RANK_LIMIT == 4);


### PR DESCRIPTION
Do not proceed if malloc returns null:
Warning Message
Pointer 'output[0].data' returned from function 'malloc' at nnstreamer_customfilter_example_scaler_allocator.c:159 may be null, and it is dereferenced at nnstreamer_customfilter_example_scaler_allocator.c:202.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
