### PR TITLE
[SVACE/414634-5] Fix 65505041/2 Warning

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -981,9 +981,9 @@ gst_tensor_filter_compare_tensors (GstTensorsInfo * info1,
     line =
         g_strdup_printf ("%2d : %s | %s %s\n", i, left, right,
         g_str_equal (left, right) ? "" : "FAILED");
-    if (left[0] != '\0')
+    if (left && left[0] != '\0')
       g_free (left);
-    if (right[0] != '\0')
+    if (right && right[0] != '\0')
       g_free (right);
 
     tmp = g_strdup_printf ("%s%s", result, line);


### PR DESCRIPTION
DEREF_OF_NULL.RET.ALLOC

Warning Message
Pointer '↦left[0]' returned from function 'g_strdup_printf' at tensor_filter.c:965 may be null, and it is dereferenced at tensor_filter.c:984.
Warning Message
Pointer '↦right[0]' returned from function 'g_strdup_printf' at tensor_filter.c:974 may be null, and it is dereferenced at tensor_filter.c:986.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
