### PR TITLE
[SVACE/414949] Fix 65505047 Warning - @open sesame 04/02 15:23

### DIFF
--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -445,7 +445,12 @@ static gchar *create_null_file (const gchar *dir, const gchar *file)
   gchar *fullpath = g_build_path ("/", dir, file, NULL);
   FILE *fp = g_fopen (fullpath, "w");
 
-  fclose (fp);
+  if (fp) {
+    fclose (fp);
+  } else {
+    g_free (fullpath);
+    return NULL;
+  }
   return fullpath;
 }
 


### PR DESCRIPTION
# PR Description

Line 448 of unittest_common.cpp has svace warning:

WID:65505047 Return value of a function 'fopen64' is dereferenced at
unittest_common.cpp:448 without checking, but it is usually checked
for this function (8/9).

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
