### PR TITLE
[Coverity 1049998/1050018] Fix useless keyword

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -377,7 +377,7 @@ nnsconf_get_fullpath (const gchar * subpluginname, nnsconf_type_path type)
 }
 
 /** @brief Public function defined in the header */
-const gboolean
+gboolean
 nnsconf_get_value_bool (nnsconf_type_value type)
 {
   gboolean ret;

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -113,7 +113,7 @@ nnsconf_get_fullpath (const gchar *subpluginname, nnsconf_type_path type);
  * @return The boolean value to the file. Caller MUST NOT modify this.
  *         Returns FALSE if we cannot find the file or the value as a DEFAULT.
  */
-extern const gboolean
+extern gboolean
 nnsconf_get_value_bool (nnsconf_type_value type);
 
 /**


### PR DESCRIPTION
const of const gboolean func() is useless.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
