### PR TITLE
[Coverity] Branch Past Initialization in _start()

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -1402,6 +1402,8 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
   gint num_channels_enabled;
   gchar *file_contents = NULL;
   gsize length = 0;
+  gchar *device_name = NULL;
+  gchar *trigger_device_dir = NULL;
 
   /** no support one shot mode for now */
   if (!g_strcmp0 (self->mode, MODE_ONE_SHOT)) {
@@ -1432,7 +1434,7 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
   /** register the trigger */
   if (self->trigger.name != NULL || self->trigger.id >= 0) {
     /** verify if trigger is supported by our device */
-    gchar *trigger_device_dir =
+    trigger_device_dir =
         g_build_filename (self->device.base_dir, TRIGGER, NULL);
     if (!g_file_test (trigger_device_dir, G_FILE_TEST_IS_DIR)) {
       GST_ERROR_OBJECT (self, "IIO device %s does not supports trigger.\n",
@@ -1598,7 +1600,7 @@ gst_tensor_src_iio_start (GstBaseSrc * src)
   g_free (dirname);
 
   /** open the buffer to read and ready the file descriptor */
-  gchar *device_name = g_strdup_printf ("%s%d", DEVICE_PREFIX, self->device.id);
+  device_name = g_strdup_printf ("%s%d", DEVICE_PREFIX, self->device.id);
   filename = g_build_filename (IIO_DEV_DIR, device_name, NULL);
   g_free (device_name);
 


### PR DESCRIPTION
[Coverity 1049985,1049986,1049990,1049991,1050015,1050016,1050030,1050272]
This fixes branch past initialization (transfer of control bypasses initialization) at many incidents

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>