### PR TITLE
[IIO] Added data validity testcases - @open sesame 04/05 12:58

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.h
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.h
@@ -131,6 +131,7 @@ struct _GstTensorSrcIIO
   guint64 default_sampling_frequency; /**< default set value of sampling frequency */
   guint default_buffer_capacity; /**< size of the buffer */
   gchar *default_trigger; /**< default set value of sampling frequency */
+  gint poll_timeout; /**< timeout for polling the fifo file */
 
   /** Only first element is filled when is_tensor is true */
   GstTensorsConfig *tensors_config; /**< tensors for storing data config */


### PR DESCRIPTION
Commit 1:
1. Added test case to check data validity for the element for various data bytes sizes
2. Added a property of timeout while reading file in non-blocking mode.
This allows looping while reading the file along with EAGAIN error.
3. Corrected mask generation
4. IIO dev file is replaced with fifo. Using threads to make these fifo as
opening it blocks unless both read and write mode are opened together.
5. Added test case to validate data with and without trigger.

Commit 2:
1. Added test cases when only some of the channels are enabled
2. Bug fix in test case for indexing when filling in data
3. Added test case for using device number and testing name-by-id

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Completed 12 hours stress test run to validate that test cases are consistently passes

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>