### PR TITLE
[Tizen/API] bugfix when passing a wrong pipeline command

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -55,6 +55,29 @@ TEST (nnstreamer_capi_construct_destruct, dummy_03)
 }
 
 /**
+ * @brief Test NNStreamer pipeline construct with non-existent filter
+ */
+TEST (nnstreamer_capi_construct_destruct, failed_01)
+{
+  const char *pipeline = "nonexistsrc ! fakesink";
+  nns_pipeline_h handle;
+  int status = nns_pipeline_construct (pipeline, &handle);
+  EXPECT_EQ (status, NNS_ERROR_PIPELINE_FAIL);
+}
+
+/**
+ * @brief Test NNStreamer pipeline construct with erroneous pipeline
+ */
+TEST (nnstreamer_capi_construct_destruct, failed_02)
+{
+  const char *pipeline = "videotestsrc num_buffers=2 ! audioconvert ! fakesink";
+  nns_pipeline_h handle;
+  int status = nns_pipeline_construct (pipeline, &handle);
+  EXPECT_EQ (status, NNS_ERROR_PIPELINE_FAIL);
+}
+
+
+/**
  * @brief Test NNStreamer pipeline construct & destruct
  */
 TEST (nnstreamer_capi_playstop, dummy_01)

--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -274,7 +274,7 @@ nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
   }
 
   pipeline = gst_parse_launch (pipeline_description, &err);
-  if (pipeline == NULL) {
+  if (pipeline == NULL || err) {
     if (err) {
       dlog_print (DLOG_ERROR, DLOG_TAG,
           "Cannot parse and launch the given pipeline = [%s], %s",


### PR DESCRIPTION
## Description

This PR fix the #1340 issue by checking both the return value and GError value in `nns_pipeline_construct()` because gst_parse_launch() could return non-NULL even though the error is set. Detailed patches are as below.

* Add pipeline failure test cases
* Bugfix when passing a wrong pipeline command

### Related Issue
* https://github.com/nnsuite/nnstreamer/issues/1340

### Self evaluation:
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

