### PR TITLE
[Demux] fix invalid pad index

### DIFF
--- a/gst/nnstreamer/tensor_demux/gsttensordemux.c
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.c
@@ -337,8 +337,7 @@ gst_tensor_demux_get_tensor_pad (GstTensorDemux * tensor_demux,
   tensorpad->last_ts = GST_CLOCK_TIME_NONE;
 
   tensor_demux->srcpads = g_slist_append (tensor_demux->srcpads, tensorpad);
-  gst_tensor_demux_get_tensor_config (tensor_demux, &config,
-      tensor_demux->num_srcpads);
+  gst_tensor_demux_get_tensor_config (tensor_demux, &config, nth);
 
   tensor_demux->num_srcpads++;
 


### PR DESCRIPTION
1. fix invalid src pad index in tensor-demux
2. add simple testcase for the properties and tensorpick option

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
