### PR TITLE
[Tizen/API] Update header file to comply with Tizen API rule

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -62,7 +62,7 @@ TEST (nnstreamer_capi_construct_destruct, failed_01)
   const char *pipeline = "nonexistsrc ! fakesink";
   nns_pipeline_h handle;
   int status = nns_pipeline_construct (pipeline, &handle);
-  EXPECT_EQ (status, NNS_ERROR_PIPELINE_FAIL);
+  EXPECT_EQ (status, NNS_ERROR_STREAMS_PIPE);
 }
 
 /**
@@ -73,7 +73,7 @@ TEST (nnstreamer_capi_construct_destruct, failed_02)
   const char *pipeline = "videotestsrc num_buffers=2 ! audioconvert ! fakesink";
   nns_pipeline_h handle;
   int status = nns_pipeline_construct (pipeline, &handle);
-  EXPECT_EQ (status, NNS_ERROR_PIPELINE_FAIL);
+  EXPECT_EQ (status, NNS_ERROR_STREAMS_PIPE);
 }
 
 
@@ -84,7 +84,7 @@ TEST (nnstreamer_capi_playstop, dummy_01)
 {
   const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
   nns_pipeline_h handle;
-  nns_pipeline_state state;
+  nns_pipeline_state_e state;
   int status = nns_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
@@ -120,7 +120,7 @@ TEST (nnstreamer_capi_playstop, dummy_02)
 {
   const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
   nns_pipeline_h handle;
-  nns_pipeline_state state;
+  nns_pipeline_state_e state;
   int status = nns_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
@@ -177,7 +177,7 @@ TEST (nnstreamer_capi_valve, test01)
   GStatBuf buf;
 
   nns_pipeline_h handle;
-  nns_pipeline_state state;
+  nns_pipeline_state_e state;
   nns_valve_h valve1;
 
   int status = nns_pipeline_construct (pipeline, &handle);

--- a/tizen-api/include/tizen-api.h
+++ b/tizen-api/include/tizen-api.h
@@ -23,8 +23,8 @@
  * @bug No known bugs except for NYI items
  */
 
-#ifndef __TIZEN_NNSTREAMER_API_MAIN_H__
-#define __TIZEN_NNSTREAMER_API_MAIN_H__
+#ifndef __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__
+#define __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__
 
 #include <tizen_error.h>
 #include <nnstreamer/tensor_typedef.h>
@@ -44,25 +44,25 @@ extern "C" {
 typedef void *nns_pipeline_h;
 
 /**
- * @brief A handle of a "sink node" of an NNStreamer pipeline
+ * @brief A handle of a "sink node" of an NNStreamer pipeline.
  * @since_tizen 5.5
  */
 typedef void *nns_sink_h;
 
 /**
- * @brief A handle of a "src node" of an NNStreamer pipeline
+ * @brief A handle of a "src node" of an NNStreamer pipeline.
  * @since_tizen 5.5
  */
 typedef void *nns_src_h;
 
 /**
- * @brief A handle of a "switch" of an NNStreamer pipeline
+ * @brief A handle of a "switch" of an NNStreamer pipeline.
  * @since_tizen 5.5
  */
 typedef void *nns_switch_h;
 
 /**
- * @brief A handle of a "valve node" of an NNStreamer pipeline
+ * @brief A handle of a "valve node" of an NNStreamer pipeline.
  * @since_tizen 5.5
  */
 typedef void *nns_valve_h;
@@ -76,7 +76,7 @@ typedef enum {
   NNS_ERROR_NONE				= TIZEN_ERROR_NONE, /**< Success! */
   NNS_ERROR_INVALID_PARAMETER			= TIZEN_ERROR_INVALID_PARAMETER, /**< Invalid parameter */
   NNS_ERROR_NOT_SUPPORTED			= TIZEN_ERROR_NOT_SUPPORTED, /**< The feature is not supported */
-  NNS_ERROR_PIPELINE_FAIL			= TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create or access Gstreamer pipeline. */
+  NNS_ERROR_STREAMS_PIPE			= TIZEN_ERROR_STREAMS_PIPE, /**< Cannot create or access Gstreamer pipeline. */
   NNS_ERROR_TRY_AGAIN				= TIZEN_ERROR_TRY_AGAIN, /**< The pipeline is not ready, yet (not negotiated, yet) */
 } nns_error_e;
 
@@ -88,12 +88,13 @@ typedef enum {
 typedef enum {
   NNS_BUF_FREE_BY_NNSTREAMER,	/**< Default. Application should not deallocate this buffer. NNStreamer will deallocate when the buffer is no more needed */
   NNS_BUF_DO_NOT_FREE1,		/**< This buffer is not to be freed by NNStreamer (i.e., it's a static object). However, be careful: NNStreamer might be accessing this object after the return of the API call. */
-  NNS_BUF_POLICY_MAX,
-} nns_buf_policy;
+  NNS_BUF_POLICY_MAX,   /**< Max size of nns_buf_policy_e structure */
+} nns_buf_policy_e;
 
 /**
- * @brief Enumeration for nns pipeline state
- * @detail Refer to https://gstreamer.freedesktop.org/documentation/design/states.html
+ * @brief Enumeration for nns pipeline state.
+ * @since_tizen 5.5
+ * @detail Refer to https://gstreamer.freedesktop.org/documentation/design/states.html.
  *         The state diagram of pipeline looks like this, assuming that there are no errors.
  *
  *          [ UNKNOWN ] "new null object"
@@ -111,7 +112,6 @@ typedef enum {
  *               V                          |                      |
  *          [ PLAYING ] --------------------+----------------------+
  *
- * @since_tizen 5.5
  * @todo The list is to be filled! (NYI) Fill with GST's state values.
  * @todo Check the consistency against MMFW APIs.
  */
@@ -121,7 +121,7 @@ typedef enum {
   NNS_PIPELINE_READY				= 2, /**< GST-State "Ready" */
   NNS_PIPELINE_PAUSED				= 3, /**< GST-State "Paused" */
   NNS_PIPELINE_PLAYING				= 4, /**< GST-State "Playing" */
-} nns_pipeline_state;
+} nns_pipeline_state_e;
 
 /**
  * @brief Enumeration for switch types
@@ -130,9 +130,9 @@ typedef enum {
  * @todo There may be more filters that can be supported.
  */
 typedef enum {
-  NNS_SWITCH_OUTPUTSELECTOR			= 0, /** GstOutputSelector */
-  NNS_SWITCH_INPUTSELECTOR			= 1, /** GstInputSelector */
-} nns_switch_type;
+  NNS_SWITCH_OUTPUTSELECTOR			= 0, /**< GstOutputSelector */
+  NNS_SWITCH_INPUTSELECTOR			= 1, /**< GstInputSelector */
+} nns_switch_type_e;
 
 /**
  * @brief Callback for sink (tensor_sink) of nnstreamer pipelines (nnstreamer's output)
@@ -141,7 +141,7 @@ typedef enum {
  * @param[in] buf The contents of the tensor output (a single frame. tensor/tensors). Number of buf is determined by tensorsinfo->num_tensors.
  * @param[in] size The size of the buffer. Number of size is determined by tensorsinfo->num_tensors. Note that max num_tensors is 16 (NNS_TENSOR_SIZE_LIMIT).
  * @param[in] tensorsinfo The cardinality, dimension, and type of given tensor/tensors.
- * @param[in/out] pdata User Application's Private Data
+ * @param[in,out] pdata User Application's Private Data
  */
 typedef void (*nns_sink_cb)
 (const char *buf[], const size_t size[], const GstTensorsInfo *tensorsinfo, void *pdata);
@@ -167,7 +167,7 @@ int nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h *pi
  * @param[in] pipe The pipeline to be destroyed.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
- * @retval #NNS_ERROR_PIPELINE_FAIL Fail. Cannot access the pipeline status.
+ * @retval #NNS_ERROR_STREAMS_PIPE Fail. Cannot access the pipeline status.
  * @retval #NNS_ERROR_INVALID_PARAMETER Fail. The parameter is invalid (pipe is NULL?)
  */
 int nns_pipeline_destroy (nns_pipeline_h pipe);
@@ -181,9 +181,9 @@ int nns_pipeline_destroy (nns_pipeline_h pipe);
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
- * @retval #NNS_ERROR_PIPELINE_FAIL Failed to get state from the pipeline.
+ * @retval #NNS_ERROR_STREAMS_PIPE Failed to get state from the pipeline.
  */
-int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state *state);
+int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e *state);
 
 /****************************************************
  ** NNStreamer Pipeline Start/Stop Control         **
@@ -196,7 +196,7 @@ int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state *state);
  * @param[in] pipe The pipeline to be started.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
- * @retval #NNS_ERROR_PIPELINE_FAIL Failed to start.
+ * @retval #NNS_ERROR_STREAMS_PIPE Failed to start.
  */
 int nns_pipeline_start (nns_pipeline_h pipe);
 
@@ -208,7 +208,7 @@ int nns_pipeline_start (nns_pipeline_h pipe);
  * @param[in] pipe The pipeline to be stopped.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
- * @retval #NNS_ERROR_PIPELINE_FAIL Failed to start.
+ * @retval #NNS_ERROR_STREAMS_PIPE Failed to start.
  */
 int nns_pipeline_stop (nns_pipeline_h pipe);
 
@@ -276,21 +276,21 @@ int nns_pipeline_src_puthandle (nns_src_h h);
  * @return 0 on success (buf is filled). otherwise a negative error value.
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
- * @retval #NNS_ERROR_PIPELINE_FAIL The pipeline has inconsistent padcaps. Not negotiated?
+ * @retval #NNS_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  *
  * @todo Allow to use GstBuffer instead of buf/size pairs, probably with yet another API.
  */
 int nns_pipeline_src_inputdata (nns_src_h h,
-    nns_buf_policy policy, char *buf[], const size_t size[], unsigned int num_tensors);
+    nns_buf_policy_e policy, char *buf[], const size_t size[], unsigned int num_tensors);
 
 /****************************************************
  ** NNStreamer Pipeline Switch/Valve Control       **
  ****************************************************/
 
 /**
- * @brief Get a handle to operate a "GstInputSelector / GstOutputSelector" node of nnstreamer pipelines
- * @detail Refer to gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-bad-plugins/html/gst-plugins-bad-plugins-input-selector.html for input selectors
- *         Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors
+ * @brief Get a handle to operate a "GstInputSelector / GstOutputSelector" node of nnstreamer pipelines.
+ * @detail Refer to gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-bad-plugins/html/gst-plugins-bad-plugins-input-selector.html for input selectors.
+ *         Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
  * @param[in] pipe The pipeline to be managed.
  * @param[in] switchname The name of switch (InputSelector/OutputSelector)
  * @param[out] type The type of the switch. If NULL, it is ignored.
@@ -299,10 +299,10 @@ int nns_pipeline_src_inputdata (nns_src_h h,
  * @retval #NNS_ERROR_NONE Successful
  */
 int nns_pipeline_switch_gethandle
-(nns_pipeline_h pipe, const char *switchname, nns_switch_type *type, nns_switch_h *h);
+(nns_pipeline_h pipe, const char *switchname, nns_switch_type_e *type, nns_switch_h *h);
 
 /**
- * @brief Close the given switch handle
+ * @brief Close the given switch handle.
  * @param[in] h The handle to be closed.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
@@ -319,7 +319,7 @@ int nns_pipeline_switch_puthandle (nns_switch_h h);
 int nns_pipeline_switch_select (nns_switch_h h, const char *padname);
 
 /**
- * @brief Get the pad names of a switch
+ * @brief Get the pad names of a switch.
  * @param[in] h The switch handle returned by nns_pipeline_switch_gethandle()
  * @param[out] list NULL terminated array of char*. The caller must free each string (char*) in the list and free the list itself.
  * @return @c 0 on success. otherwise a negative error value
@@ -328,7 +328,7 @@ int nns_pipeline_switch_select (nns_switch_h h, const char *padname);
 int nns_pipeline_switch_nodelist (nns_switch_h h, char *** list);
 
 /**
- * @brief Get a handle to operate a "GstValve" node of nnstreamer pipelines
+ * @brief Get a handle to operate a "GstValve" node of nnstreamer pipelines.
  * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-valve.html for more info.
  * @param[in] pipe The pipeline to be managed.
  * @param[in] valvename The name of valve (Valve)
@@ -340,7 +340,7 @@ int nns_pipeline_valve_gethandle
 (nns_pipeline_h pipe, const char *valvename, nns_valve_h *h);
 
 /**
- * @brief Close the given valve handle
+ * @brief Close the given valve handle.
  * @param[in] h The handle to be closed.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
@@ -348,7 +348,7 @@ int nns_pipeline_valve_gethandle
 int nns_pipeline_valve_puthandle (nns_valve_h h);
 
 /**
- * @brief Control the valve with the given handle
+ * @brief Control the valve with the given handle.
  * @param[in] h The valve handle returned by nns_pipeline_valve_gethandle()
  * @param[in] valve_drop 1 to close (drop & stop the flow). 0 to open (let the flow pass)
  * @return @c 0 on success. otherwise a negative error value
@@ -362,4 +362,4 @@ int nns_pipeline_valve_control (nns_valve_h h, int valve_drop);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /*__TIZEN_NNSTREAMER_API_MAIN_H__*/
+#endif /* __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__ */

--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -270,7 +270,7 @@ nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
       dlog_print (DLOG_ERROR, DLOG_TAG,
           "Cannot initialize gstreamer. Unknown reason.");
     }
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
   }
 
   pipeline = gst_parse_launch (pipeline_description, &err);
@@ -285,7 +285,7 @@ nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
           "Cannot parse and launch the given pipeline = [%s], unknown reason",
           pipeline_description);
     }
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
   }
 
   pipe_h = g_new0 (nns_pipeline, 1);
@@ -395,7 +395,7 @@ nns_pipeline_destroy (nns_pipeline_h pipe)
     scret = gst_element_set_state (p->element, GST_STATE_PAUSED);
     if (scret == GST_STATE_CHANGE_FAILURE) {
       g_mutex_unlock (&p->lock);
-      return NNS_ERROR_PIPELINE_FAIL;
+      return NNS_ERROR_STREAMS_PIPE;
     }
   }
 
@@ -411,7 +411,7 @@ nns_pipeline_destroy (nns_pipeline_h pipe)
   scret = gst_element_set_state (p->element, GST_STATE_NULL);
   if (scret != GST_STATE_CHANGE_SUCCESS) {
     g_mutex_unlock (&p->lock);
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
   }
 
   gst_object_unref (p->element);
@@ -425,7 +425,7 @@ nns_pipeline_destroy (nns_pipeline_h pipe)
  * @brief Get the pipeline state (more info in tizen-api.h)
  */
 int
-nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state * state)
+nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e * state)
 {
   nns_pipeline *p = pipe;
   GstState _state;
@@ -441,7 +441,7 @@ nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state * state)
   g_mutex_unlock (&p->lock);
 
   if (scret == GST_STATE_CHANGE_FAILURE)
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
 
   *state = _state;
   return NNS_ERROR_NONE;
@@ -464,7 +464,7 @@ nns_pipeline_start (nns_pipeline_h pipe)
   g_mutex_unlock (&p->lock);
 
   if (scret == GST_STATE_CHANGE_FAILURE)
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
 
   return NNS_ERROR_NONE;
 }
@@ -483,7 +483,7 @@ nns_pipeline_stop (nns_pipeline_h pipe)
   g_mutex_unlock (&p->lock);
 
   if (scret == GST_STATE_CHANGE_FAILURE)
-    return NNS_ERROR_PIPELINE_FAIL;
+    return NNS_ERROR_STREAMS_PIPE;
 
   return NNS_ERROR_NONE;
 }
@@ -567,7 +567,7 @@ nns_pipeline_sink_unregister (nns_sink_h h)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy in tizen-api.h,
+ * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h,
  *        "Free"
  */
 static void
@@ -577,7 +577,7 @@ nnsbufpolicy_free (gpointer data)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy in tizen-api.h,
+ * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h,
  *        "Do Nothing"
  */
 static void
@@ -587,7 +587,7 @@ nnsbufpolicy_nop (gpointer data)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy in tizen-api.h
+ * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h
  */
 static const GDestroyNotify bufpolicy[NNS_BUF_POLICY_MAX] = {
   [NNS_BUF_FREE_BY_NNSTREAMER] = nnsbufpolicy_free,
@@ -668,7 +668,7 @@ nns_pipeline_src_puthandle (nns_src_h h)
  */
 int
 nns_pipeline_src_inputdata (nns_src_h h,
-    nns_buf_policy policy, char *buf[], const size_t size[],
+    nns_buf_policy_e policy, char *buf[], const size_t size[],
     unsigned int num_tensors)
 {
   /** @todo NYI */
@@ -718,7 +718,7 @@ nns_pipeline_src_inputdata (nns_src_h h,
                 elem->name, elem->tensorsinfo.num_tensors, num_tensors);
             gst_caps_unref (caps);
             elem->sink = NULL;
-            ret = NNS_ERROR_PIPELINE_FAIL;
+            ret = NNS_ERROR_STREAMS_PIPE;
             goto unlock_return;
           }
 
@@ -786,7 +786,7 @@ nns_pipeline_src_inputdata (nns_src_h h,
   } else if (gret == GST_FLOW_EOS) {
     dlog_print (DLOG_WARN, DLOG_TAG,
         "THe pipeline is in EOS state. The input is ignored.");
-    ret = NNS_ERROR_PIPELINE_FAIL;
+    ret = NNS_ERROR_STREAMS_PIPE;
   }
 
   handle_exit (h);
@@ -801,7 +801,7 @@ nns_pipeline_src_inputdata (nns_src_h h,
  */
 int
 nns_pipeline_switch_gethandle (nns_pipeline_h pipe, const char *switchname,
-    nns_switch_type * type, nns_switch_h * h)
+    nns_switch_type_e * type, nns_switch_h * h)
 {
   element *elem;
   nns_pipeline *p = pipe;
@@ -953,7 +953,7 @@ nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
     dlog_print (DLOG_ERROR, DLOG_TAG,
         "The element, [%s], is supposed to be input/output switch, but it is not. Internal data structure is broken.",
         elem->name);
-    ret = NNS_ERROR_PIPELINE_FAIL;
+    ret = NNS_ERROR_STREAMS_PIPE;
     goto unlock_return;
   }
 
@@ -975,7 +975,7 @@ nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
         dlog_print (DLOG_ERROR, DLOG_TAG,
             "Cannot access the list of pad properly of a switch, [%s].",
             elem->name);
-        ret = NNS_ERROR_PIPELINE_FAIL;
+        ret = NNS_ERROR_STREAMS_PIPE;
         break;
       case GST_ITERATOR_DONE:
         done = TRUE;
@@ -1001,7 +1001,7 @@ nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
         dlog_print (DLOG_ERROR, DLOG_TAG,
             "Internal data inconsistency. This could be a bug in nnstreamer. Switch [%s].",
             elem->name);
-        ret = NNS_ERROR_PIPELINE_FAIL;
+        ret = NNS_ERROR_STREAMS_PIPE;
         goto unlock_return;
       }
     }


### PR DESCRIPTION
In order to comply with the checklist of Tizen API, this patch modifies
a user header file, which is actually included in the code. Detailed
items of modification are as below.

* Add a period "." at the end of @brief.
* Values NNS_ERROR_PIPELINE_FAIL and TIZEN_ERROR_STREAMS_PIPE have
  different suffixes.
* No description in enum variables.
* Enum names should end with '_e'.
* Please use @param[in], @param[out] or @param[in,out]

### Related Issue
* https://github.com/nnsuite/nnstreamer/issues/1347

### Self evaluation:
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>
