### PR TITLE
[IIO] bugfixes related to errors from yocto run

### DIFF
--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -209,6 +209,8 @@ make_iio_dev_structure (int num)
   iio_dev->dev_device_dir =
       g_build_filename (iio_dev->dev_dir, device_folder_name, NULL);
 
+  iio_dev->log_file = NULL;
+
   PREV_IIO_DEV_DIR = IIO_DEV_DIR;
   IIO_DEV_DIR = g_strdup (iio_dev->dev_dir);
 
@@ -690,7 +692,7 @@ static gint
 safe_remove (const char *filename)
 {
   /** cover for both regular file as well as pipes */
-  if (g_file_test (filename, G_FILE_TEST_EXISTS)
+  if (filename && g_file_test (filename, G_FILE_TEST_EXISTS)
       && !g_file_test (filename, G_FILE_TEST_IS_DIR)) {
     return remove (filename);
   }
@@ -707,7 +709,7 @@ safe_remove (const char *filename)
 static gint
 safe_rmdir (const char *dirname)
 {
-  if (g_file_test (dirname, G_FILE_TEST_IS_DIR)) {
+  if (dirname && g_file_test (dirname, G_FILE_TEST_IS_DIR)) {
     return rmdir (dirname);
   }
   return 0;


### PR DESCRIPTION
1. set base src as async, resolves the error of hanging
  without setting base_src as async, _start_complete gets called twice
2. initializing log_file to NULL
3. NULL check for variable before using it for remove/rmdir
4. remove _query function, was incomplete, and complete function
  was same as parent class function

resolve #1353, nnsuite/TAOS-CI#489

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>