### PR TITLE
[CONF] remove unnecessary free

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -312,7 +312,6 @@ nnsconf_loadconf (gboolean force_reload)
   }
 
   conf.loaded = TRUE;
-  g_key_file_free (key_file);
 
   return TRUE;
 }


### PR DESCRIPTION
Remove unnecessary free that caused error with valgrind

resolves nnsuite/TAOS-CI#489

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>