### PR TITLE
[Tizen/API] Remove dependency 'tensor_typedef.h'

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -237,7 +237,7 @@ TEST (nnstreamer_capi_valve, test01)
  * @brief A tensor-sink callback for sink handle in a pipeline
  */
 static void nns_sink_callback_dm01 (const char *buf[], const size_t size[],
-    const GstTensorsInfo *tensorsinfo, void *pdata)
+    const nns_tensors_info_s *tensorsinfo, void *pdata)
 {
   gchar *filepath = (gchar *) pdata;
   FILE *fp = g_fopen (filepath, "a");
@@ -361,7 +361,8 @@ TEST (nnstreamer_capi_src, dummy_01)
   nns_pipeline_state_e state;
   nns_src_h srchandle;
   int status = nns_pipeline_construct (pipeline, &handle);
-  GstTensorsInfo tensorsinfo;
+  nns_tensors_info_s tensorsinfo;
+
   int i;
   char *uintarray2[10];
   uint8_t *content;
@@ -400,14 +401,14 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   EXPECT_EQ (tensorsinfo.num_tensors, 1);
-  EXPECT_EQ (tensorsinfo.info[0].type, _NNS_UINT8);
+  EXPECT_EQ (tensorsinfo.info[0].type, NNS_UINT8);
   EXPECT_EQ (tensorsinfo.info[0].dimension[0], 4);
   EXPECT_EQ (tensorsinfo.info[0].dimension[1], 1);
   EXPECT_EQ (tensorsinfo.info[0].dimension[2], 1);
   EXPECT_EQ (tensorsinfo.info[0].dimension[3], 1);
 
   tensorsinfo.num_tensors = 1;
-  tensorsinfo.info[0].type = _NNS_UINT8;
+  tensorsinfo.info[0].type = NNS_UINT8;
   tensorsinfo.info[0].dimension[0] = 4;
   tensorsinfo.info[0].dimension[1] = 1;
   tensorsinfo.info[0].dimension[2] = 1;
@@ -426,7 +427,7 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   EXPECT_EQ (tensorsinfo.num_tensors, 1);
-  EXPECT_EQ (tensorsinfo.info[0].type, _NNS_UINT8);
+  EXPECT_EQ (tensorsinfo.info[0].type, NNS_UINT8);
   EXPECT_EQ (tensorsinfo.info[0].dimension[0], 4);
   EXPECT_EQ (tensorsinfo.info[0].dimension[1], 1);
   EXPECT_EQ (tensorsinfo.info[0].dimension[2], 1);


### PR DESCRIPTION
In order to pass the ACR process, 'tensor_typedef.h' in tizen-api.h
should be removed and its related thing also be updated. This patch
handles that issues. Detailed modification are as below.

* Remove dependency for 'nnstreamer/tensor_typedef.h' header
* Add necessary constant and enum variables such as
  NNS_TENSOR_RANK_LIMIT and nns_tensors_info.
* Use nns_tensors_info structure instead of GstTensorsInfo

### Related Issue
* http://suprem.sec.samsung.net/jira/browse/ACR-1382

### Self evaluation:
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>