### PR TITLE
[UNITTEST] add tensorflow-lite test cases accorting to option - @open sesame 04/19 15:01

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -104,6 +104,13 @@ if get_option('install-test')
   install_subdir('nnstreamer_decoder', install_dir: join_paths(unittest_install_dir,'tests'))
   install_subdir('nnstreamer_demux', install_dir: join_paths(unittest_install_dir,'tests'))
   install_subdir('nnstreamer_filter_custom', install_dir: join_paths(unittest_install_dir,'tests'))
+  if get_option('enable-tensorflow-lite')
+     install_subdir('nnstreamer_filter_tensorflow-lite', install_dir: join_paths(unittest_install_dir,'tests'))
+     install_subdir('nnstreamer_decoder_image_labeling', install_dir: join_paths(unittest_install_dir,'tests'))
+  endif
+  if get_option('enable-tensorflow')
+     install_subdir('nnstreamer_filter_tensorflow', install_dir: join_paths(unittest_install_dir,'tests'))
+  endif
   install_subdir('nnstreamer_mux', install_dir: join_paths(unittest_install_dir,'tests'))
   install_subdir('nnstreamer_repo', install_dir: join_paths(unittest_install_dir,'tests'))
   install_subdir('nnstreamer_repo_dynamicity', install_dir: join_paths(unittest_install_dir,'tests'))


### PR DESCRIPTION
# PR Description
add
 . nnstreamer_filter_tensorflow-lite
 . nnstreamer_filter_tensorflow
 . nnstreamer_decoder_image_labeling

according to enable-tensorflow and enable-tensorflow-lite option.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
