### PR TITLE
[Coverity] Resolved negative returns issue @open sesame 4/18 17:28

### DIFF
--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -1105,6 +1105,7 @@ TEST (test_tensor_src_iio, \
   } \
   /** verify correctness of data */ \
   fd = open (dev0->log_file, O_RDONLY); \
+  ASSERT_GE (fd, 0); \
   bytes_to_read = sizeof (float) * BUF_LENGTH * dev0->num_scan_elements/SKIP; \
   data_buffer = (gchar *) malloc (bytes_to_read); \
   bytes_read = read (fd, data_buffer, bytes_to_read); \
@@ -1233,6 +1234,7 @@ TEST (test_tensor_src_iio, data_verify_trigger)
 
     /** verify correctness of data */
     fd = open (dev0->log_file, O_RDONLY);
+    ASSERT_GE (fd, 0);
     bytes_to_read = sizeof (float) * BUF_LENGTH * dev0->num_scan_elements;
     data_buffer = (gchar *) malloc (bytes_to_read);
     bytes_read = read (fd, data_buffer, bytes_to_read);
@@ -1407,7 +1409,7 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
   src_iio_pipeline = gst_parse_launch (parse_launch, NULL);
 
   /** move channel specific type for channel 1 to generic */
-  g_rename (dev0->scan_el_type[1], dev0->scan_el_type_generic);
+  ASSERT_EQ (g_rename (dev0->scan_el_type[1], dev0->scan_el_type_generic), 0);
   /** disable all/some channels */
   for (int idx = 0; idx < num_scan_elements; idx++) {
     write_file_int (dev0->scan_el_en[idx], 0);
@@ -1441,6 +1443,7 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
 
     /** verify correctness of data */
     fd = open (dev0->log_file, O_RDONLY);
+    ASSERT_GE (fd, 0);
     bytes_to_read = sizeof (float) * BUF_LENGTH * dev0->num_scan_elements;
     data_buffer = (gchar *) malloc (bytes_to_read);
     bytes_read = read (fd, data_buffer, bytes_to_read);


### PR DESCRIPTION
Negative returns: negative value used as argument to a function
expecting a positive value

Resolved with an assert

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
