### PR TITLE
[SVACE] Addressess memory leaks @open sesame 4/18 17:28

### DIFF
--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -2367,6 +2367,9 @@ gst_tensor_src_iio_fill (GstBaseSrc * src, guint64 offset,
   /** get writable buffer */
   mem = gst_buffer_peek_memory (buffer, 0);
   g_assert (gst_memory_map (mem, &map, GST_MAP_WRITE));
+  /** memory to data from file */
+  bytes_to_read = self->scan_size * self->buffer_capacity;
+  raw_data_base = g_malloc (bytes_to_read);
 
   /** wait for the data to arrive */
   time_to_end = g_get_real_time () + self->poll_timeout * 1000;
@@ -2397,9 +2400,6 @@ gst_tensor_src_iio_fill (GstBaseSrc * src, guint64 offset,
       }
     }
 
-    /** read the data from file */
-    bytes_to_read = self->scan_size * self->buffer_capacity;
-    raw_data_base = g_malloc (bytes_to_read);
     /** using read for non-blocking access */
     status = read (self->buffer_data_fp->fd, raw_data_base, bytes_to_read);
     if (status < bytes_to_read) {

--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -527,6 +527,9 @@ build_dev_dir_scan_elements (iio_dev_dir_struct * iio_dev,
 
   data_size = num_bytes * iio_dev->num_scan_elements / skip;
   scan_el_data = (char *) malloc (data_size);
+  if (scan_el_data == NULL) {
+    return -1;
+  }
   /** total 8 possible cases */
   for (int idx = 0; idx < iio_dev->num_scan_elements; idx++) {
     enabled = (idx % skip == 0);
@@ -583,7 +586,10 @@ build_dev_dir_scan_elements (iio_dev_dir_struct * iio_dev,
         case 8:
           CHANGE_ENDIANNESS (64);
         default:
+        {
+          g_free (scan_el_data);
           return -1;
+        }
       };
     }
   }
@@ -1118,6 +1124,7 @@ TEST (test_tensor_src_iio, \
     EXPECT_STREQ (expect_val_char, actual_val_char); \
     g_free (actual_val_char); \
   } \
+  g_free (expect_val_char); \
   close (fd); \
 \
   /** delete device structure */ \
@@ -1246,6 +1253,7 @@ TEST (test_tensor_src_iio, data_verify_trigger)
       EXPECT_STREQ (expect_val_char, actual_val_char);
       g_free (actual_val_char);
     }
+    g_free (expect_val_char);
     close (fd);
     ASSERT_EQ (safe_remove (dev0->log_file), 0);
     /** update data value to check data updates */
@@ -1454,6 +1462,7 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
       EXPECT_STREQ (expect_val_char, actual_val_char);
       g_free (actual_val_char);
     }
+    g_free (expect_val_char);
     close (fd);
     ASSERT_EQ (safe_remove (dev0->log_file), 0);
     /** update data value to check data updates */


### PR DESCRIPTION
MEMORY_LEAK_EX : Dynamic memory reference was allocated and lost.

Resolved memory leaks given by svace for src_iio code as well as tests

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>