### PR TITLE
[Orc] remove unnecessary code

### DIFF
--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -48,10 +48,6 @@
 #include <gst/gst.h>
 #include <gst/gstplugin.h>
 
-#ifdef HAVE_ORC
-#include <orc/orc.h>
-#endif
-
 #define NNSTREAMER_PLUGIN(name) \
   extern gboolean G_PASTE(nnstreamer_export_, name) (GstPlugin *plugin)
 
@@ -81,11 +77,6 @@ NNSTREAMER_PLUGIN (tensor_reposrc);
 static gboolean
 gst_nnstreamer_init (GstPlugin * plugin)
 {
-#ifdef HAVE_ORC
-  GST_INFO ("[NNStreamer] Initialize the Orc library");
-  orc_init ();
-#endif
-
   NNSTREAMER_INIT (tensor_converter, plugin);
   NNSTREAMER_INIT (tensor_aggregator, plugin);
   NNSTREAMER_INIT (tensor_decoder, plugin);

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -38,7 +38,7 @@
 #include "nnstreamer_plugin_api.h"
 
 #ifdef HAVE_ORC
-#include <orc/orc.h>
+#include <orc/orcfunctions.h>
 
 #define nns_memcpy(d,s,n) do { \
     if ((n) > 100) orc_memcpy ((d), (s), (n)); \


### PR DESCRIPTION
We don't need to init orc functions.
It will be called when creating new orc program.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
