### PR TITLE
[SVACE] Fix Issue WGID 414639

### DIFF
--- a/gst/nnstreamer/tensor_reposrc/tensor_reposrc.c
+++ b/gst/nnstreamer/tensor_reposrc/tensor_reposrc.c
@@ -330,11 +330,20 @@ gst_tensor_reposrc_create (GstPushSrc * src, GstBuffer ** buffer)
 
     meta = GST_META_REPO_GET (buf);
 
+    if (meta == NULL) {
+      GST_ELEMENT_ERROR (GST_ELEMENT (self), RESOURCE, NOT_FOUND,
+          ("Cannot get meta from buffer!"), (NULL));
+      return GST_FLOW_ERROR;
+    }
+
     if (!self->negotiation && buf != NULL) {
       if (!gst_caps_can_intersect (self->caps, meta->caps)) {
         GST_ELEMENT_ERROR (GST_ELEMENT (self), CORE, NEGOTIATION,
             ("Negotiation Failed! : repo_sink & repos_src"), (NULL));
-        gst_buffer_remove_meta (buf, (GstMeta *) meta);
+        if (!gst_buffer_remove_meta (buf, (GstMeta *) meta)) {
+          GST_ELEMENT_ERROR (GST_ELEMENT (self), RESOURCE, WRITE,
+              ("Cannot remove meta from buffer!"), (NULL));
+        }
         gst_buffer_unref (buf);
         gst_tensor_repo_set_eos (self->myid);
         return GST_FLOW_EOS;


### PR DESCRIPTION
# RP Description

Threre is svace issue said:

WID:66310927 Return value of a function 'gst_buffer_get_meta' is
dereferenced at tensor_reposrc.c:338 without checking, but it is
usually checked for this function (20/21).

Add check if the meta is null and arise the error.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
