### PR TITLE
[SVACE] Fix Issue #414638

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -1099,6 +1099,11 @@ gst_gen_tensors_from_collectpad (GstCollectPads * collect,
     GstBuffer *buf;
 
     walk = g_slist_nth (walk, sync.data_basepad.sink_id);
+    if (walk == NULL) {
+      GST_ERROR_OBJECT (collect, "Cannot get GstCollectData from GSList");
+      return FALSE;
+    }
+
     data = (GstCollectData *) walk->data;
     pad = (GstTensorCollectPadData *) data;
 


### PR DESCRIPTION
# PR Description

There is svace issuse said:
WID:66310552 Return value of a function 'g_slist_nth' is dereferenced
at tensor_common.c:1096 without checking, but it is usually checked
for this function (195/205).

Add Null check.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
