### PR TITLE
[Common] pad info struct - @open sesame 04/24 15:54

### DIFF
--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -96,6 +96,17 @@ typedef struct
 } GstTensorCollectPadData;
 
 /**
+ * @brief Internal data structure for pad in demux / split
+ */
+typedef struct
+{
+  GstPad *pad;
+  GstClockTime last_ts;
+  GstFlowReturn last_ret;
+  gint nth;
+} GstTensorPad;
+
+/**
  * @brief A callback for typefind, trying to find whether a file is other/tensors or not.
  * For the concrete definition of headers, please look at the wiki page of nnstreamer:
  * https://github.com/nnsuite/nnstreamer/wiki/Design-External-Save-Format-for-other-tensor-and-other-tensors-Stream-for-TypeFind

--- a/gst/nnstreamer/tensor_demux/gsttensordemux.h
+++ b/gst/nnstreamer/tensor_demux/gsttensordemux.h
@@ -32,6 +32,7 @@
 #include <tensor_common.h>
 
 G_BEGIN_DECLS
+
 #define GST_TYPE_TENSOR_DEMUX (gst_tensor_demux_get_type ())
 #define GST_TENSOR_DEMUX(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), GST_TYPE_TENSOR_DEMUX, GstTensorDemux))
 #define GST_TENSOR_DEMUX_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST ((klass), GST_TYPE_TENSOR_DEMUX, GstTensorDemuxClass))
@@ -39,16 +40,9 @@ G_BEGIN_DECLS
 #define GST_IS_TENSOR_DEMUX(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_DEMUX))
 #define GST_IS_TENSOR_DEMUX_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_DEMUX))
 #define GST_TENSOR_DEMUX_CAST(obj)((GstTensorDemux*)(obj))
+
 typedef struct _GstTensorDemux GstTensorDemux;
 typedef struct _GstTensorDemuxClass GstTensorDemuxClass;
-
-typedef struct
-{
-  GstPad *pad;
-  GstClockTime last_ts;
-  GstFlowReturn last_ret;
-  gint nth;
-} GstTensorPad;
 
 /**
  * @brief Tensor Muxer data structure
@@ -82,4 +76,5 @@ struct _GstTensorDemuxClass
 GType gst_tensor_demux_get_type (void);
 
 G_END_DECLS
+
 #endif  /** __GST_TENSOR_DEMUX_H__ **/

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.h
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.h
@@ -44,15 +44,6 @@ G_BEGIN_DECLS
 typedef struct _GstTensorSplit GstTensorSplit;
 typedef struct _GstTensorSplitClass GstTensorSplitClass;
 
-/** @todo consider to move this to common header */
-typedef struct
-{
-  GstPad *pad;
-  GstClockTime last_ts;
-  GstFlowReturn last_ret;
-  gint nth;
-} GstTensorPad;
-
 /**
  * @brief Tensor Spliter data structure
  */


### PR DESCRIPTION
define common tensor-pad struct used in split/demux

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
