### PR TITLE
[Decoder/Api] change function name / sub-plugin mode

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -991,13 +991,12 @@ static gchar decoder_subplugin_bounding_box[] = "bounding_boxes";
 /** @brief Bounding box tensordec-plugin GstTensorDecoderDef instance */
 static GstTensorDecoderDef boundingBox = {
   .modename = decoder_subplugin_bounding_box,
-  .type = OUTPUT_VIDEO,
   .init = bb_init,
   .exit = bb_exit,
   .setOption = bb_setOption,
   .getOutCaps = bb_getOutCaps,
   .getTransformSize = bb_getTransformSize,
-  .decode = bb_decode,
+  .decode = bb_decode
 };
 
 /** @brief Initialize this object for tensordec-plugin */

--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -146,7 +146,7 @@ _init_modes (bounding_boxes * bdata)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 bb_init (void **pdata)
 {
@@ -199,7 +199,7 @@ _exit_modes (bounding_boxes * bdata)
   }
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static void
 bb_exit (void **pdata)
 {
@@ -358,7 +358,7 @@ _setOption_mode (bounding_boxes * bdata, const char *param)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 bb_setOption (void **pdata, int opNum, const char *param)
 {
@@ -497,7 +497,7 @@ _set_max_detection (bounding_boxes * data, const guint max_detection,
 }
 
 /**
- * @brief tensordec-plugin's TensorDecDef callback
+ * @brief tensordec-plugin's GstTensorDecoderDef callback
  *
  * [TF-Lite SSD Model]
  * The first tensor is boxes. BOX_SIZE : 1 : #MaxDetection, ANY-TYPE
@@ -597,7 +597,7 @@ bb_getOutCaps (void **pdata, const GstTensorsConfig * config)
   return caps;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static size_t
 bb_getTransformSize (void **pdata, const GstTensorsConfig * config,
     GstCaps * caps, size_t size, GstCaps * othercaps, GstPadDirection direction)
@@ -889,7 +889,7 @@ draw (GstMapInfo * out_info, bounding_boxes * bdata, GArray * results)
   }
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static GstFlowReturn
 bb_decode (void **pdata, const GstTensorsConfig * config,
     const GstTensorMemory * input, GstBuffer * outbuf)
@@ -988,8 +988,8 @@ bb_decode (void **pdata, const GstTensorsConfig * config,
 
 static gchar decoder_subplugin_bounding_box[] = "bounding_boxes";
 
-/** @brief Bounding box tensordec-plugin TensorDecDef instance */
-static TensorDecDef boundingBox = {
+/** @brief Bounding box tensordec-plugin GstTensorDecoderDef instance */
+static GstTensorDecoderDef boundingBox = {
   .modename = decoder_subplugin_bounding_box,
   .type = OUTPUT_VIDEO,
   .init = bb_init,
@@ -1004,12 +1004,12 @@ static TensorDecDef boundingBox = {
 void
 init_bb (void)
 {
-  tensordec_probe (&boundingBox);
+  nnstreamer_decoder_probe (&boundingBox);
 }
 
 /** @brief Destruct this object for tensordec-plugin */
 void
 fini_bb (void)
 {
-  tensordec_exit (boundingBox.modename);
+  nnstreamer_decoder_exit (boundingBox.modename);
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -38,7 +38,7 @@ void fini_dv (void) __attribute__ ((destructor));
     GST_VIDEO_CAPS_MAKE ("{ RGB, BGRx, GRAY8 }") \
     ", views = (int) 1, interlace-mode = (string) progressive"
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 dv_init (void **pdata)
 {
@@ -46,7 +46,7 @@ dv_init (void **pdata)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static void
 dv_exit (void **pdata)
 {
@@ -54,7 +54,7 @@ dv_exit (void **pdata)
   return;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 dv_setOption (void **pdata, int opNum, const char *param)
 {
@@ -62,7 +62,7 @@ dv_setOption (void **pdata, int opNum, const char *param)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static GstCaps *
 dv_getOutCaps (void **pdata, const GstTensorsConfig * config)
 {
@@ -126,7 +126,7 @@ _get_video_xraw_bufsize (const tensor_dim dim)
   return ((dim[0] * dim[1] - 1) / 4 + 1) * 4 * dim[2];
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static size_t
 dv_getTransformSize (void **pdata, const GstTensorsConfig * config,
     GstCaps * caps, size_t size, GstCaps * othercaps, GstPadDirection direction)
@@ -140,7 +140,7 @@ dv_getTransformSize (void **pdata, const GstTensorsConfig * config,
     return 0; /** @todo NYI */
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static GstFlowReturn
 dv_decode (void **pdata, const GstTensorsConfig * config,
     const GstTensorMemory * input, GstBuffer * outbuf)
@@ -193,8 +193,8 @@ dv_decode (void **pdata, const GstTensorsConfig * config,
 
 static gchar decoder_subplugin_direct_video[] = "direct_video";
 
-/** @brief Direct-Video tensordec-plugin TensorDecDef instance */
-static TensorDecDef directVideo = {
+/** @brief Direct-Video tensordec-plugin GstTensorDecoderDef instance */
+static GstTensorDecoderDef directVideo = {
   .modename = decoder_subplugin_direct_video,
   .type = OUTPUT_VIDEO,
   .init = dv_init,
@@ -209,12 +209,12 @@ static TensorDecDef directVideo = {
 void
 init_dv (void)
 {
-  tensordec_probe (&directVideo);
+  nnstreamer_decoder_probe (&directVideo);
 }
 
 /** @brief Destruct this object for tensordec-plugin */
 void
 fini_dv (void)
 {
-  tensordec_exit (directVideo.modename);
+  nnstreamer_decoder_exit (directVideo.modename);
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-directvideo.c
@@ -196,13 +196,12 @@ static gchar decoder_subplugin_direct_video[] = "direct_video";
 /** @brief Direct-Video tensordec-plugin GstTensorDecoderDef instance */
 static GstTensorDecoderDef directVideo = {
   .modename = decoder_subplugin_direct_video,
-  .type = OUTPUT_VIDEO,
   .init = dv_init,
   .exit = dv_exit,
   .setOption = dv_setOption,
   .getOutCaps = dv_getOutCaps,
   .getTransformSize = dv_getTransformSize,
-  .decode = dv_decode,
+  .decode = dv_decode
 };
 
 /** @brief Initialize this object for tensordec-plugin */

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -49,7 +49,7 @@ typedef struct
   guint max_word_length; /**< The max size of labels */
 } ImageLabelData;
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 il_init (void **pdata)
 {
@@ -58,7 +58,7 @@ il_init (void **pdata)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static void
 il_exit (void **pdata)
 {
@@ -127,7 +127,7 @@ loadImageLabels (ImageLabelData * data)
   return;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static int
 il_setOption (void **pdata, int opNum, const char *param)
 {
@@ -152,7 +152,7 @@ il_setOption (void **pdata, int opNum, const char *param)
   return TRUE;
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static GstCaps *
 il_getOutCaps (void **pdata, const GstTensorsConfig * config)
 {
@@ -174,7 +174,7 @@ il_getOutCaps (void **pdata, const GstTensorsConfig * config)
   return gst_caps_from_string (DECODER_IL_TEXT_CAPS_STR);
 }
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static size_t
 il_getTransformSize (void **pdata, const GstTensorsConfig * config,
     GstCaps * caps, size_t size, GstCaps * othercaps, GstPadDirection direction)
@@ -205,7 +205,7 @@ case typename:\
   break;
 
 
-/** @brief tensordec-plugin's TensorDecDef callback */
+/** @brief tensordec-plugin's GstTensorDecoderDef callback */
 static GstFlowReturn
 il_decode (void **pdata, const GstTensorsConfig * config,
     const GstTensorMemory * input, GstBuffer * outbuf)
@@ -275,8 +275,8 @@ il_decode (void **pdata, const GstTensorsConfig * config,
 
 static gchar decoder_subplugin_image_labeling[] = "image_labeling";
 
-/** @brief Image Labeling tensordec-plugin TensorDecDef instance */
-static TensorDecDef imageLabeling = {
+/** @brief Image Labeling tensordec-plugin GstTensorDecoderDef instance */
+static GstTensorDecoderDef imageLabeling = {
   .modename = decoder_subplugin_image_labeling,
   .type = OUTPUT_TEXT,
   .init = il_init,
@@ -291,12 +291,12 @@ static TensorDecDef imageLabeling = {
 void
 init_il (void)
 {
-  tensordec_probe (&imageLabeling);
+  nnstreamer_decoder_probe (&imageLabeling);
 }
 
 /** @brief Destruct this object for tensordec-plugin */
 void
 fini_il (void)
 {
-  tensordec_exit (imageLabeling.modename);
+  nnstreamer_decoder_exit (imageLabeling.modename);
 }

--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -278,13 +278,12 @@ static gchar decoder_subplugin_image_labeling[] = "image_labeling";
 /** @brief Image Labeling tensordec-plugin GstTensorDecoderDef instance */
 static GstTensorDecoderDef imageLabeling = {
   .modename = decoder_subplugin_image_labeling,
-  .type = OUTPUT_TEXT,
   .init = il_init,
   .exit = il_exit,
   .setOption = il_setOption,
   .getOutCaps = il_getOutCaps,
   .getTransformSize = il_getTransformSize,
-  .decode = il_decode,
+  .decode = il_decode
 };
 
 /** @brief Initialize this object for tensordec-plugin */

--- a/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
@@ -28,17 +28,6 @@
 #include <gst/gst.h>
 
 /**
- * @brief Tensor Decoder Output type.
- */
-typedef enum
-{
-  OUTPUT_VIDEO,
-  OUTPUT_AUDIO,
-  OUTPUT_TEXT,
-  OUTPUT_UNKNOWN
-} GstDecMediaType;
-
-/**
  * @brief Decoder definitions for different semantics of tensors
  *        This allows developers to create their own decoders.
  */
@@ -46,8 +35,6 @@ typedef struct _GstTensorDecoderDef
 {
   char *modename;
       /**< Unique decoder name. GST users choose decoders with mode="modename". */
-  GstDecMediaType type;
-      /**< Output media type. VIDEO/AUDIO/TEXT are supported */
   int (*init) (void **private_data);
       /**< Object initialization for the decoder */
   void (*exit) (void **private_data);

--- a/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
@@ -14,7 +14,7 @@
  *
  */
 /**
- * @file  nnstreamer_plugin_api_filters.h
+ * @file  nnstreamer_plugin_api_decoder.h
  * @date  30 Jan 2019
  * @brief Mandatory APIs for NNStreamer Decoder sub-plugins (Need Gst Devel)
  * @see https://github.com/nnsuite/nnstreamer
@@ -42,7 +42,7 @@ typedef enum
  * @brief Decoder definitions for different semantics of tensors
  *        This allows developers to create their own decoders.
  */
-typedef struct _TensorDecDef
+typedef struct _GstTensorDecoderDef
 {
   char *modename;
       /**< Unique decoder name. GST users choose decoders with mode="modename". */
@@ -69,19 +69,22 @@ typedef struct _TensorDecDef
       GstCaps *caps, size_t size, GstCaps *othercaps,
       GstPadDirection direction);
       /**< EXPERIMENTAL! @todo We are not ready to use this. This should be NULL or return 0 */
-} TensorDecDef;
+} GstTensorDecoderDef;
 
 /* extern functions for subplugin management, exist in tensor_decoder.c */
 /**
  * @brief decoder's subplugins should call this function to register
  * @param[in] decoder The decoder subplugin instance
  */
-extern gboolean tensordec_probe (TensorDecDef * decoder);
+extern gboolean
+nnstreamer_decoder_probe (GstTensorDecoderDef * decoder);
+
 /**
  * @brief decoder's subplugin may call this to unregister
  * @param[in] name the name of decoder (modename)
  */
-extern void tensordec_exit (const gchar * name);
+extern void
+nnstreamer_decoder_exit (const gchar * name);
 
 
 #endif /* __NNS_PLUGIN_API_DECODER_H__ */

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -161,7 +161,7 @@ static gboolean gst_tensordec_transform_size (GstBaseTransform * trans,
  * @param[in] decoder The decoder subplugin instance
  */
 gboolean
-tensordec_probe (TensorDecDef * decoder)
+nnstreamer_decoder_probe (GstTensorDecoderDef * decoder)
 {
   return register_subplugin (NNS_SUBPLUGIN_DECODER, decoder->modename, decoder);
 }
@@ -171,7 +171,7 @@ tensordec_probe (TensorDecDef * decoder)
  * @param[in] name the name of decoder (modename)
  */
 void
-tensordec_exit (const gchar * name)
+nnstreamer_decoder_exit (const gchar * name)
 {
   unregister_subplugin (NNS_SUBPLUGIN_DECODER, name);
 }
@@ -180,8 +180,8 @@ tensordec_exit (const gchar * name)
  * @brief Find decoders subplugin with the name
  * @param[in] name the name of decoder (modename)
  */
-static const TensorDecDef *
-tensordec_find (const gchar * name)
+static const GstTensorDecoderDef *
+nnstreamer_decoder_find (const gchar * name)
 {
   return get_subplugin (NNS_SUBPLUGIN_DECODER, name);
 }
@@ -443,10 +443,10 @@ gst_tensordec_set_property (GObject * object, guint prop_id,
       break;
     case PROP_MODE:{
       int i;
-      const TensorDecDef *decoder;
+      const GstTensorDecoderDef *decoder;
       gboolean retval = TRUE;
       temp_string = g_value_dup_string (value);
-      decoder = tensordec_find (temp_string);
+      decoder = nnstreamer_decoder_find (temp_string);
 
       /* See if we are using "plugin" */
       if (NULL != decoder) {

--- a/gst/nnstreamer/tensor_decoder/tensordec.h
+++ b/gst/nnstreamer/tensor_decoder/tensordec.h
@@ -31,9 +31,10 @@
 
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
-#include <tensor_common.h>
-#include <nnstreamer_subplugin.h>
-#include <nnstreamer_plugin_api_decoder.h>
+
+#include "tensor_common.h"
+#include "nnstreamer_subplugin.h"
+#include "nnstreamer_plugin_api_decoder.h"
 
 G_BEGIN_DECLS
 
@@ -64,17 +65,14 @@ struct _GstTensorDec
   /** For transformer */
   gboolean negotiated; /**< TRUE if tensor metadata is set */
   gboolean silent; /**< True if logging is minimized */
-  guint output_type; /**< Denotes the output type */
-  guint mode; /** Mode for tensor decoder "direct_video" or "image_labeling" or "bounding_boxes */
   gchar *option[TensorDecMaxOpNum]; /**< Assume we have two options */
 
   /** For Tensor */
   gboolean configured; /**< TRUE if already successfully configured tensor metadata */
-  void *plugin_data;
-  void (*cleanup_plugin_data)(void **pdata); /**< exit() of subplugin is registered here. If it's null, gfree(plugin_data) is used. */
   GstTensorsConfig tensor_config; /**< configured tensor info @todo support tensors in the future */
 
   const GstTensorDecoderDef *decoder; /**< Plugin object */
+  void *plugin_data;
 };
 
 /**
@@ -88,15 +86,6 @@ struct _GstTensorDecClass
 {
   GstBaseTransformClass parent_class; /**< Inherits GstBaseTransformClass */
 };
-
-/**
- * @brief Decoder Mode.
- */
-typedef enum
-{
-  DECODE_MODE_PLUGIN,
-  DECODE_MODE_UNKNOWN
-} GstDecMode;
 
 /**
  * @brief Get Type function required for gst elements

--- a/gst/nnstreamer/tensor_decoder/tensordec.h
+++ b/gst/nnstreamer/tensor_decoder/tensordec.h
@@ -74,7 +74,7 @@ struct _GstTensorDec
   void (*cleanup_plugin_data)(void **pdata); /**< exit() of subplugin is registered here. If it's null, gfree(plugin_data) is used. */
   GstTensorsConfig tensor_config; /**< configured tensor info @todo support tensors in the future */
 
-  const TensorDecDef *decoder; /**< Plugin object */
+  const GstTensorDecoderDef *decoder; /**< Plugin object */
 };
 
 /**


### PR DESCRIPTION
1. change decoder register function / struct name
2. remove unnecessary private properties and code clean (sub-plugin mode only)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
