### PR TITLE
[Unittest] Added tensorflow-lite model data @open sesame 04/30 15:10

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -106,6 +106,7 @@ if get_option('install-test')
   install_subdir('nnstreamer_demux', install_dir: join_paths(unittest_install_dir,'tests'))
   install_subdir('nnstreamer_filter_custom', install_dir: join_paths(unittest_install_dir,'tests'))
   if get_option('enable-tensorflow-lite')
+    install_subdir('test_models', install_dir: join_paths(unittest_install_dir,'tests'))
     install_subdir('nnstreamer_filter_tensorflow_lite', install_dir: join_paths(unittest_install_dir,'tests'))
     install_subdir('nnstreamer_decoder_image_labeling', install_dir: join_paths(unittest_install_dir,'tests'))
   endif


### PR DESCRIPTION
# PR Description

Add tensorflow-lite model data when test unittest is installed.

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
