### PR TITLE
[Security] [Decoder/Sub-plugins] use glib to load labels

### DIFF
--- a/ext/nnstreamer/tensor_decoder/meson.build
+++ b/ext/nnstreamer/tensor_decoder/meson.build
@@ -56,13 +56,13 @@ endforeach
 
 shared_library('nnstreamer_decoder_bounding_boxes',
   nnstreamer_decoder_bounding_boxes_sources,
-  dependencies: [nnstreamer_dep, glib_dep, gst_dep],
+  dependencies: [nnstreamer_dep, glib_dep, gst_dep, libm_dep],
   install: true,
   install_dir: decoder_subplugin_install_dir
 )
 static_library('nnstreamer_decoder_bounding_boxes',
   nnstreamer_decoder_bounding_boxes_sources,
-  dependencies: [nnstreamer_dep, glib_dep, gst_dep],
+  dependencies: [nnstreamer_dep, glib_dep, gst_dep, libm_dep],
   install: true,
   install_dir: nnstreamer_libdir
 )


### PR DESCRIPTION
1. use glib function to load and initialize labels (fix one of security issues)
2. fix exception case when total label is larger then ssd model output

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
