### PR TITLE
[Build/Warning] add warnings used in gst-plugin-bad & add missing pro…

### DIFF
--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -47,23 +47,7 @@
 
 #include <gst/gst.h>
 #include <gst/gstplugin.h>
-
-#define NNSTREAMER_PLUGIN(name) \
-  extern gboolean G_PASTE(nnstreamer_export_, name) (GstPlugin *plugin)
-
-NNSTREAMER_PLUGIN (tensor_converter);
-NNSTREAMER_PLUGIN (tensor_aggregator);
-NNSTREAMER_PLUGIN (tensor_decoder);
-NNSTREAMER_PLUGIN (tensor_demux);
-NNSTREAMER_PLUGIN (tensor_merge);
-NNSTREAMER_PLUGIN (tensor_mux);
-NNSTREAMER_PLUGIN (tensor_sink);
-NNSTREAMER_PLUGIN (tensor_src_iio);
-NNSTREAMER_PLUGIN (tensor_split);
-NNSTREAMER_PLUGIN (tensor_transform);
-NNSTREAMER_PLUGIN (tensor_filter);
-NNSTREAMER_PLUGIN (tensor_reposink);
-NNSTREAMER_PLUGIN (tensor_reposrc);
+#include <tensor_common.h>
 
 #define NNSTREAMER_INIT(name, plugin) \
   do { \

--- a/gst/nnstreamer/tensor_common.h
+++ b/gst/nnstreamer/tensor_common.h
@@ -122,6 +122,22 @@ extern void gst_tensors_typefind_function (GstTypeFind * tf, gpointer pdata);
 #define NNSTREAMER_PLUGIN_INIT(name)	\
   gboolean G_PASTE(nnstreamer_export_, name) (GstPlugin * plugin)
 
+/**
+ * @brief Prototypes for tensor plugins
+ */
+NNSTREAMER_PLUGIN_INIT (tensor_converter);
+NNSTREAMER_PLUGIN_INIT (tensor_aggregator);
+NNSTREAMER_PLUGIN_INIT (tensor_decoder);
+NNSTREAMER_PLUGIN_INIT (tensor_demux);
+NNSTREAMER_PLUGIN_INIT (tensor_merge);
+NNSTREAMER_PLUGIN_INIT (tensor_mux);
+NNSTREAMER_PLUGIN_INIT (tensor_sink);
+NNSTREAMER_PLUGIN_INIT (tensor_src_iio);
+NNSTREAMER_PLUGIN_INIT (tensor_split);
+NNSTREAMER_PLUGIN_INIT (tensor_transform);
+NNSTREAMER_PLUGIN_INIT (tensor_filter);
+NNSTREAMER_PLUGIN_INIT (tensor_reposink);
+NNSTREAMER_PLUGIN_INIT (tensor_reposrc);
 
 /**
  * @brief A function call to decide current timestamp among collected pads based on PTS.

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,50 @@ cxx = meson.get_compiler('cpp')
 
 gst_api_verision = '1.0'
 
+# Set compiler warnings
+warning_flags = [
+  '-Wwrite-strings',
+  '-Wformat',
+  '-Wformat-security',
+  '-Winit-self',
+  '-Wmissing-include-dirs',
+  '-Waddress',
+  '-Wno-multichar',
+  '-Wvla',
+  '-Wpointer-arith',
+]
+
+warning_c_flags = [
+  '-Wmissing-prototypes',
+  '-Wdeclaration-after-statement',
+  '-Wold-style-definition',
+]
+
+warning_cxx_flags = [
+  '-Wformat-nonliteral',
+]
+
+foreach extra_arg : warning_c_flags
+  if cc.has_argument (extra_arg)
+    add_project_arguments([extra_arg], language: 'c')
+  endif
+endforeach
+
+foreach extra_arg : warning_cxx_flags
+  if cxx.has_argument (extra_arg)
+    add_project_arguments([extra_arg], language: 'cpp')
+  endif
+endforeach
+
+foreach extra_arg : warning_flags
+  if cc.has_argument (extra_arg)
+    add_project_arguments([extra_arg], language: 'c')
+  endif
+  if cxx.has_argument (extra_arg)
+    add_project_arguments([extra_arg], language: 'cpp')
+  endif
+endforeach
+
 # Set configuration
 nnstreamer_conf = configuration_data()
 nnstreamer_conf.set('VERSION', meson.project_version())


### PR DESCRIPTION
…ssing prototypes

1. Add compiler warnings used in gst-plugin-bad
2. Add prototypes for tensor plugins

NOTE:
- Wmissing-declarations is not compatible with 'tensorflow'
- Wredundant-decls is not compatible with 'gtest'

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>