### PR TITLE
[Tizen/API] Rename tizen-api.h to nnstreamer.h

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -301,7 +301,7 @@ popd
 %{_libdir}/libcapi-nnstreamer.so.*
 
 %files -n capi-nnstreamer-devel
-%{_includedir}/nnstreamer/tizen-api.h
+%{_includedir}/nnstreamer/nnstreamer.h
 %{_libdir}/pkgconfig/capi-nnstreamer.pc
 %{_libdir}/libcapi-nnstreamer.so
 %{_libdir}/libcapi-nnstreamer.a

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -7,7 +7,7 @@
  * @bug         No known bugs
  */
 
-#include <tizen-api.h>
+#include <nnstreamer.h>
 #include <gtest/gtest.h>
 #include <glib.h>
 #include <glib/gstdio.h> /* GStatBuf */

--- a/tizen-api/capi-nnstreamer.pc.in
+++ b/tizen-api/capi-nnstreamer.pc.in
@@ -4,7 +4,7 @@
 prefix=@PREFIX@
 exec_prefix=@PREFIX@
 libdir=@LIB_INSTALL_DIR@
-includedir=@INCLUDE_INSTALL_DIR@/nnstreamer
+includedir=@INCLUDE_INSTALL_DIR@
 
 Name: tizen-api-nnstreamer
 Description: NNStreamer API for Tizen

--- a/tizen-api/doc/nnstreamer_doc.h
+++ b/tizen-api/doc/nnstreamer_doc.h
@@ -52,7 +52,7 @@
  * @defgroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE NNStreamer Pipeline
  * @brief The NNStreamer API provides interfaces to create and execute stream pipelines with neural networks and sensors.
  * @section CAPI_ML_NNSTREAMER_PIPELINE_HEADER Required Header
- *   \#include <nnstreamer/tizen-api.h> \n
+ *   \#include <nnstreamer/nnstreamer.h> \n
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_OVERVIEW Overview
  * The NNStreamer API provides interfaces to create and execute stream pipelines with neural networks and sensors.

--- a/tizen-api/include/nnstreamer.h
+++ b/tizen-api/include/nnstreamer.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * @file tizen-api.h
+ * @file nnstreamer.h
  * @date 07 March 2019
  * @brief Tizen NNStreamer/Pipeline(main) C-API Header.
  *        This allows to construct and control NNStreamer pipelines.
@@ -23,8 +23,8 @@
  * @bug No known bugs except for NYI items
  */
 
-#ifndef __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__
-#define __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__
+#ifndef __TIZEN_MACHINELEARNING_NNSTREAMER_H__
+#define __TIZEN_MACHINELEARNING_NNSTREAMER_H__
 
 #include <stddef.h>
 #include <tizen_error.h>
@@ -418,4 +418,4 @@ int nns_pipeline_valve_control (nns_valve_h h, int valve_drop);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
-#endif /* __TIZEN_MACHINELEARNING_NNSTREAMER_TIZEN_API_H__ */
+#endif /* __TIZEN_MACHINELEARNING_NNSTREAMER_H__ */

--- a/tizen-api/include/tizen-api-private.h
+++ b/tizen-api/include/tizen-api-private.h
@@ -29,7 +29,7 @@
 #include <glib.h>
 #include <gmodule.h>
 #include <gst/gst.h>
-#include "tizen-api.h"
+#include "nnstreamer.h"
 #include <tizen_error.h>
 #include <nnstreamer/tensor_typedef.h>
 #include <gst/app/gstappsrc.h>

--- a/tizen-api/meson.build
+++ b/tizen-api/meson.build
@@ -22,7 +22,7 @@ capi_main = []
 capi_main += join_paths(meson.current_source_dir(), 'src', 'tizen-api-pipeline.c')
 
 capi_devel_main = []
-capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'tizen-api.h')
+capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer.h')
 
 inc = include_directories('include')
 nninc = include_directories('../gst')

--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -97,8 +97,8 @@ construct_element (GstElement * e, nns_pipeline * p, const char *name,
  * @brief Internal function to convert GstTensorsInfo into nns_tensors_info_s structure.
  */
 static int
-get_tensors_info_from_GstTensorsInfo (GstTensorsInfo *gst_tensorsinfo,
-  nns_tensors_info_s *tensors_info)
+get_tensors_info_from_GstTensorsInfo (GstTensorsInfo * gst_tensorsinfo,
+    nns_tensors_info_s * tensors_info)
 {
   if (!gst_tensorsinfo) {
     dlog_print (DLOG_ERROR, DLOG_TAG, "GstTensorsInfo should not be NULL!");
@@ -107,7 +107,7 @@ get_tensors_info_from_GstTensorsInfo (GstTensorsInfo *gst_tensorsinfo,
 
   /** Currently, the data structures of GstTensorsInfo are
    * completely same as that of nns_tensors_info_s. */
-  memcpy (tensors_info, gst_tensorsinfo, sizeof(GstTensorsInfo));
+  memcpy (tensors_info, gst_tensorsinfo, sizeof (GstTensorsInfo));
 
   return NNS_ERROR_NONE;
 }
@@ -271,7 +271,7 @@ cleanup_node (gpointer data)
 }
 
 /**
- * @brief Construct the pipeline (more info in tizen-api.h)
+ * @brief Construct the pipeline (more info in nnstreamer.h)
  */
 int
 nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
@@ -396,7 +396,7 @@ nns_pipeline_construct (const char *pipeline_description, nns_pipeline_h * pipe)
 }
 
 /**
- * @brief Destroy the pipeline (more info in tizen-api.h)
+ * @brief Destroy the pipeline (more info in nnstreamer.h)
  */
 int
 nns_pipeline_destroy (nns_pipeline_h pipe)
@@ -444,7 +444,7 @@ nns_pipeline_destroy (nns_pipeline_h pipe)
 }
 
 /**
- * @brief Get the pipeline state (more info in tizen-api.h)
+ * @brief Get the pipeline state (more info in nnstreamer.h)
  */
 int
 nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e * state)
@@ -473,7 +473,7 @@ nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e * state)
  ** NNStreamer Pipeline Start/Stop Control         **
  ****************************************************/
 /**
- * @brief Start/Resume the pipeline! (more info in tizen-api.h)
+ * @brief Start/Resume the pipeline! (more info in nnstreamer.h)
  */
 int
 nns_pipeline_start (nns_pipeline_h pipe)
@@ -492,7 +492,7 @@ nns_pipeline_start (nns_pipeline_h pipe)
 }
 
 /**
- * @brief Pause the pipeline! (more info in tizen-api.h)
+ * @brief Pause the pipeline! (more info in nnstreamer.h)
  */
 int
 nns_pipeline_stop (nns_pipeline_h pipe)
@@ -514,7 +514,7 @@ nns_pipeline_stop (nns_pipeline_h pipe)
  ** NNStreamer Pipeline Sink/Src Control           **
  ****************************************************/
 /**
- * @brief Register a callback for sink (more info in tizen-api.h)
+ * @brief Register a callback for sink (more info in nnstreamer.h)
  */
 int
 nns_pipeline_sink_register (nns_pipeline_h pipe, const char *sinkname,
@@ -576,7 +576,7 @@ unlock_return:
 }
 
 /**
- * @brief Unregister a callback for sink (more info in tizen-api.h)
+ * @brief Unregister a callback for sink (more info in nnstreamer.h)
  */
 int
 nns_pipeline_sink_unregister (nns_sink_h h)
@@ -589,7 +589,7 @@ nns_pipeline_sink_unregister (nns_sink_h h)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h,
+ * @brief Implementation of policies decalred by nns_buf_policy_e in nnstreamer.h,
  *        "Free"
  */
 static void
@@ -599,7 +599,7 @@ nnsbufpolicy_free (gpointer data)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h.
+ * @brief Implementation of policies decalred by nns_buf_policy_e in nnstreamer.h.
  *        "Do Nothing"
  */
 static void
@@ -609,7 +609,7 @@ nnsbufpolicy_nop (gpointer data)
 }
 
 /**
- * @brief Implementation of policies decalred by nns_buf_policy_e in tizen-api.h.
+ * @brief Implementation of policies decalred by nns_buf_policy_e in nnstreamer.h.
  */
 static const GDestroyNotify bufpolicy[NNS_BUF_POLICY_MAX] = {
   [NNS_BUF_FREE_BY_NNSTREAMER] = nnsbufpolicy_free,
@@ -617,11 +617,11 @@ static const GDestroyNotify bufpolicy[NNS_BUF_POLICY_MAX] = {
 };
 
 /**
- * @brief Get a handle to operate a src (more info in tizen-api.h)
+ * @brief Get a handle to operate a src (more info in nnstreamer.h)
  */
 int nns_pipeline_src_gethandle
-    (nns_pipeline_h pipe, const char *srcname, nns_tensors_info_s *tensors_info,
-    nns_src_h * h)
+    (nns_pipeline_h pipe, const char *srcname,
+    nns_tensors_info_s * tensors_info, nns_src_h * h)
 {
   nns_pipeline *p = pipe;
   element *elem;
@@ -716,7 +716,7 @@ unlock_return:
 }
 
 /**
- * @brief Close a src node (more info in tizen-api.h)
+ * @brief Close a src node (more info in nnstreamer.h)
  */
 int
 nns_pipeline_src_puthandle (nns_src_h h)
@@ -729,7 +729,7 @@ nns_pipeline_src_puthandle (nns_src_h h)
 }
 
 /**
- * @brief Push a data frame to a src (more info in tizen-api.h)
+ * @brief Push a data frame to a src (more info in nnstreamer.h)
  */
 int
 nns_pipeline_src_inputdata (nns_src_h h,
@@ -861,7 +861,7 @@ nns_pipeline_src_inputdata (nns_src_h h,
  ****************************************************/
 
 /**
- * @brief Get a handle to operate a selector (more info in tizen-api.h)
+ * @brief Get a handle to operate a selector (more info in nnstreamer.h)
  */
 int
 nns_pipeline_switch_gethandle (nns_pipeline_h pipe, const char *switchname,
@@ -936,7 +936,7 @@ unlock_return:
 }
 
 /**
- * @brief Close the given switch handle (more info in tizen-api.h)
+ * @brief Close the given switch handle (more info in nnstreamer.h)
  */
 int
 nns_pipeline_switch_puthandle (nns_switch_h h)
@@ -949,7 +949,7 @@ nns_pipeline_switch_puthandle (nns_switch_h h)
 }
 
 /**
- * @brief Control the switch (more info in tizen-api.h)
+ * @brief Control the switch (more info in nnstreamer.h)
  */
 int
 nns_pipeline_switch_select (nns_switch_h h, const char *padname)
@@ -995,7 +995,7 @@ nns_pipeline_switch_select (nns_switch_h h, const char *padname)
 }
 
 /**
- * @brief List nodes of a switch (more info in tizen-api.h)
+ * @brief List nodes of a switch (more info in nnstreamer.h)
  */
 int
 nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
@@ -1076,7 +1076,7 @@ nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
 }
 
 /**
- * @brief Get a handle to operate a Valve (more info in tizen-api.h)
+ * @brief Get a handle to operate a Valve (more info in nnstreamer.h)
  */
 int nns_pipeline_valve_gethandle
     (nns_pipeline_h pipe, const char *valvename, nns_valve_h * h)
@@ -1136,7 +1136,7 @@ unlock_return:
 }
 
 /**
- * @brief Close the given valve handle (more info in tizen-api.h)
+ * @brief Close the given valve handle (more info in nnstreamer.h)
  */
 int
 nns_pipeline_valve_puthandle (nns_valve_h h)
@@ -1149,7 +1149,7 @@ nns_pipeline_valve_puthandle (nns_valve_h h)
 }
 
 /**
- * @brief Control the valve with the given handle (more info in tizen-api.h)
+ * @brief Control the valve with the given handle (more info in nnstreamer.h)
  */
 int
 nns_pipeline_valve_control (nns_valve_h h, int valve_drop)


### PR DESCRIPTION
The file name "tizen-api.h" is ubsurd for Tizen application writers.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

CC: @again4you 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
