### PR TITLE
[Build/Meson] remove unnecessary flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,14 +139,12 @@ endif
 
 # Install .ini
 configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer.ini',
-  install: true,
   install_dir: nnstreamer_inidir,
   configuration: nnstreamer_conf
 )
 
 # Install .pc
 configure_file(input: 'nnstreamer.pc.in', output: 'nnstreamer.pc',
-  install: true,
   install_dir: join_paths(nnstreamer_libdir, 'pkgconfig'),
   configuration: nnstreamer_conf
 )

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -179,7 +179,6 @@ ninja -C build %{?_smp_mflags}
     export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
     export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
     %ifarch x86_64 aarch64
-    export TEST_TENSORFLOW=1
     export NNSTREAMER_TF_MEM_OPTMZ=0
     %endif
     ./tests/unittest_common

--- a/tizen-api/meson.build
+++ b/tizen-api/meson.build
@@ -64,7 +64,6 @@ tizen_capi_dep = declare_dependency(link_with: tizen_capi_lib,
 )
 
 configure_file(input: 'capi-nnstreamer.pc.in', output: 'capi-nnstreamer.pc',
-  install: true,
   install_dir: join_paths(nnstreamer_libdir, 'pkgconfig'),
   configuration: nnstreamer_conf
 )


### PR DESCRIPTION
Meson v0.50 supports the install arg in configure_file().
If install_dir is set, configured file will be installed.

Also, TEST_TENSORFLOW in rpm spec is unnecessary.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
