### PR TITLE
[Conf/Tensorflow] remove default flag in conf setting

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -81,7 +81,8 @@ tf_loadModelFile (const GstTensorFilterProperties * prop, void **private_data)
     }
   }
 
-  tf_mem_optmz = nnsconf_get_value_bool (NNSCONF_VAL_TF_MEM_OPTMZ);
+  tf_mem_optmz = nnsconf_get_custom_value_bool ("tensorflow",
+      "enable_mem_optimization", FALSE);
 
   tf = g_new0 (tf_data, 1); /** initialize tf Fill Zero! */
   *private_data = tf;

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -69,7 +69,6 @@ typedef enum {
   NNSCONF_PATH_FILTERS = 0,
   NNSCONF_PATH_DECODERS,
   NNSCONF_PATH_CUSTOM_FILTERS,
-  NNSCONF_PATH_CONFFILE,
 
   NNSCONF_PATH_END,
 } nnsconf_type_path;
@@ -90,7 +89,7 @@ nnsconf_loadconf (gboolean force_reload);
  *         Returns NULL if we cannot find the file.
  */
 extern const gchar *
-nnsconf_get_fullpath_fromfile (const gchar * file2find, nnsconf_type_path type);
+nnsconf_get_fullpath_from_file (const gchar * file2find, nnsconf_type_path type);
 
 /**
  * @brief Get the configured paths for the type with sub-plugin name.

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -41,14 +41,12 @@ G_BEGIN_DECLS
 #define NNSTREAMER_ENVVAR_FILTERS       "NNSTREAMER_FILTERS"
 #define NNSTREAMER_ENVVAR_DECODERS      "NNSTREAMER_DECODERS"
 #define NNSTREAMER_ENVVAR_CUSTOMFILTERS "NNSTREAMER_CUSTOMFILTERS"
-#define NNSTREAMER_ENVVAR_TF_MEM_OPTMZ  "NNSTREAMER_TF_MEM_OPTMZ"
 
 /* Internal Hardcoded Values */
 #define NNSTREAMER_DEFAULT_CONF_FILE    "/etc/nnstreamer.ini"
 #define NNSTREAMER_FILTERS              "/usr/lib/nnstreamer/filters/"
 #define NNSTREAMER_DECODERS             "/usr/lib/nnstreamer/decoders/"
 #define NNSTREAMER_CUSTOM_FILTERS       "/usr/lib/nnstreamer/customfilters/"
-#define NNSTREAMER_TF_MEM_OPTMZ         "false"
 /**
  *  Note that users still can place their custom filters anywhere if they
  * designate them with the full path.
@@ -75,12 +73,6 @@ typedef enum {
 
   NNSCONF_PATH_END,
 } nnsconf_type_path;
-
-typedef enum {
-  NNSCONF_VAL_TF_MEM_OPTMZ = 0,
-
-  NNSCONF_VAL_END,
-} nnsconf_type_value;
 
 /**
  * @brief Load the .ini file
@@ -127,15 +119,6 @@ nnsconf_get_subplugin_name_prefix (nnsconf_type_path type);
  */
 extern guint
 nnsconf_get_subplugin_info (nnsconf_type_path type, subplugin_info_s * info);
-
-/**
- * @brief Get the configured boolean values for the type
- * @param[in] type The type (TF_MEM_OPTMZ)
- * @return The boolean value to the file. Caller MUST NOT modify this.
- *         Returns FALSE if we cannot find the file or the value as a DEFAULT.
- */
-extern gboolean
-nnsconf_get_value_bool (nnsconf_type_value type);
 
 /**
  * @brief Get the custom configuration value from .ini and envvar.

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -8,7 +8,7 @@ decoders=@SUBPLUGIN_INSTALL_PREFIX@/decoders/
 # Set 1 or TRUE if you want to eliminate memcpy of tensorflow input frames for faster executions.
 # It may break in some special cases (running tensorflow & nnstreamer in a chroot of a AWS VM); in such a case, keep it 0 or FALSE.
 [tensorflow]
-mem_optmz=@TF_MEM_OPTMZ@
+enable_mem_optimization=@TF_MEM_OPTMZ@
 
 # Set 1 or TRUE if you want to use NNAPI with tensorflow-lite, which enables to use NNAPI backend, which may use GPU or NPU/TPU.
 [tensorflowlite]

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -5,11 +5,11 @@ customfilters=@SUBPLUGIN_INSTALL_PREFIX@/customfilters/
 [decoder]
 decoders=@SUBPLUGIN_INSTALL_PREFIX@/decoders/
 
-# Set 1 or TRUE if you want to eliminate memcpy of tensorflow input frames for faster executions.
+# Set 1 or True if you want to eliminate memcpy of tensorflow input frames for faster executions.
 # It may break in some special cases (running tensorflow & nnstreamer in a chroot of a AWS VM); in such a case, keep it 0 or FALSE.
 [tensorflow]
 enable_mem_optimization=@TF_MEM_OPTMZ@
 
-# Set 1 or TRUE if you want to use NNAPI with tensorflow-lite, which enables to use NNAPI backend, which may use GPU or NPU/TPU.
+# Set 1 or True if you want to use NNAPI with tensorflow-lite, which enables to use NNAPI backend, which may use GPU or NPU/TPU.
 [tensorflowlite]
-enable_nnapi=FALSE
+enable_nnapi=False

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -178,9 +178,6 @@ ninja -C build %{?_smp_mflags}
     export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
     export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
     export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
-    %ifarch x86_64 aarch64
-    export NNSTREAMER_TF_MEM_OPTMZ=0
-    %endif
     ./tests/unittest_common
     ./tests/unittest_sink --gst-plugin-path=.
     ./tests/unittest_plugins --gst-plugin-path=.


### PR DESCRIPTION
Remove default flag about tensorflow memory optimization.
In tensorflow sub-plugin, read this option using custom-bool function.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
