### PR TITLE
[Unittest] GCC7-GTEST compatibility

### DIFF
--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -181,11 +181,11 @@ TEST (common_get_tensor_dimension, case1)
   guint rank;
 
   rank = gst_tensor_parse_dimension ("345:123:433:177", dim);
-  EXPECT_EQ (rank, 4);
-  EXPECT_EQ (dim[0], 345);
-  EXPECT_EQ (dim[1], 123);
-  EXPECT_EQ (dim[2], 433);
-  EXPECT_EQ (dim[3], 177);
+  EXPECT_EQ (rank, 4U);
+  EXPECT_EQ (dim[0], 345U);
+  EXPECT_EQ (dim[1], 123U);
+  EXPECT_EQ (dim[2], 433U);
+  EXPECT_EQ (dim[3], 177U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (g_str_equal (dim_str, "345:123:433:177"));
@@ -202,11 +202,11 @@ TEST (common_get_tensor_dimension, case2)
   guint rank;
 
   rank = gst_tensor_parse_dimension ("345:123:433", dim);
-  EXPECT_EQ (rank, 3);
-  EXPECT_EQ (dim[0], 345);
-  EXPECT_EQ (dim[1], 123);
-  EXPECT_EQ (dim[2], 433);
-  EXPECT_EQ (dim[3], 1);
+  EXPECT_EQ (rank, 3U);
+  EXPECT_EQ (dim[0], 345U);
+  EXPECT_EQ (dim[1], 123U);
+  EXPECT_EQ (dim[2], 433U);
+  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (g_str_equal (dim_str, "345:123:433:1"));
@@ -223,11 +223,11 @@ TEST (common_get_tensor_dimension, case3)
   guint rank;
 
   rank = gst_tensor_parse_dimension ("345:123", dim);
-  EXPECT_EQ (rank, 2);
-  EXPECT_EQ (dim[0], 345);
-  EXPECT_EQ (dim[1], 123);
-  EXPECT_EQ (dim[2], 1);
-  EXPECT_EQ (dim[3], 1);
+  EXPECT_EQ (rank, 2U);
+  EXPECT_EQ (dim[0], 345U);
+  EXPECT_EQ (dim[1], 123U);
+  EXPECT_EQ (dim[2], 1U);
+  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (g_str_equal (dim_str, "345:123:1:1"));
@@ -244,11 +244,11 @@ TEST (common_get_tensor_dimension, case4)
   guint rank;
 
   rank = gst_tensor_parse_dimension ("345", dim);
-  EXPECT_EQ (rank, 1);
-  EXPECT_EQ (dim[0], 345);
-  EXPECT_EQ (dim[1], 1);
-  EXPECT_EQ (dim[2], 1);
-  EXPECT_EQ (dim[3], 1);
+  EXPECT_EQ (rank, 1U);
+  EXPECT_EQ (dim[0], 345U);
+  EXPECT_EQ (dim[1], 1U);
+  EXPECT_EQ (dim[2], 1U);
+  EXPECT_EQ (dim[3], 1U);
 
   dim_str = gst_tensor_get_dimension_string (dim);
   EXPECT_TRUE (g_str_equal (dim_str, "345:1:1:1"));
@@ -335,7 +335,7 @@ TEST (common_tensors_info_string, dimensions)
 
   /* 1 tensor info */
   num_dims = gst_tensors_info_parse_dimensions_string (&info, "1:2:3:4");
-  EXPECT_EQ (num_dims, 1);
+  EXPECT_EQ (num_dims, 1U);
 
   info.num_tensors = num_dims;
 
@@ -345,7 +345,7 @@ TEST (common_tensors_info_string, dimensions)
 
   /* 4 tensors info */
   num_dims = gst_tensors_info_parse_dimensions_string (&info, "1, 2, 3, 4");
-  EXPECT_EQ (num_dims, 4);
+  EXPECT_EQ (num_dims, 4U);
 
   info.num_tensors = num_dims;
 
@@ -356,7 +356,7 @@ TEST (common_tensors_info_string, dimensions)
   /* max */
   num_dims = gst_tensors_info_parse_dimensions_string (&info,
       "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20");
-  EXPECT_EQ (num_dims, NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_dims, (guint) NNS_TENSOR_SIZE_LIMIT);
 }
 
 /**
@@ -372,7 +372,7 @@ TEST (common_tensors_info_string, types)
 
   /* 1 tensor info */
   num_types = gst_tensors_info_parse_types_string (&info, "uint16");
-  EXPECT_EQ (num_types, 1);
+  EXPECT_EQ (num_types, 1U);
 
   info.num_tensors = num_types;
 
@@ -383,7 +383,7 @@ TEST (common_tensors_info_string, types)
   /* 4 tensors info */
   num_types = gst_tensors_info_parse_types_string (&info,
       "int8, int16, int32, int64");
-  EXPECT_EQ (num_types, 4);
+  EXPECT_EQ (num_types, 4U);
 
   info.num_tensors = num_types;
 
@@ -395,7 +395,7 @@ TEST (common_tensors_info_string, types)
   num_types = gst_tensors_info_parse_types_string (&info,
       "int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, "
       "int8, int8, int8, int8, int8, int8, int8, int8, int8, int8, int8");
-  EXPECT_EQ (num_types, NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_types, (guint) NNS_TENSOR_SIZE_LIMIT);
 }
 
 /**
@@ -411,7 +411,7 @@ TEST (common_tensors_info_string, names)
 
   /* 1 tensor info */
   num_names = gst_tensors_info_parse_names_string (&info, "t1");
-  EXPECT_EQ (num_names, 1);
+  EXPECT_EQ (num_names, 1U);
 
   info.num_tensors = num_names;
 
@@ -422,7 +422,7 @@ TEST (common_tensors_info_string, names)
   /* 4 tensors info */
   num_names = gst_tensors_info_parse_names_string (&info,
       "tensor1, tensor2, tensor3, tensor4");
-  EXPECT_EQ (num_names, 4);
+  EXPECT_EQ (num_names, 4U);
 
   info.num_tensors = num_names;
 
@@ -432,7 +432,7 @@ TEST (common_tensors_info_string, names)
 
   /* empty name string */
   num_names = gst_tensors_info_parse_names_string (&info, ",,");
-  EXPECT_EQ (num_names, 3);
+  EXPECT_EQ (num_names, 3U);
 
   info.num_tensors = num_names;
   for (i = 0; i < num_names; ++i) {
@@ -447,7 +447,7 @@ TEST (common_tensors_info_string, names)
   num_names = gst_tensors_info_parse_names_string (&info,
       "t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, "
       "t16, t17, t18, t19, t20, t21, t22, t23, t24, t25, t26, t27, t28");
-  EXPECT_EQ (num_names, NNS_TENSOR_SIZE_LIMIT);
+  EXPECT_EQ (num_names, (guint) NNS_TENSOR_SIZE_LIMIT);
 }
 
 /**

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -90,7 +90,7 @@
         out_buf = gst_harness_pull (h); \
         \
         ASSERT_TRUE (out_buf != NULL);  \
-        ASSERT_EQ (gst_buffer_n_memory (out_buf), 1); \
+        ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U); \
         ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size); \
         \
         mem = gst_buffer_peek_memory (out_buf, 0);  \
@@ -171,142 +171,142 @@ TEST (test_tensor_transform, properties)
 /**
  * @brief Test for tensor_transform typecast (uint8 > uint32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_1, 3, 5, uint8_t, _NNS_UINT8, uint32_t, "uint32", _NNS_UINT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_1, 3U, 5U, uint8_t, _NNS_UINT8, uint32_t, "uint32", _NNS_UINT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint8 > uint32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_1_accel, 3, 5, uint8_t, _NNS_UINT8, uint32_t, "uint32", _NNS_UINT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_1_accel, 3U, 5U, uint8_t, _NNS_UINT8, uint32_t, "uint32", _NNS_UINT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint32 > float64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_2, 3, 5, uint32_t, _NNS_UINT32, double, "float64", _NNS_FLOAT64, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_2, 3U, 5U, uint32_t, _NNS_UINT32, double, "float64", _NNS_FLOAT64, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint32 > float64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_2_accel, 3, 5, uint32_t, _NNS_UINT32, double, "float64", _NNS_FLOAT64, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_2_accel, 3U, 5U, uint32_t, _NNS_UINT32, double, "float64", _NNS_FLOAT64, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (int32 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_3, 3, 5, int32_t, _NNS_INT32, float, "float32", _NNS_FLOAT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_3, 3U, 5U, int32_t, _NNS_INT32, float, "float32", _NNS_FLOAT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, int32 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_3_accel, 3, 5, int32_t, _NNS_INT32, float, "float32", _NNS_FLOAT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_3_accel, 3U, 5U, int32_t, _NNS_INT32, float, "float32", _NNS_FLOAT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (int8 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_4, 3, 5, int8_t, _NNS_INT8, float, "float32", _NNS_FLOAT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_4, 3U, 5U, int8_t, _NNS_INT8, float, "float32", _NNS_FLOAT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, int8 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_4_accel, 3, 5, int8_t, _NNS_INT8, float, "float32", _NNS_FLOAT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_4_accel, 3U, 5U, int8_t, _NNS_INT8, float, "float32", _NNS_FLOAT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint8 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_5, 3, 5, uint8_t, _NNS_UINT8, float, "float32", _NNS_FLOAT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_5, 3U, 5U, uint8_t, _NNS_UINT8, float, "float32", _NNS_FLOAT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint8 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_5_accel, 3, 5, uint8_t, _NNS_UINT8, float, "float32", _NNS_FLOAT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_5_accel, 3U, 5U, uint8_t, _NNS_UINT8, float, "float32", _NNS_FLOAT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (int16 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_6, 3, 5, int16_t, _NNS_INT16, float, "float32", _NNS_FLOAT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_6, 3U, 5U, int16_t, _NNS_INT16, float, "float32", _NNS_FLOAT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, int16 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_6_accel, 3, 5, int16_t, _NNS_INT16, float, "float32", _NNS_FLOAT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_6_accel, 3U, 5U, int16_t, _NNS_INT16, float, "float32", _NNS_FLOAT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint16 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_7, 3, 5, uint16_t, _NNS_UINT16, float, "float32", _NNS_FLOAT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_7, 3U, 5U, uint16_t, _NNS_UINT16, float, "float32", _NNS_FLOAT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint16 > float32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_7_accel, 3, 5, uint16_t, _NNS_UINT16, float, "float32", _NNS_FLOAT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_7_accel, 3U, 5U, uint16_t, _NNS_UINT16, float, "float32", _NNS_FLOAT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint64 -> int64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_8, 3, 5, uint64_t, _NNS_UINT64, int64_t, "int64", _NNS_INT64, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_8, 3U, 5U, uint64_t, _NNS_UINT64, int64_t, "int64", _NNS_INT64, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint64 -> int64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_8_accel, 3, 5, uint64_t, _NNS_UINT64, int64_t, "int64", _NNS_INT64, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_8_accel, 3U, 5U, uint64_t, _NNS_UINT64, int64_t, "int64", _NNS_INT64, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (float -> uint32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_9, 3, 5, float, _NNS_FLOAT32, uint32_t, "uint32", _NNS_UINT32, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_9, 3U, 5U, float, _NNS_FLOAT32, uint32_t, "uint32", _NNS_UINT32, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, float -> uint32)
  */
-TEST_TRANSFORM_TYPECAST (typecast_9_accel, 3, 5, float, _NNS_FLOAT32, uint32_t, "uint32", _NNS_UINT32, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_9_accel, 3U, 5U, float, _NNS_FLOAT32, uint32_t, "uint32", _NNS_UINT32, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint8 -> int8)
  */
-TEST_TRANSFORM_TYPECAST (typecast_10, 3, 5, uint8_t, _NNS_UINT8, int8_t, "int8", _NNS_INT8, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_10, 3U, 5U, uint8_t, _NNS_UINT8, int8_t, "int8", _NNS_INT8, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint8 -> int8)
  */
-TEST_TRANSFORM_TYPECAST (typecast_10_accel, 3, 5, uint8_t, _NNS_UINT8, int8_t, "int8", _NNS_INT8, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_10_accel, 3U, 5U, uint8_t, _NNS_UINT8, int8_t, "int8", _NNS_INT8, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (uint32 -> int16)
  */
-TEST_TRANSFORM_TYPECAST (typecast_11, 3, 5, uint32_t, _NNS_UINT32, int16_t, "int16", _NNS_INT16, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_11, 3U, 5U, uint32_t, _NNS_UINT32, int16_t, "int16", _NNS_INT16, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, uint32 -> int16)
  */
-TEST_TRANSFORM_TYPECAST (typecast_11_accel, 3, 5, uint32_t, _NNS_UINT32, int16_t, "int16", _NNS_INT16, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_11_accel, 3U, 5U, uint32_t, _NNS_UINT32, int16_t, "int16", _NNS_INT16, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (float -> uint8)
  */
-TEST_TRANSFORM_TYPECAST (typecast_12, 3, 5, float, _NNS_FLOAT32, uint8_t, "uint8", _NNS_UINT8, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_12, 3U, 5U, float, _NNS_FLOAT32, uint8_t, "uint8", _NNS_UINT8, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, float -> uint8)
  */
-TEST_TRANSFORM_TYPECAST (typecast_12_accel, 3, 5, float, _NNS_FLOAT32, uint8_t, "uint8", _NNS_UINT8, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_12_accel, 3U, 5U, float, _NNS_FLOAT32, uint8_t, "uint8", _NNS_UINT8, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (double -> uint16)
  */
-TEST_TRANSFORM_TYPECAST (typecast_13, 3, 5, double, _NNS_FLOAT64, uint16_t, "uint16", _NNS_UINT16, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_13, 3U, 5U, double, _NNS_FLOAT64, uint16_t, "uint16", _NNS_UINT16, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, double -> uint16)
  */
-TEST_TRANSFORM_TYPECAST (typecast_13_accel, 3, 5, double, _NNS_FLOAT64, uint16_t, "uint16", _NNS_UINT16, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_13_accel, 3U, 5U, double, _NNS_FLOAT64, uint16_t, "uint16", _NNS_UINT16, TRUE)
 
 /**
  * @brief Test for tensor_transform typecast (double -> uint64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_14, 3, 5, double, _NNS_FLOAT64, uint64_t, "uint64", _NNS_UINT64, FALSE)
+TEST_TRANSFORM_TYPECAST (typecast_14, 3U, 5U, double, _NNS_FLOAT64, uint64_t, "uint64", _NNS_UINT64, FALSE)
 
 /**
  * @brief Test for tensor_transform typecast (acceleration, double -> uint64)
  */
-TEST_TRANSFORM_TYPECAST (typecast_14_accel, 3, 5, double, _NNS_FLOAT64, uint64_t, "uint64", _NNS_UINT64, TRUE)
+TEST_TRANSFORM_TYPECAST (typecast_14_accel, 3U, 5U, double, _NNS_FLOAT64, uint64_t, "uint64", _NNS_UINT64, TRUE)
 
 /**
  * @brief Test for tensor_transform arithmetic (float32, add .5)
@@ -359,7 +359,7 @@ TEST (test_tensor_transform, arithmetic_1)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -429,7 +429,7 @@ TEST (test_tensor_transform, arithmetic_1_accel)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -499,7 +499,7 @@ TEST (test_tensor_transform, arithmetic_2)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -569,7 +569,7 @@ TEST (test_tensor_transform, arithmetic_2_accel)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -643,7 +643,7 @@ TEST (test_tensor_transform, arithmetic_3)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -717,7 +717,7 @@ TEST (test_tensor_transform, arithmetic_3_accel)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -791,7 +791,7 @@ TEST (test_tensor_transform, arithmetic_4)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -865,7 +865,7 @@ TEST (test_tensor_transform, arithmetic_4_accel)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -939,7 +939,7 @@ TEST (test_tensor_transform, arithmetic_5)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1013,7 +1013,7 @@ TEST (test_tensor_transform, arithmetic_5_accel)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1077,7 +1077,7 @@ TEST (test_tensor_transform, arithmetic_change_option_string)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1111,7 +1111,7 @@ TEST (test_tensor_transform, arithmetic_change_option_string)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1125,7 +1125,7 @@ TEST (test_tensor_transform, arithmetic_change_option_string)
   gst_memory_unmap (mem, &info);
   gst_buffer_unref (out_buf);
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 2);
+  EXPECT_EQ (gst_harness_buffers_received (h), 2U);
   gst_harness_teardown (h);
 }
 
@@ -1161,7 +1161,7 @@ TEST (test_tensor_aggregator, properties)
 
   /* default frames-in is 1 */
   g_object_get (h->element, "frames-in", &fr_val, NULL);
-  EXPECT_EQ (fr_val, 1);
+  EXPECT_EQ (fr_val, 1U);
 
   fr_val = 2;
   g_object_set (h->element, "frames-in", fr_val, NULL);
@@ -1170,7 +1170,7 @@ TEST (test_tensor_aggregator, properties)
 
   /* default frames-out is 1 */
   g_object_get (h->element, "frames-out", &fr_val, NULL);
-  EXPECT_EQ (fr_val, 1);
+  EXPECT_EQ (fr_val, 1U);
 
   fr_val = 2;
   g_object_set (h->element, "frames-out", fr_val, NULL);
@@ -1179,7 +1179,7 @@ TEST (test_tensor_aggregator, properties)
 
   /* default frames-flush is 0 */
   g_object_get (h->element, "frames-flush", &fr_val, NULL);
-  EXPECT_EQ (fr_val, 0);
+  EXPECT_EQ (fr_val, 0U);
 
   fr_val = 2;
   g_object_set (h->element, "frames-flush", fr_val, NULL);
@@ -1188,7 +1188,7 @@ TEST (test_tensor_aggregator, properties)
 
   /* default frames-dim is (NNS_TENSOR_RANK_LIMIT - 1) */
   g_object_get (h->element, "frames-dim", &fr_val, NULL);
-  EXPECT_EQ (fr_val, (NNS_TENSOR_RANK_LIMIT - 1));
+  EXPECT_EQ (fr_val, (guint) (NNS_TENSOR_RANK_LIMIT - 1));
 
   fr_val = 1;
   g_object_set (h->element, "frames-dim", fr_val, NULL);
@@ -1262,7 +1262,7 @@ TEST (test_tensor_aggregator, aggregate_1)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1286,7 +1286,7 @@ TEST (test_tensor_aggregator, aggregate_1)
   gst_memory_unmap (mem, &info);
   gst_buffer_unref (out_buf);
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 1);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
   gst_harness_teardown (h);
 }
 
@@ -1338,7 +1338,7 @@ TEST (test_tensor_aggregator, aggregate_2)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1362,7 +1362,7 @@ TEST (test_tensor_aggregator, aggregate_2)
   gst_memory_unmap (mem, &info);
   gst_buffer_unref (out_buf);
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 1);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
   gst_harness_teardown (h);
 }
 
@@ -1414,7 +1414,7 @@ TEST (test_tensor_aggregator, aggregate_3)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1438,7 +1438,7 @@ TEST (test_tensor_aggregator, aggregate_3)
   gst_memory_unmap (mem, &info);
   gst_buffer_unref (out_buf);
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 1);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
   gst_harness_teardown (h);
 }
 
@@ -1490,7 +1490,7 @@ TEST (test_tensor_aggregator, aggregate_4)
   out_buf = gst_harness_pull (h);
 
   ASSERT_TRUE (out_buf != NULL);
-  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+  ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
   ASSERT_EQ (gst_buffer_get_size (out_buf), data_out_size);
 
   mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1514,7 +1514,7 @@ TEST (test_tensor_aggregator, aggregate_4)
   gst_memory_unmap (mem, &info);
   gst_buffer_unref (out_buf);
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 1);
+  EXPECT_EQ (gst_harness_buffers_received (h), 1U);
   gst_harness_teardown (h);
 }
 
@@ -1562,7 +1562,7 @@ TEST (test_tensor_aggregator, aggregate_5)
     out_buf = gst_harness_pull (h);
 
     ASSERT_TRUE (out_buf != NULL);
-    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1);
+    ASSERT_EQ (gst_buffer_n_memory (out_buf), 1U);
     ASSERT_EQ (gst_buffer_get_size (out_buf), data_size);
 
     mem = gst_buffer_peek_memory (out_buf, 0);
@@ -1576,7 +1576,7 @@ TEST (test_tensor_aggregator, aggregate_5)
     gst_buffer_unref (out_buf);
   }
 
-  EXPECT_EQ (gst_harness_buffers_received (h), 2);
+  EXPECT_EQ (gst_harness_buffers_received (h), 2U);
   gst_harness_teardown (h);
 }
 
@@ -1595,23 +1595,23 @@ TEST (test_tensor_transform, orc_add)
   int8_t data_s8[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s8[i] = i - 1;
+    data_s8[i] = (gint) i - 1;
   }
 
   nns_orc_add_c_s8 (data_s8, -20, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s8[i], i - 1 - 20);
+    EXPECT_EQ (data_s8[i], (gint) i - 1 - 20);
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s8[i] = i + 1;
+    data_s8[i] = (gint) i + 1;
   }
 
   nns_orc_add_c_s8 (data_s8, 20, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s8[i], i + 1 + 20);
+    EXPECT_EQ (data_s8[i], (gint) i + 1 + 20);
   }
 
   /* add constant u8 */
@@ -1631,23 +1631,23 @@ TEST (test_tensor_transform, orc_add)
   int16_t data_s16[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s16[i] = i - 1;
+    data_s16[i] = (gint) i - 1;
   }
 
   nns_orc_add_c_s16 (data_s16, -16, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s16[i], i - 1 - 16);
+    EXPECT_EQ (data_s16[i], (gint) i - 1 - 16);
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s16[i] = i + 1;
+    data_s16[i] = (gint) i + 1;
   }
 
   nns_orc_add_c_s16 (data_s16, 16, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s16[i], i + 1 + 16);
+    EXPECT_EQ (data_s16[i], (gint) i + 1 + 16);
   }
 
   /* add constant u16 */
@@ -1667,23 +1667,23 @@ TEST (test_tensor_transform, orc_add)
   int32_t data_s32[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s32[i] = i + 1;
+    data_s32[i] = (gint) i + 1;
   }
 
   nns_orc_add_c_s32 (data_s32, -32, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s32[i], i + 1 - 32);
+    EXPECT_EQ (data_s32[i], (gint) i + 1 - 32);
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s32[i] = i + 1;
+    data_s32[i] = (gint) i + 1;
   }
 
   nns_orc_add_c_s32 (data_s32, 32, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s32[i], i + 1 + 32);
+    EXPECT_EQ (data_s32[i], (gint) i + 1 + 32);
   }
 
   /* add constant u32 */
@@ -1758,23 +1758,23 @@ TEST (test_tensor_transform, orc_mul)
   int8_t data_s8[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s8[i] = i + 1;
+    data_s8[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s8 (data_s8, -3, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s8[i], (i + 1) * (-3));
+    EXPECT_EQ (data_s8[i], (gint) (i + 1) * (-3));
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s8[i] = i + 1;
+    data_s8[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s8 (data_s8, 5, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s8[i], (i + 1) * 5);
+    EXPECT_EQ (data_s8[i], (gint) (i + 1) * 5);
   }
 
   /* mul constant u8 */
@@ -1794,23 +1794,23 @@ TEST (test_tensor_transform, orc_mul)
   int16_t data_s16[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s16[i] = i + 1;
+    data_s16[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s16 (data_s16, -16, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s16[i], (i + 1) * (-16));
+    EXPECT_EQ (data_s16[i], (gint) (i + 1) * (-16));
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s16[i] = i + 1;
+    data_s16[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s16 (data_s16, 16, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s16[i], (i + 1) * 16);
+    EXPECT_EQ (data_s16[i], (gint) (i + 1) * 16);
   }
 
   /* mul constant u16 */
@@ -1830,23 +1830,23 @@ TEST (test_tensor_transform, orc_mul)
   int32_t data_s32[array_size] = { 0, };
 
   for (i = 0; i < array_size; i++) {
-    data_s32[i] = i + 1;
+    data_s32[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s32 (data_s32, -32, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s32[i], (i + 1) * (-32));
+    EXPECT_EQ (data_s32[i], (gint) (i + 1) * (-32));
   }
 
   for (i = 0; i < array_size; i++) {
-    data_s32[i] = i + 1;
+    data_s32[i] = (gint) i + 1;
   }
 
   nns_orc_mul_c_s32 (data_s32, 32, array_size);
 
   for (i = 0; i < array_size; i++) {
-    EXPECT_EQ (data_s32[i], (i + 1) * 32);
+    EXPECT_EQ (data_s32[i], (gint) (i + 1) * 32);
   }
 
   /* mul constant u32 */

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -965,7 +965,7 @@ TEST (tensor_sink_test, properties)
 
   /** default signal-rate is 0 */
   g_object_get (g_test_data.sink, "signal-rate", &rate, NULL);
-  EXPECT_EQ (rate, 0);
+  EXPECT_EQ (rate, 0U);
 
   rate += 10;
   g_object_set (g_test_data.sink, "signal-rate", rate, NULL);
@@ -1107,7 +1107,7 @@ TEST (tensor_sink_test, emit_signal)
   EXPECT_EQ (g_test_data.status, TEST_EOS);
 
   /** check received buffers and signals */
-  EXPECT_EQ (g_test_data.received, 0);
+  EXPECT_EQ (g_test_data.received, 0U);
   EXPECT_EQ (g_test_data.start, FALSE);
   EXPECT_EQ (g_test_data.end, FALSE);
 
@@ -1190,7 +1190,7 @@ TEST (tensor_sink_test, caps_error)
   EXPECT_EQ (g_test_data.status, TEST_ERR_MESSAGE);
 
   /** check received buffers */
-  EXPECT_EQ (g_test_data.received, 0);
+  EXPECT_EQ (g_test_data.received, 0U);
 
   /** check caps and config for tensor */
   {
@@ -1234,8 +1234,8 @@ TEST (tensor_sink_test, caps_tensors)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 2);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 2U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
@@ -1245,14 +1245,14 @@ TEST (tensor_sink_test, caps_tensors)
 
   /** check tensors config for video */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 2);
+  EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 2U);
 
   for (i = 0; i < g_test_data.tensors_config.info.num_tensors; i++) {
     EXPECT_EQ (g_test_data.tensors_config.info.info[i].type, _NNS_UINT8);
-    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[0], 3);
-    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[1], 160);
-    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[2], 120);
-    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[3], 1);
+    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[0], 3U);
+    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[1], 160U);
+    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[2], 120U);
+    EXPECT_EQ (g_test_data.tensors_config.info.info[i].dimension[3], 1U);
   }
 
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 30);
@@ -1298,8 +1298,8 @@ TEST (tensor_stream_test, video_rgb)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1310,10 +1310,10 @@ TEST (tensor_stream_test, video_rgb)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1340,8 +1340,8 @@ TEST (tensor_stream_test, video_bgr)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1352,10 +1352,10 @@ TEST (tensor_stream_test, video_bgr)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1382,8 +1382,8 @@ TEST (tensor_stream_test, video_rgb_padding)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1394,10 +1394,10 @@ TEST (tensor_stream_test, video_rgb_padding)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1424,8 +1424,8 @@ TEST (tensor_stream_test, video_bgr_padding)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1436,10 +1436,10 @@ TEST (tensor_stream_test, video_bgr_padding)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1466,8 +1466,8 @@ TEST (tensor_stream_test, video_rgb_3f)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 3);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1478,10 +1478,10 @@ TEST (tensor_stream_test, video_rgb_3f)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1508,8 +1508,8 @@ TEST (tensor_stream_test, video_rgba)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1520,10 +1520,10 @@ TEST (tensor_stream_test, video_rgba)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1550,8 +1550,8 @@ TEST (tensor_stream_test, video_bgra)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1562,10 +1562,10 @@ TEST (tensor_stream_test, video_bgra)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1592,8 +1592,8 @@ TEST (tensor_stream_test, video_argb)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1604,10 +1604,10 @@ TEST (tensor_stream_test, video_argb)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1634,8 +1634,8 @@ TEST (tensor_stream_test, video_abgr)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1646,10 +1646,10 @@ TEST (tensor_stream_test, video_abgr)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1676,8 +1676,8 @@ TEST (tensor_stream_test, video_rgbx)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1688,10 +1688,10 @@ TEST (tensor_stream_test, video_rgbx)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1718,8 +1718,8 @@ TEST (tensor_stream_test, video_xrgb)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1730,10 +1730,10 @@ TEST (tensor_stream_test, video_xrgb)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1760,8 +1760,8 @@ TEST (tensor_stream_test, video_xbgr)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1772,10 +1772,10 @@ TEST (tensor_stream_test, video_xbgr)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1802,8 +1802,8 @@ TEST (tensor_stream_test, video_bgrx)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 162 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1814,10 +1814,10 @@ TEST (tensor_stream_test, video_bgrx)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1844,8 +1844,8 @@ TEST (tensor_stream_test, video_bgrx_2f)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 2);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4 * 160 * 120 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U * 160 * 120 * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1856,10 +1856,10 @@ TEST (tensor_stream_test, video_bgrx_2f)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 2);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 4U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 2U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1886,8 +1886,8 @@ TEST (tensor_stream_test, video_gray8)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 160 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 160U * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1898,10 +1898,10 @@ TEST (tensor_stream_test, video_gray8)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1928,8 +1928,8 @@ TEST (tensor_stream_test, video_gray8_padding)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 162 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 162U * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1940,10 +1940,10 @@ TEST (tensor_stream_test, video_gray8_padding)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -1970,8 +1970,8 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
 
   /** check received buffers and signals */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 162 * 120 * 3);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 162U * 120 * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -1982,10 +1982,10 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2012,8 +2012,8 @@ TEST (tensor_stream_test, audio_s8)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2024,10 +2024,10 @@ TEST (tensor_stream_test, audio_s8)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2054,8 +2054,8 @@ TEST (tensor_stream_test, audio_u8_100f)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 5);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 100);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 100U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2066,10 +2066,10 @@ TEST (tensor_stream_test, audio_u8_100f)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 100);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 100U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2096,8 +2096,8 @@ TEST (tensor_stream_test, audio_s16)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2108,10 +2108,10 @@ TEST (tensor_stream_test, audio_s16)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2138,8 +2138,8 @@ TEST (tensor_stream_test, audio_u16_1000f)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers / 2);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2 * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2150,10 +2150,10 @@ TEST (tensor_stream_test, audio_u16_1000f)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1000);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1000U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2180,8 +2180,8 @@ TEST (tensor_stream_test, audio_s32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 4);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2192,10 +2192,10 @@ TEST (tensor_stream_test, audio_s32)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 44100);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2222,8 +2222,8 @@ TEST (tensor_stream_test, audio_u32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 4);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2234,10 +2234,10 @@ TEST (tensor_stream_test, audio_u32)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 44100);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2264,8 +2264,8 @@ TEST (tensor_stream_test, audio_f32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 4);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 4);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2276,10 +2276,10 @@ TEST (tensor_stream_test, audio_f32)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_FLOAT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 44100);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2306,8 +2306,8 @@ TEST (tensor_stream_test, audio_f64)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 8);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 8);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2318,10 +2318,10 @@ TEST (tensor_stream_test, audio_f64)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_FLOAT64);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 44100);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2355,8 +2355,8 @@ TEST (tensor_stream_test, text_utf8)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 20);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 20U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2367,10 +2367,10 @@ TEST (tensor_stream_test, text_utf8)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 20);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 20U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2412,7 +2412,7 @@ TEST (tensor_stream_test, text_utf8_3f)
   EXPECT_EQ (prop_bool, TRUE);
 
   g_object_get (convert, "frames-per-tensor", &prop_uint, NULL);
-  EXPECT_EQ (prop_uint, 3);
+  EXPECT_EQ (prop_uint, 3U);
 
   gst_object_unref (convert);
 
@@ -2431,8 +2431,8 @@ TEST (tensor_stream_test, text_utf8_3f)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers / 3);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 30 * 3);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 30U * 3);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2443,10 +2443,10 @@ TEST (tensor_stream_test, text_utf8_3f)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 30);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 30U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2480,8 +2480,8 @@ TEST (tensor_stream_test, octet_current_ts)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2492,10 +2492,10 @@ TEST (tensor_stream_test, octet_current_ts)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2529,8 +2529,8 @@ TEST (tensor_stream_test, octet_framerate_ts)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2541,10 +2541,10 @@ TEST (tensor_stream_test, octet_framerate_ts)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2586,7 +2586,7 @@ TEST (tensor_stream_test, octet_valid_ts)
   EXPECT_EQ (prop_bool, TRUE);
 
   g_object_get (convert, "frames-per-tensor", &prop_uint, NULL);
-  EXPECT_EQ (prop_uint, 1);
+  EXPECT_EQ (prop_uint, 1U);
 
   gst_object_unref (convert);
 
@@ -2605,8 +2605,8 @@ TEST (tensor_stream_test, octet_valid_ts)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2617,10 +2617,10 @@ TEST (tensor_stream_test, octet_valid_ts)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2662,7 +2662,7 @@ TEST (tensor_stream_test, octet_invalid_ts)
   EXPECT_EQ (prop_bool, TRUE);
 
   g_object_get (convert, "frames-per-tensor", &prop_uint, NULL);
-  EXPECT_EQ (prop_uint, 1);
+  EXPECT_EQ (prop_uint, 1U);
 
   gst_object_unref (convert);
 
@@ -2681,8 +2681,8 @@ TEST (tensor_stream_test, octet_invalid_ts)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2693,10 +2693,10 @@ TEST (tensor_stream_test, octet_invalid_ts)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2738,7 +2738,7 @@ TEST (tensor_stream_test, octet_2f)
   EXPECT_EQ (prop_bool, TRUE);
 
   g_object_get (convert, "frames-per-tensor", &prop_uint, NULL);
-  EXPECT_EQ (prop_uint, 1);
+  EXPECT_EQ (prop_uint, 1U);
 
   gst_object_unref (convert);
 
@@ -2757,8 +2757,8 @@ TEST (tensor_stream_test, octet_2f)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 2);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 5);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 5U);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2769,10 +2769,10 @@ TEST (tensor_stream_test, octet_2f)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 5);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 5U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 10);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2799,8 +2799,8 @@ TEST (tensor_stream_test, custom_filter_tensor)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -2811,10 +2811,10 @@ TEST (tensor_stream_test, custom_filter_tensor)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -2858,8 +2858,8 @@ TEST (tensor_stream_test, custom_filter_tensors)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 3);
-  EXPECT_EQ (g_test_data.received_size, 95616); /** 160 * 120 * 3 + 120 * 80 * 3 + 64 * 48 * 3 */
+  EXPECT_EQ (g_test_data.mem_blocks, 3U);
+  EXPECT_EQ (g_test_data.received_size, 95616U); /** 160 * 120 * 3 + 120 * 80 * 3 + 64 * 48 * 3 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensors"));
@@ -2869,25 +2869,25 @@ TEST (tensor_stream_test, custom_filter_tensors)
 
   /** check tensors config for video */
   EXPECT_TRUE (gst_tensors_config_validate (&g_test_data.tensors_config));
-  EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 3);
+  EXPECT_EQ (g_test_data.tensors_config.info.num_tensors, 3U);
 
   EXPECT_EQ (g_test_data.tensors_config.info.info[0].type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[0].dimension[3], 1U);
 
   EXPECT_EQ (g_test_data.tensors_config.info.info[1].type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[1], 120);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[2], 80);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[1], 120U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[2], 80U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[1].dimension[3], 1U);
 
   EXPECT_EQ (g_test_data.tensors_config.info.info[2].type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[1], 64);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[2], 48);
-  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[1], 64U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[2], 48U);
+  EXPECT_EQ (g_test_data.tensors_config.info.info[2].dimension[3], 1U);
 
   EXPECT_EQ (g_test_data.tensors_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensors_config.rate_d, 1);
@@ -3121,9 +3121,9 @@ TEST (tensor_stream_test, custom_filter_drop_buffer)
   EXPECT_EQ (g_test_data.status, TEST_EOS);
 
   /** check received buffers */
-  EXPECT_EQ (g_test_data.received, 2);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 200 * 2);
+  EXPECT_EQ (g_test_data.received, 2U);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 200U * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3134,10 +3134,10 @@ TEST (tensor_stream_test, custom_filter_drop_buffer)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 200);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 200U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3164,8 +3164,8 @@ TEST (tensor_stream_test, tensors_mix)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3176,10 +3176,10 @@ TEST (tensor_stream_test, tensors_mix)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30); /** 30 fps from video stream */
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3245,8 +3245,8 @@ TEST (tensor_stream_test, demux_properties_1)
 
   /* check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 64 * 48);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 64 * 48);
 
   /* check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3257,10 +3257,10 @@ TEST (tensor_stream_test, demux_properties_1)
   /* check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 64);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 48);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 64U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 48U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3309,8 +3309,8 @@ TEST (tensor_stream_test, demux_properties_2)
 
   /* check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2);
 
   /* check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3321,10 +3321,10 @@ TEST (tensor_stream_test, demux_properties_2)
   /* check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 500U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3360,8 +3360,8 @@ TEST (tensor_stream_test, typecast_int32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3372,10 +3372,10 @@ TEST (tensor_stream_test, typecast_int32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3411,8 +3411,8 @@ TEST (tensor_stream_test, typecast_uint32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3423,10 +3423,10 @@ TEST (tensor_stream_test, typecast_uint32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3462,8 +3462,8 @@ TEST (tensor_stream_test, typecast_int16)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3474,10 +3474,10 @@ TEST (tensor_stream_test, typecast_int16)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3513,8 +3513,8 @@ TEST (tensor_stream_test, typecast_uint16)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3525,10 +3525,10 @@ TEST (tensor_stream_test, typecast_uint16)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3564,8 +3564,8 @@ TEST (tensor_stream_test, typecast_float64)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3576,10 +3576,10 @@ TEST (tensor_stream_test, typecast_float64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3615,8 +3615,8 @@ TEST (tensor_stream_test, typecast_float32)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3627,10 +3627,10 @@ TEST (tensor_stream_test, typecast_float32)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3666,8 +3666,8 @@ TEST (tensor_stream_test, typecast_int64)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3678,10 +3678,10 @@ TEST (tensor_stream_test, typecast_int64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3717,8 +3717,8 @@ TEST (tensor_stream_test, typecast_uint64)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 10 * t_size);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 10U * t_size);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3729,10 +3729,10 @@ TEST (tensor_stream_test, typecast_uint64)
   /** check tensor config for text */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, t_type);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 10U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 0);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3779,8 +3779,8 @@ TEST (tensor_stream_test, video_split)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 160 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 160U * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3791,10 +3791,10 @@ TEST (tensor_stream_test, video_split)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3821,8 +3821,8 @@ TEST (tensor_stream_test, video_aggregate_1)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, (num_buffers - 10) / 5 + 1);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 160 * 120 * 10);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 160 * 120 * 10);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3833,10 +3833,10 @@ TEST (tensor_stream_test, video_aggregate_1)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 10);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 10U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3863,8 +3863,8 @@ TEST (tensor_stream_test, video_aggregate_2)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, (num_buffers - 10) / 5 + 1);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 1600 * 120);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 1600 * 120);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3875,10 +3875,10 @@ TEST (tensor_stream_test, video_aggregate_2)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1600);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1600U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3905,8 +3905,8 @@ TEST (tensor_stream_test, video_aggregate_3)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, (num_buffers / 10));
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 3 * 64 * 48 * 8);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 3U * 64 * 48 * 8);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3917,10 +3917,10 @@ TEST (tensor_stream_test, video_aggregate_3)
   /** check tensor config for video */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 64 * 8);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 48);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 3U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 64U * 8);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 48U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3947,8 +3947,8 @@ TEST (tensor_stream_test, audio_aggregate_s16)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers / 4);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2 * 4);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2 * 4);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -3959,10 +3959,10 @@ TEST (tensor_stream_test, audio_aggregate_s16)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_INT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 2000);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 2000U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -3989,8 +3989,8 @@ TEST (tensor_stream_test, audio_aggregate_u16)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 5);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 500 * 2 / 5);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 500U * 2 / 5);
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4001,10 +4001,10 @@ TEST (tensor_stream_test, audio_aggregate_u16)
   /** check tensor config for audio */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT16);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 100);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 100U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
   EXPECT_EQ (g_test_data.tensor_config.rate_n, 16000);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
@@ -4034,8 +4034,8 @@ TEST (tensor_stream_test, issue739_mux_parallel_1)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4046,10 +4046,10 @@ TEST (tensor_stream_test, issue739_mux_parallel_1)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4098,8 +4098,8 @@ TEST (tensor_stream_test, issue739_mux_parallel_2)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4110,10 +4110,10 @@ TEST (tensor_stream_test, issue739_mux_parallel_2)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4163,8 +4163,8 @@ TEST (tensor_stream_test, issue739_mux_parallel_3)
   /** check received buffers */
   EXPECT_GE (g_test_data.received, num_buffers * 25 - 1);
   EXPECT_LE (g_test_data.received, num_buffers * 25);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4175,10 +4175,10 @@ TEST (tensor_stream_test, issue739_mux_parallel_3)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4245,8 +4245,8 @@ TEST (tensor_stream_test, issue739_merge_parallel_1)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4257,10 +4257,10 @@ TEST (tensor_stream_test, issue739_merge_parallel_1)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4309,8 +4309,8 @@ TEST (tensor_stream_test, issue739_merge_parallel_2)
 
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4321,10 +4321,10 @@ TEST (tensor_stream_test, issue739_merge_parallel_2)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4374,8 +4374,8 @@ TEST (tensor_stream_test, issue739_merge_parallel_3)
   /** check received buffers */
   EXPECT_GE (g_test_data.received, num_buffers * 25 - 1);
   EXPECT_LE (g_test_data.received, num_buffers * 25);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 4);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4386,10 +4386,10 @@ TEST (tensor_stream_test, issue739_merge_parallel_3)
   /** check tensor config */
   EXPECT_TRUE (gst_tensor_config_validate (&g_test_data.tensor_config));
   EXPECT_EQ (g_test_data.tensor_config.info.type, _NNS_UINT32);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1);
-  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[0], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 1U);
+  EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
 
   /** @todo Check contents in the sink */
   if (option.tmpfile) {
@@ -4487,9 +4487,9 @@ TEST (tensor_stream_test, tensor_decoder_property)
   EXPECT_EQ (g_test_data.status, TEST_EOS);
 
   /** check received buffers */
-  EXPECT_EQ (g_test_data.received, 5);
-  EXPECT_EQ (g_test_data.mem_blocks, 1);
-  EXPECT_EQ (g_test_data.received_size, 64);     /* uint8_t, 4:4:4:1 */
+  EXPECT_EQ (g_test_data.received, 5U);
+  EXPECT_EQ (g_test_data.mem_blocks, 1U);
+  EXPECT_EQ (g_test_data.received_size, 64U);     /* uint8_t, 4:4:4:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));

--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -35,8 +35,8 @@ gchar *PREV_IIO_DEV_DIR;
 /**
  * @brief iio default and test values
  */
-#define DEFAULT_BUFFER_CAPACITY 1
-#define DEFAULT_FREQUENCY 0
+#define DEFAULT_BUFFER_CAPACITY (1U)
+#define DEFAULT_FREQUENCY (0U)
 #define DEFAULT_SILENT TRUE
 #define DEFAULT_MERGE_CHANNELS TRUE
 #define DEFAULT_POLL_TIMEOUT 10000
@@ -1220,10 +1220,10 @@ TEST (test_tensor_src_iio, data_verify_trigger)
   EXPECT_EQ (config.rate_n, samp_freq);
   EXPECT_EQ (config.rate_d, 1);
   EXPECT_EQ (config.info.type, _NNS_FLOAT32);
-  EXPECT_EQ (config.info.dimension[0], num_scan_elements);
-  EXPECT_EQ (config.info.dimension[1], 1);
-  EXPECT_EQ (config.info.dimension[2], 1);
-  EXPECT_EQ (config.info.dimension[3], 1);
+  EXPECT_EQ (config.info.dimension[0], (guint) num_scan_elements);
+  EXPECT_EQ (config.info.dimension[1], 1U);
+  EXPECT_EQ (config.info.dimension[2], 1U);
+  EXPECT_EQ (config.info.dimension[3], 1U);
 
   gst_object_unref (src_iio);
   gst_object_unref (src_pad);
@@ -1346,10 +1346,10 @@ TEST (test_tensor_src_iio, data_verify_custom_channels)
   EXPECT_EQ (config.rate_n, samp_freq);
   EXPECT_EQ (config.rate_d, 1);
   EXPECT_EQ (config.info.type, _NNS_FLOAT32);
-  EXPECT_EQ (config.info.dimension[0], 3);
-  EXPECT_EQ (config.info.dimension[1], 1);
-  EXPECT_EQ (config.info.dimension[2], 1);
-  EXPECT_EQ (config.info.dimension[3], 1);
+  EXPECT_EQ (config.info.dimension[0], 3U);
+  EXPECT_EQ (config.info.dimension[1], 1U);
+  EXPECT_EQ (config.info.dimension[2], 1U);
+  EXPECT_EQ (config.info.dimension[3], 1U);
 
   gst_object_unref (src_iio);
   gst_object_unref (src_pad);
@@ -1463,19 +1463,19 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
   EXPECT_EQ (gst_tensors_config_from_structure (&config, structure), TRUE);
   EXPECT_EQ (config.rate_n, samp_freq);
   EXPECT_EQ (config.rate_d, 1);
-  EXPECT_EQ (config.info.num_tensors, num_scan_elements);
+  EXPECT_EQ (config.info.num_tensors, (guint) num_scan_elements);
   for (int idx = 0; idx < num_scan_elements; idx++) {
     EXPECT_EQ (config.info.info[idx].type, _NNS_FLOAT32);
-    EXPECT_EQ (config.info.info[idx].dimension[0], 1);
-    EXPECT_EQ (config.info.info[idx].dimension[1], 1);
-    EXPECT_EQ (config.info.info[idx].dimension[2], 1);
-    EXPECT_EQ (config.info.info[idx].dimension[3], 1);
+    EXPECT_EQ (config.info.info[idx].dimension[0], 1U);
+    EXPECT_EQ (config.info.info[idx].dimension[1], 1U);
+    EXPECT_EQ (config.info.info[idx].dimension[2], 1U);
+    EXPECT_EQ (config.info.info[idx].dimension[3], 1U);
   }
   for (int idx = num_scan_elements; idx < NNS_TENSOR_SIZE_LIMIT; idx++) {
-    EXPECT_EQ (config.info.info[idx].dimension[0], 0);
-    EXPECT_EQ (config.info.info[idx].dimension[1], 0);
-    EXPECT_EQ (config.info.info[idx].dimension[2], 0);
-    EXPECT_EQ (config.info.info[idx].dimension[3], 0);
+    EXPECT_EQ (config.info.info[idx].dimension[0], 0U);
+    EXPECT_EQ (config.info.info[idx].dimension[1], 0U);
+    EXPECT_EQ (config.info.info[idx].dimension[2], 0U);
+    EXPECT_EQ (config.info.info[idx].dimension[3], 0U);
   }
 
   gst_object_unref (src_iio);


### PR DESCRIPTION
GCC7 has stricter rules on signed-unsigned comparison.

Update unit-test cases to avoid gtest errors with gcc7.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [x]Skipped
