### PR TITLE
[Conf] Handle the case of using the default 'sysconfdir' value of meson @open sesame 7/25 19:20

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -235,6 +235,7 @@ _fill_in_vstr (gchar *** fullpath_vstr, gchar *** basename_vstr,
 gboolean
 nnsconf_loadconf (gboolean force_reload)
 {
+  const gchar root_path_prefix[] = NNSTREAMER_SYS_ROOT_PATH_PREFIX;
   g_autoptr (GKeyFile) key_file = NULL;
   guint i;
 
@@ -265,7 +266,14 @@ nnsconf_loadconf (gboolean force_reload)
   }
 
   /* Read from the conf file first */
-  conf.conffile = g_strdup (NNSTREAMER_CONF_FILE);
+  if (g_path_is_absolute (NNSTREAMER_CONF_FILE)) {
+    conf.conffile = g_strdup (NNSTREAMER_CONF_FILE);
+  } else {
+    /** default value of 'sysconfdir' in meson is 'etc' */
+    conf.conffile = g_build_path (G_DIR_SEPARATOR_S, root_path_prefix,
+        NNSTREAMER_CONF_FILE, NULL);
+  }
+
   if (!g_file_test (conf.conffile, G_FILE_TEST_IS_REGULAR)) {
     /* File not found or not configured */
     g_free (conf.conffile);

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -36,6 +36,13 @@
 #include <glib.h>
 G_BEGIN_DECLS
 
+/* Hard-coded system-dependent root path prefix */
+#ifdef G_OS_WIN32
+#define NNSTREAMER_SYS_ROOT_PATH_PREFIX "c:\\"
+#else
+#define NNSTREAMER_SYS_ROOT_PATH_PREFIX "/"
+#endif /* G_OS_WIN32 */
+
 /* Env-var names */
 #define NNSTREAMER_ENVVAR_CONF_FILE     "NNSTREAMER_CONF"
 #define NNSTREAMER_ENVVAR_FILTERS       "NNSTREAMER_FILTERS"


### PR DESCRIPTION
Since the default value of 'sysconfdir' in the Meson build system is just 'etc' instead of '/etc', NNSTREAMER_CONF_FILE could be set to wrong path when the default value is used. This patch fixes this issue.

CC: @jaeyun-jung 
See also: https://github.com/nnsuite/nnstreamer/pull/1424

**Changes**
- V4: Add #define to the header file and remove 'const static' in the c file
- V3: Regard the path of root directory for "windows" and "others" as "c:\" and "/" n, respectively
- V2: Use g_path_is_absolute() instead of NNSTREAMER_CONF_FILE[0] == ' /'

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>