### PR TITLE
Release of NNStreamer 0.2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,15 @@
+0.1.2 -> 0.2.0:
+	- A lot of security issues and bugs fixed (for Tizen 5.5 M1 release)
+	- Tizen Public C-API Pipeline for 5.5 M1
+	- Tizen Public C-API SingleShot Prototype
+	- Yocto/Openembedded layer released
+	- ROS sink/src
+	- IIO support
+	- Android source draft
+	- Python custom filter
+	- Android sample application released
+	- Tensorflow-lite / NNAPI support
+
 0.1.1 -> 0.1.2:
 	- Tizen Public C-API Draft Prototype
 	- Yocto/Openembedded Layer Tested.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (0.2.0.0) unstable xenial bionic; urgency=medium
+
+  * 0.2.0 Release. 0.1.3 becomes 0.2.0 as Tizen 5.5 M1 releases with nnstreamer.
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Mon, 27 May 2019 19:08:00 +0900
+
 nnstreamer (0.1.3.0) unstable xenial bionic; urgency=medium
 
   * 0.1.3 RC Development Started

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -4,7 +4,7 @@ ifndef NNSTREAMER_ROOT
 $(error NNSTREAMER_ROOT is not defined!)
 endif
 
-NNSTREAMER_VERSION  := 0.1.3
+NNSTREAMER_VERSION  := 0.2.0
 
 NNSTREAMER_GST_HOME := $(NNSTREAMER_ROOT)/gst/nnstreamer
 NNSTREAMER_EXT_HOME := $(NNSTREAMER_ROOT)/ext/nnstreamer

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -13,7 +13,7 @@ Summary:	gstremaer plugins for neural networks
 # 2. Tizen  : ./packaging/nnstreamer.spec
 # 3. Android: ./jni/nnstreamer.mk
 # 4. Meson  : ./meson.build
-Version:	0.1.3
+Version:	0.2.0
 Release:	0
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -322,6 +322,9 @@ popd
 %endif
 
 %changelog
+* Mon May 27 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 0.2.0
+
 * Wed Mar 20 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.1.2
 


### PR DESCRIPTION
0.1.3 RC has become 0.2.0 as this version is accepted by Tizen 5.5 M1.

- A lot of security issues and bugs fixed (for Tizen 5.5 M1 release)
- Tizen Public C-API Pipeline for 5.5 M1
- Tizen Public C-API SingleShot Prototype
- Yocto/Openembedded layer released
- ROS sink/src
- IIO support
- Android source draft
- Python custom filter
- Android sample application released
- Tensorflow-lite / NNAPI support

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
