### PR TITLE
[Api/Tizen] change function name and refactor code

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -89,21 +89,21 @@ TEST (nnstreamer_capi_playstop, dummy_01)
 
   status = nns_pipeline_start (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-  g_usleep(50000); /* 50ms. Let a few frames flow. */
-  status = nns_pipeline_getstate(handle, &state);
+  g_usleep (50000); /* 50ms. Let a few frames flow. */
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PLAYING);
 
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  g_usleep (50000); /* 50ms. Let a few frames flow. */
 
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
 
@@ -125,21 +125,21 @@ TEST (nnstreamer_capi_playstop, dummy_02)
 
   status = nns_pipeline_start (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-  g_usleep(50000); /* 50ms. Let a few frames flow. */
-  status = nns_pipeline_getstate(handle, &state);
+  g_usleep (50000); /* 50ms. Let a few frames flow. */
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PLAYING);
 
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  g_usleep (50000); /* 50ms. Let a few frames flow. */
 
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
 
@@ -149,11 +149,11 @@ TEST (nnstreamer_capi_playstop, dummy_02)
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-  g_usleep(50000); /* 50ms. Enough to empty the queue */
+  g_usleep (50000); /* 50ms. Enough to empty the queue */
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
 
@@ -166,13 +166,15 @@ TEST (nnstreamer_capi_playstop, dummy_02)
  */
 TEST (nnstreamer_capi_valve, test01)
 {
-  const gchar *_tmpdir = g_get_tmp_dir();
+  const gchar *_tmpdir = g_get_tmp_dir ();
   const gchar *_dirname = "nns-tizen-XXXXXX";
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
-  gchar *dir = g_mkdtemp((gchar *) fullpath);
-  gchar *file1 = g_build_path("/", dir, "valve1", NULL);
-  gchar *pipeline = g_strdup_printf("videotestsrc is-live=true num-buffers=20 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=60/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
-    file1);
+  gchar *dir = g_mkdtemp ((gchar *) fullpath);
+  gchar *file1 = g_build_path ("/", dir, "valve1", NULL);
+  gchar *pipeline =
+      g_strdup_printf
+      ("videotestsrc is-live=true num-buffers=20 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=60/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
+      file1);
   GStatBuf buf;
 
   nns_pipeline_h handle;
@@ -184,7 +186,7 @@ TEST (nnstreamer_capi_valve, test01)
 
   EXPECT_TRUE (dir != NULL);
 
-  status = nns_pipeline_valve_gethandle (handle, "valve1", &valve1);
+  status = nns_pipeline_valve_get_handle (handle, "valve1", &valve1);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   status = nns_pipeline_start (handle);
@@ -193,12 +195,12 @@ TEST (nnstreamer_capi_valve, test01)
   status = nns_pipeline_valve_control (valve1, 1); /* close */
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-  g_usleep(100000); /* 100ms. Let a few frames flow. */
+  g_usleep (100000); /* 100ms. Let a few frames flow. */
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
@@ -211,10 +213,10 @@ TEST (nnstreamer_capi_valve, test01)
 
   status = nns_pipeline_valve_control (valve1, 0); /* open */
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_valve_puthandle (valve1); /* release valve handle */
+  status = nns_pipeline_valve_put_handle (valve1); /* release valve handle */
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  g_usleep(50000); /* 50ms. Let a few frames flow. */
+  g_usleep (50000); /* 50ms. Let a few frames flow. */
 
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
@@ -235,8 +237,9 @@ TEST (nnstreamer_capi_valve, test01)
 /**
  * @brief A tensor-sink callback for sink handle in a pipeline
  */
-static void nns_sink_callback_dm01 (const char *buf[], const size_t size[],
-    const nns_tensors_info_s *tensorsinfo, void *pdata)
+static void
+nns_sink_callback_dm01 (const char *buf[], const size_t size[],
+    const nns_tensors_info_s * tensorsinfo, void *pdata)
 {
   gchar *filepath = (gchar *) pdata;
   FILE *fp = g_fopen (filepath, "a");
@@ -255,7 +258,8 @@ static void nns_sink_callback_dm01 (const char *buf[], const size_t size[],
 /**
  * @brief compare the two files.
  */
-static int file_cmp (const gchar *f1, const gchar *f2)
+static int
+file_cmp (const gchar * f1, const gchar * f2)
 {
   gboolean r;
   gchar *content1, *content2;
@@ -298,7 +302,9 @@ TEST (nnstreamer_capi_sink, dummy_01)
 
   gchar *file1 = g_build_path ("/", dir, "original", NULL);
   gchar *file2 = g_build_path ("/", dir, "sink", NULL);
-  gchar *pipeline = g_strdup_printf ("videotestsrc num-buffers=3 ! videoconvert ! video/x-raw,format=BGRx,width=64,height=48,famerate=60/1 ! tee name=t t. ! queue ! filesink location=\"%s\"  t. ! queue ! tensor_converter ! tensor_sink name=sinkx",
+  gchar *pipeline =
+      g_strdup_printf
+      ("videotestsrc num-buffers=3 ! videoconvert ! video/x-raw,format=BGRx,width=64,height=48,famerate=60/1 ! tee name=t t. ! queue ! filesink location=\"%s\"  t. ! queue ! tensor_converter ! tensor_sink name=sinkx",
       file1);
   nns_pipeline_h handle;
   nns_pipeline_state_e state;
@@ -311,21 +317,21 @@ TEST (nnstreamer_capi_sink, dummy_01)
 
   status = nns_pipeline_start (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-  g_usleep(100000); /* 100ms. Let a few frames flow. */
-  status = nns_pipeline_getstate(handle, &state);
+  g_usleep (100000); /* 100ms. Let a few frames flow. */
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PLAYING);
 
   status = nns_pipeline_stop (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  g_usleep(10000); /* 10ms. Wait a bit. */
+  g_usleep (10000); /* 10ms. Wait a bit. */
 
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_EQ (state, NNS_PIPELINE_PAUSED);
 
@@ -342,7 +348,7 @@ TEST (nnstreamer_capi_sink, dummy_01)
 }
 
 static char uintarray[10][4];
-static char* uia_index[10];
+static char *uia_index[10];
 
 /**
  * @brief Test NNStreamer pipeline src
@@ -354,7 +360,9 @@ TEST (nnstreamer_capi_src, dummy_01)
   gchar *fullpath = g_build_path ("/", _tmpdir, _dirname, NULL);
   gchar *dir = g_mkdtemp ((gchar *) fullpath);
   gchar *file1 = g_build_path ("/", dir, "output", NULL);
-  gchar *pipeline = g_strdup_printf ("appsrc name=srcx ! other/tensor,dimension=4:1:1:1,type=uint8,framerate=0/1 ! filesink location=\"%s\"",
+  gchar *pipeline =
+      g_strdup_printf
+      ("appsrc name=srcx ! other/tensor,dimension=4:1:1:1,type=uint8,framerate=0/1 ! filesink location=\"%s\"",
       file1);
   nns_pipeline_h handle;
   nns_pipeline_state_e state;
@@ -367,7 +375,7 @@ TEST (nnstreamer_capi_src, dummy_01)
   uint8_t *content;
   gboolean r;
   gsize len;
-  const size_t size[1] = {4};
+  const size_t size[1] = { 4 };
 
   EXPECT_EQ (status, NNS_ERROR_NONE);
   EXPECT_TRUE (dir != NULL);
@@ -375,14 +383,14 @@ TEST (nnstreamer_capi_src, dummy_01)
     uia_index[i] = &uintarray[i][0];
 
     uintarray[i][0] = i;
-    uintarray[i][1] = i+1;
-    uintarray[i][2] = i+3;
-    uintarray[i][3] = i+2;
+    uintarray[i][1] = i + 1;
+    uintarray[i][2] = i + 3;
+    uintarray[i][3] = i + 2;
 
     uintarray2[i] = (char *) g_malloc (4);
-    uintarray2[i][0] = i+3;
-    uintarray2[i][1] = i+2;
-    uintarray2[i][2] = i+1;
+    uintarray2[i][0] = i + 3;
+    uintarray2[i][1] = i + 2;
+    uintarray2[i][2] = i + 1;
     uintarray2[i][3] = i;
     /* These will be free'ed by gstreamer (NNS_BUF_FREE_BY_NNSTREAMER) */
     /** @todo Check whether gstreamer really deallocates this */
@@ -390,13 +398,12 @@ TEST (nnstreamer_capi_src, dummy_01)
 
   status = nns_pipeline_start (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_getstate(handle, &state);
+  status = nns_pipeline_get_state (handle, &state);
   EXPECT_EQ (status, NNS_ERROR_NONE); /* At this moment, it can be READY, PAUSED, or PLAYING */
   EXPECT_NE (state, NNS_PIPELINE_UNKNOWN);
   EXPECT_NE (state, NNS_PIPELINE_NULL);
 
-
-  status = nns_pipeline_src_gethandle (handle, "srcx", &tensorsinfo, &srchandle);
+  status = nns_pipeline_src_get_handle (handle, "srcx", &tensorsinfo, &srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   EXPECT_EQ (tensorsinfo.num_tensors, 1);
@@ -413,16 +420,16 @@ TEST (nnstreamer_capi_src, dummy_01)
   tensorsinfo.info[0].dimension[2] = 1;
   tensorsinfo.info[0].dimension[3] = 1;
 
-  status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_DO_NOT_FREE1,
+  status = nns_pipeline_src_input_data (srchandle, NNS_BUF_DO_NOT_FREE1,
       &(uia_index[0]), size, 1);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_DO_NOT_FREE1,
+  status = nns_pipeline_src_input_data (srchandle, NNS_BUF_DO_NOT_FREE1,
       &(uia_index[0]), size, 1);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_src_puthandle (srchandle);
+  status = nns_pipeline_src_put_handle (srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
-  status = nns_pipeline_src_gethandle (handle, "srcx", &tensorsinfo, &srchandle);
+  status = nns_pipeline_src_get_handle (handle, "srcx", &tensorsinfo, &srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   EXPECT_EQ (tensorsinfo.num_tensors, 1);
@@ -434,15 +441,15 @@ TEST (nnstreamer_capi_src, dummy_01)
 
 
   for (i = 0; i < 10; i++) {
-    status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_DO_NOT_FREE1,
+    status = nns_pipeline_src_input_data (srchandle, NNS_BUF_DO_NOT_FREE1,
         &(uia_index[i]), size, 1);
     EXPECT_EQ (status, NNS_ERROR_NONE);
-    status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_FREE_BY_NNSTREAMER,
+    status = nns_pipeline_src_input_data (srchandle, NNS_BUF_FREE_BY_NNSTREAMER,
         &(uintarray2[i]), size, 1);
     EXPECT_EQ (status, NNS_ERROR_NONE);
   }
 
-  status = nns_pipeline_src_puthandle (srchandle);
+  status = nns_pipeline_src_put_handle (srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   g_usleep (50000); /* Wait for the pipeline to flush all */
@@ -458,14 +465,14 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (len, 8 * 11);
 
   for (i = 0; i < 10; i++) {
-    EXPECT_EQ (content[i*8 + 0 + 8], i);
-    EXPECT_EQ (content[i*8 + 1 + 8], i+1);
-    EXPECT_EQ (content[i*8 + 2 + 8], i+3);
-    EXPECT_EQ (content[i*8 + 3 + 8], i+2);
-    EXPECT_EQ (content[i*8 + 4 + 8], i+3);
-    EXPECT_EQ (content[i*8 + 5 + 8], i+2);
-    EXPECT_EQ (content[i*8 + 6 + 8], i+1);
-    EXPECT_EQ (content[i*8 + 7 + 8], i);
+    EXPECT_EQ (content[i * 8 + 0 + 8], i);
+    EXPECT_EQ (content[i * 8 + 1 + 8], i + 1);
+    EXPECT_EQ (content[i * 8 + 2 + 8], i + 3);
+    EXPECT_EQ (content[i * 8 + 3 + 8], i + 2);
+    EXPECT_EQ (content[i * 8 + 4 + 8], i + 3);
+    EXPECT_EQ (content[i * 8 + 5 + 8], i + 2);
+    EXPECT_EQ (content[i * 8 + 6 + 8], i + 1);
+    EXPECT_EQ (content[i * 8 + 7 + 8], i);
   }
 
   g_free (content);
@@ -481,7 +488,7 @@ TEST (nnstreamer_capi_src, failure_01)
   nns_tensors_info_s tensorsinfo;
   nns_src_h srchandle;
 
-  status = nns_pipeline_src_gethandle (NULL, "dummy", &tensorsinfo, &srchandle);
+  status = nns_pipeline_src_get_handle (NULL, "dummy", &tensorsinfo, &srchandle);
   EXPECT_EQ (status, NNS_ERROR_INVALID_PARAMETER);
 }
 
@@ -499,7 +506,7 @@ TEST (nnstreamer_capi_src, failure_02)
   int status = nns_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_src_gethandle (handle, "wrongname", &tensorsinfo, &srchandle);
+  status = nns_pipeline_src_get_handle (handle, "wrongname", &tensorsinfo, &srchandle);
   EXPECT_EQ (status, NNS_ERROR_INVALID_PARAMETER);
 
   status = nns_pipeline_destroy (handle);
@@ -519,11 +526,11 @@ TEST (nnstreamer_capi_src, failure_03)
   nns_pipeline_h handle;
   nns_tensors_info_s tensorsinfo;
   nns_src_h srchandle;
-  const size_t tensor_size[1] = {num_dims};
+  const size_t tensor_size[1] = { num_dims };
   char *pbuffer[num_tensors];
 
   for (int i = 0; i < num_tensors; ++i)
-    pbuffer[i] = (char *)g_malloc0 (sizeof(char) * num_dims);
+    pbuffer[i] = (char *) g_malloc0 (sizeof (char) * num_dims);
 
   int status = nns_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
@@ -531,18 +538,18 @@ TEST (nnstreamer_capi_src, failure_03)
   status = nns_pipeline_start (handle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_src_gethandle (handle, "srcx", &tensorsinfo, &srchandle);
+  status = nns_pipeline_src_get_handle (handle, "srcx", &tensorsinfo, &srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
-  status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_DO_NOT_FREE1,
-    &(pbuffer[0]), tensor_size, num_tensors);
+  status = nns_pipeline_src_input_data (srchandle, NNS_BUF_DO_NOT_FREE1,
+      &(pbuffer[0]), tensor_size, num_tensors);
   EXPECT_EQ (status, NNS_ERROR_INVALID_PARAMETER);
 
-  status = nns_pipeline_src_inputdata (srchandle, NNS_BUF_DO_NOT_FREE1,
-    &(pbuffer[0]), tensor_size, 0);
+  status = nns_pipeline_src_input_data (srchandle, NNS_BUF_DO_NOT_FREE1,
+      &(pbuffer[0]), tensor_size, 0);
   EXPECT_EQ (status, NNS_ERROR_INVALID_PARAMETER);
 
-  status = nns_pipeline_src_puthandle (srchandle);
+  status = nns_pipeline_src_put_handle (srchandle);
   EXPECT_EQ (status, NNS_ERROR_NONE);
 
   status = nns_pipeline_stop (handle);
@@ -558,7 +565,8 @@ TEST (nnstreamer_capi_src, failure_03)
 /**
  * @brief Main gtest
  */
-int main (int argc, char **argv)
+int
+main (int argc, char **argv)
 {
   testing::InitGoogleTest (&argc, argv);
 

--- a/tizen-api/include/nnstreamer.h
+++ b/tizen-api/include/nnstreamer.h
@@ -238,7 +238,7 @@ int nns_pipeline_destroy (nns_pipeline_h pipe);
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #NNS_ERROR_STREAMS_PIPE Failed to get state from the pipeline.
  */
-int nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e *state);
+int nns_pipeline_get_state (nns_pipeline_h pipe, nns_pipeline_state_e *state);
 
 /****************************************************
  ** NNStreamer Pipeline Start/Stop Control         **
@@ -300,7 +300,7 @@ int nns_pipeline_sink_unregister (nns_sink_h h);
 /**
  * @brief Gets a handle to operate as a src node of nnstreamer pipelines.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_src_puthandle().
+ * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_src_put_handle().
  * @param[in] pipe The pipeline to be attached with a src node.
  * @param[in] srcname The name of src node, described with nns_pipeline_construct().
  * @param[out] tensors_info The cardinality, dimension, and type of given tensor/tensors.
@@ -310,7 +310,7 @@ int nns_pipeline_sink_unregister (nns_sink_h h);
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #NNS_ERROR_STREAMS_PIPE Fail to get SRC element.
  */
-int nns_pipeline_src_gethandle (nns_pipeline_h pipe, const char *srcname, nns_tensors_info_s *tensors_info, nns_src_h *h);
+int nns_pipeline_src_get_handle (nns_pipeline_h pipe, const char *srcname, nns_tensors_info_s *tensors_info, nns_src_h *h);
 
 /**
  * @brief Closes the given handle of a src node of nnstreamer pipelines.
@@ -320,15 +320,15 @@ int nns_pipeline_src_gethandle (nns_pipeline_h pipe, const char *srcname, nns_te
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_pipeline_src_puthandle (nns_src_h h);
+int nns_pipeline_src_put_handle (nns_src_h h);
 
 /**
  * @brief Puts an input data frame.
  * @param[in] h The nns_src_handle returned by nns_pipeline_gethandle().
  * @param[in] policy The policy of buf deallocation.
  * @param[in] buf The input buffers, in the format of tensorsinfo given by nns_pipeline_gethandle()
- * @param[in] size The sizes of input buffers. This must be consistent with the given tensorsinfo, probed by nns_pipeline_src_gethandle().
- * @param[in] num_tensors The number of tensors (number of buf and number of size) for the input frame. This must be consistent with the given tensorinfo, probed by nns_pipeline_src_gethandle(). MAX is 16 (NNS_TENSOR_SIZE_LIMIT).
+ * @param[in] size The sizes of input buffers. This must be consistent with the given tensorsinfo, probed by nns_pipeline_src_get_handle().
+ * @param[in] num_tensors The number of tensors (number of buf and number of size) for the input frame. This must be consistent with the given tensorinfo, probed by nns_pipeline_src_get_handle(). MAX is 16 (NNS_TENSOR_SIZE_LIMIT).
  * @return 0 on success (buf is filled). otherwise a negative error value.
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
@@ -337,7 +337,7 @@ int nns_pipeline_src_puthandle (nns_src_h h);
  *
  * @todo Allow to use GstBuffer instead of buf/size pairs, probably with yet another API.
  */
-int nns_pipeline_src_inputdata (nns_src_h h, nns_buf_policy_e policy, char *buf[], const size_t size[], unsigned int num_tensors);
+int nns_pipeline_src_input_data (nns_src_h h, nns_buf_policy_e policy, char *buf[], const size_t size[], unsigned int num_tensors);
 
 /****************************************************
  ** NNStreamer Pipeline Switch/Valve Control       **
@@ -347,7 +347,7 @@ int nns_pipeline_src_inputdata (nns_src_h h, nns_buf_policy_e policy, char *buf[
  * @brief Gets a handle to operate a "GstInputSelector / GstOutputSelector" node of nnstreamer pipelines.
  * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-bad-plugins/html/gst-plugins-bad-plugins-input-selector.html for input selectors.
  *         Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
- * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_switch_puthandle().
+ * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_switch_put_handle().
  * @param[in] pipe The pipeline to be managed.
  * @param[in] switchname The name of switch (InputSelector/OutputSelector)
  * @param[out] type The type of the switch. If NULL, it is ignored.
@@ -356,7 +356,7 @@ int nns_pipeline_src_inputdata (nns_src_h h, nns_buf_policy_e policy, char *buf[
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_pipeline_switch_gethandle (nns_pipeline_h pipe, const char *switchname, nns_switch_type_e *type, nns_switch_h *h);
+int nns_pipeline_switch_get_handle (nns_pipeline_h pipe, const char *switchname, nns_switch_type_e *type, nns_switch_h *h);
 
 /**
  * @brief Closes the given switch handle.
@@ -365,11 +365,11 @@ int nns_pipeline_switch_gethandle (nns_pipeline_h pipe, const char *switchname, 
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_pipeline_switch_puthandle (nns_switch_h h);
+int nns_pipeline_switch_put_handle (nns_switch_h h);
 
 /**
  * @brief Controls the switch with the given handle to select input/output nodes(pads).
- * @param[in] h The switch handle returned by nns_pipeline_switch_gethandle()
+ * @param[in] h The switch handle returned by nns_pipeline_switch_get_handle()
  * @param[in] padname The name of the chosen pad to be activated. Use nns_pipeline_switch_nodelist to list the available pad names.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
@@ -379,7 +379,7 @@ int nns_pipeline_switch_select (nns_switch_h h, const char *padname);
 
 /**
  * @brief Gets the pad names of a switch.
- * @param[in] h The switch handle returned by nns_pipeline_switch_gethandle()
+ * @param[in] h The switch handle returned by nns_pipeline_switch_get_handle()
  * @param[out] list NULL terminated array of char*. The caller must free each string (char*) in the list and free the list itself.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
@@ -391,7 +391,7 @@ int nns_pipeline_switch_nodelist (nns_switch_h h, char *** list);
 /**
  * @brief Gets a handle to operate a "GstValve" node of nnstreamer pipelines.
  * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-valve.html for more info.
- * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_valve_puthandle().
+ * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_valve_put_handle().
  * @param[in] pipe The pipeline to be managed.
  * @param[in] valvename The name of valve (Valve)
  * @param[out] h The valve handle.
@@ -399,7 +399,7 @@ int nns_pipeline_switch_nodelist (nns_switch_h h, char *** list);
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_pipeline_valve_gethandle (nns_pipeline_h pipe, const char *valvename, nns_valve_h *h);
+int nns_pipeline_valve_get_handle (nns_pipeline_h pipe, const char *valvename, nns_valve_h *h);
 
 /**
  * @brief Closes the given valve handle.
@@ -408,11 +408,11 @@ int nns_pipeline_valve_gethandle (nns_pipeline_h pipe, const char *valvename, nn
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int nns_pipeline_valve_puthandle (nns_valve_h h);
+int nns_pipeline_valve_put_handle (nns_valve_h h);
 
 /**
  * @brief Controls the valve with the given handle.
- * @param[in] h The valve handle returned by nns_pipeline_valve_gethandle()
+ * @param[in] h The valve handle returned by nns_pipeline_valve_get_handle()
  * @param[in] valve_drop 1 to close (drop & stop the flow). 0 to open (let the flow pass)
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful

--- a/tizen-api/src/tizen-api-pipeline.c
+++ b/tizen-api/src/tizen-api-pipeline.c
@@ -445,7 +445,7 @@ nns_pipeline_destroy (nns_pipeline_h pipe)
  * @brief Get the pipeline state (more info in nnstreamer.h)
  */
 int
-nns_pipeline_getstate (nns_pipeline_h pipe, nns_pipeline_state_e * state)
+nns_pipeline_get_state (nns_pipeline_h pipe, nns_pipeline_state_e * state)
 {
   nns_pipeline *p = pipe;
   GstState _state;
@@ -617,8 +617,8 @@ static const GDestroyNotify bufpolicy[NNS_BUF_POLICY_MAX] = {
 /**
  * @brief Get a handle to operate a src (more info in nnstreamer.h)
  */
-int nns_pipeline_src_gethandle
-    (nns_pipeline_h pipe, const char *srcname,
+int
+nns_pipeline_src_get_handle (nns_pipeline_h pipe, const char *srcname,
     nns_tensors_info_s * tensors_info, nns_src_h * h)
 {
   nns_pipeline *p = pipe;
@@ -654,7 +654,7 @@ int nns_pipeline_src_gethandle
     elem->src = gst_element_get_static_pad (elem->element, "src");
 
   if (elem->src != NULL) {
-    /** @todo : refactor this along with nns_pipeline_src_inputdata */
+    /** @todo : refactor this along with nns_pipeline_src_input_data */
     GstCaps *caps = gst_pad_get_allowed_caps (elem->src);
 
     /** @todo caps may be NULL for prerolling */
@@ -717,7 +717,7 @@ unlock_return:
  * @brief Close a src node (more info in nnstreamer.h)
  */
 int
-nns_pipeline_src_puthandle (nns_src_h h)
+nns_pipeline_src_put_handle (nns_src_h h)
 {
   handle_init (src, src, h);
 
@@ -730,7 +730,7 @@ nns_pipeline_src_puthandle (nns_src_h h)
  * @brief Push a data frame to a src (more info in nnstreamer.h)
  */
 int
-nns_pipeline_src_inputdata (nns_src_h h,
+nns_pipeline_src_input_data (nns_src_h h,
     nns_buf_policy_e policy, char *buf[], const size_t size[],
     unsigned int num_tensors)
 {
@@ -862,7 +862,7 @@ nns_pipeline_src_inputdata (nns_src_h h,
  * @brief Get a handle to operate a selector (more info in nnstreamer.h)
  */
 int
-nns_pipeline_switch_gethandle (nns_pipeline_h pipe, const char *switchname,
+nns_pipeline_switch_get_handle (nns_pipeline_h pipe, const char *switchname,
     nns_switch_type_e * type, nns_switch_h * h)
 {
   element *elem;
@@ -937,7 +937,7 @@ unlock_return:
  * @brief Close the given switch handle (more info in nnstreamer.h)
  */
 int
-nns_pipeline_switch_puthandle (nns_switch_h h)
+nns_pipeline_switch_put_handle (nns_switch_h h)
 {
   handle_init (switch, swtc, h);
 
@@ -1076,8 +1076,9 @@ nns_pipeline_switch_nodelist (nns_switch_h h, char ***list)
 /**
  * @brief Get a handle to operate a Valve (more info in nnstreamer.h)
  */
-int nns_pipeline_valve_gethandle
-    (nns_pipeline_h pipe, const char *valvename, nns_valve_h * h)
+int
+nns_pipeline_valve_get_handle (nns_pipeline_h pipe, const char *valvename,
+    nns_valve_h * h)
 {
   element *elem;
   nns_pipeline *p = pipe;
@@ -1137,7 +1138,7 @@ unlock_return:
  * @brief Close the given valve handle (more info in nnstreamer.h)
  */
 int
-nns_pipeline_valve_puthandle (nns_valve_h h)
+nns_pipeline_valve_put_handle (nns_valve_h h)
 {
   handle_init (valve, valve, h);
 


### PR DESCRIPTION
1. change function name and indent rule in tizen-capi.
2. unref object after usage (caps and pad data).
3. add macros for log message.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
