### PR TITLE
[Tizen/API] Remove unnecessary todo and TBD items

### DIFF
--- a/tizen-api/doc/nnstreamer_doc.h
+++ b/tizen-api/doc/nnstreamer_doc.h
@@ -42,10 +42,6 @@
  * \n
  * There are following sub groups proposed:\n
  * * Pipeline: construct and control an NNStreamer pipeline.\n
- * * **TBD** CustomModel: create a custom neural network (C/C++) for an NNStreamer pipeline construction. (tensor_filter::custom)\n
- * * **TBD** PythonModel: create a custom neural network (Python) for an NNStreamer pipeline construction. (TBD)\n
- * * **TBD** NNFW: use new neural network frameworks and their models. (tensor_filter subplugin)\n
- * * **TBD** Decoder: provide a new tensor-to-media decoder. (tensor_decoder subplugin)\n
  *
  * @defgroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE NNStreamer Pipeline
  * @ingroup  CAPI_ML_NNSTREAMER
@@ -66,7 +62,7 @@
  *  Note that this API set is supposed to be thread-safe.
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_FEATURE Related Features
- * This API is related with the following features (TBD):\n
+ * This API is related with the following features :\n
  *  - http://tizen.org/feature/nnstreamer.pipeline\n
  *
  * It is recommended to probe features in your application for reliability.\n

--- a/tizen-api/include/nnstreamer.h
+++ b/tizen-api/include/nnstreamer.h
@@ -104,7 +104,6 @@ typedef enum _nns_tensor_type_e
 /**
  * @brief Enumeration for the error codes of NNStreamer Pipelines.
  * @since_tizen 5.5
- * @todo The list is to be filled! (NYI)
  */
 typedef enum {
   NNS_ERROR_NONE				= TIZEN_ERROR_NONE, /**< Success! */
@@ -117,7 +116,6 @@ typedef enum {
 /**
  * @brief Enumeration for buffer deallocation policies.
  * @since_tizen 5.5
- * @todo The list is to be filled! (NYI): "Memcpy Mode"? "GstBuffer Mode"?
  */
 typedef enum {
   NNS_BUF_FREE_BY_NNSTREAMER,	/**< Default. Application should not deallocate this buffer. NNStreamer will deallocate when the buffer is no more needed */
@@ -146,8 +144,6 @@ typedef enum {
  *               V                          |                      |
  *          [ PLAYING ] --------------------+----------------------+
  *
- * @todo The list is to be filled! (NYI) Fill with GST's state values.
- * @todo Check the consistency against MMFW APIs.
  */
 typedef enum {
   NNS_PIPELINE_STATE_UNKNOWN				= 0, /**< Unknown state. Maybe not constructed? */
@@ -161,7 +157,6 @@ typedef enum {
  * @brief Enumeration for switch types
  * @detail This designates different GStreamer filters, "GstInputSelector"/"GetOutputSelector".
  * @since_tizen 5.5
- * @todo There may be more filters that can be supported.
  */
 typedef enum {
   NNS_SWITCH_OUTPUT_SELECTOR			= 0, /**< GstOutputSelector */
@@ -285,8 +280,6 @@ int nns_pipeline_stop (nns_pipeline_h pipe);
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL, sink_name is not found, or sink_name has an invalid type.)
- *
- * @todo Allow to use GstBuffer instead of buf/size pairs of cb, probably with yet another API.
  */
 int nns_pipeline_sink_register (nns_pipeline_h pipe, const char *sink_name, nns_sink_cb cb, nns_sink_h *h, void *pdata);
 
@@ -337,8 +330,6 @@ int nns_pipeline_src_put_handle (nns_src_h h);
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #NNS_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  * @retval #NNS_ERROR_TRY_AGAIN The pipeline is not ready yet.
- *
- * @todo Allow to use GstBuffer instead of buf/size pairs, probably with yet another API.
  */
 int nns_pipeline_src_input_data (nns_src_h h, nns_buf_policy_e policy, char *buf[], const size_t size[], unsigned int num_tensors);
 


### PR DESCRIPTION
In order to pass the ACR process, unnecessary information such as `TBD`
or `todo` should be removed in Public header. This patch removes those
things.

### Related Issue
* https://github.com/nnsuite/nnstreamer/issues/1435


### Self evaluation:
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>