### PR TITLE
[Filter/Python] Fix missing initialization of class members @open sesame 5/31 14:27

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python_core.cc
@@ -97,6 +97,8 @@ PYCore::PYCore (const char* _script_path, const char* _custom)
   gst_tensors_info_init (&inputTensorMeta);
   gst_tensors_info_init (&outputTensorMeta);
 
+  callback_type = CB_END;
+  core_obj = NULL;
   configured = false;
 
   /** to prevent concurrent Python C-API calls */


### PR DESCRIPTION
This PR updates missing initializations of class member variables.
It's reported from SVACE.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>