### PR TITLE
[Tizen/API] Update Tizen API to comply with ACR process @open sesame 6/03 17:40

### DIFF
--- a/tizen-api/doc/nnstreamer_doc.h
+++ b/tizen-api/doc/nnstreamer_doc.h
@@ -45,28 +45,28 @@
  *
  * @defgroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE NNStreamer Pipeline
  * @ingroup  CAPI_ML_NNSTREAMER
- * @brief The NNStreamer API provides interfaces to create and execute stream pipelines with neural networks and sensors.
+ * @brief The NNStreamer function provides interfaces to create and execute stream pipelines with neural networks and sensors.
  * @section CAPI_ML_NNSTREAMER_PIPELINE_HEADER Required Header
  *   \#include <nnstreamer/nnstreamer.h> \n
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_OVERVIEW Overview
- * The NNStreamer API provides interfaces to create and execute stream pipelines with neural networks and sensors.
+ * The NNStreamer function provides interfaces to create and execute stream pipelines with neural networks and sensors.
  *
- *  This API allows the following operations with NNStreamer:
+ *  This function allows the following operations with NNStreamer:
  * - Create a stream pipeline with NNStreamer plugins, GStreamer plugins, and sensor/camera/mic inputs
  * - Interfaces to push data to the pipeline from the application
  * - Interfaces to pull data from the pipeline to the application
  * - Interfaces to start/stop/destroy the pipeline
  * - Interfaces to control switches and valves in the pipeline.
  *
- *  Note that this API set is supposed to be thread-safe.
+ *  Note that this function set is supposed to be thread-safe.
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_FEATURE Related Features
- * This API is related with the following features :\n
+ * This function is related with the following features :\n
  *  - http://tizen.org/feature/nnstreamer.pipeline\n
  *
  * It is recommended to probe features in your application for reliability.\n
- * You can check if a device supports the related features for this API by using
+ * You can check if a device supports the related features for this function by using
  * @ref CAPI_SYSTEM_SYSTEM_INFO_MODULE, thereby controlling the procedure of
  * your application.\n
  * To ensure your application is only running on the device with specific

--- a/tizen-api/include/nnstreamer.h
+++ b/tizen-api/include/nnstreamer.h
@@ -126,7 +126,7 @@ typedef enum {
 /**
  * @brief Enumeration for nns pipeline state.
  * @since_tizen 5.5
- * @detail Refer to https://gstreamer.freedesktop.org/documentation/design/states.html.
+ * @detail Refer to https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html.
  *         The state diagram of pipeline looks like this, assuming that there are no errors.
  *
  *          [ UNKNOWN ] "new null object"
@@ -339,7 +339,7 @@ int nns_pipeline_src_input_data (nns_src_h h, nns_buf_policy_e policy, char *buf
 
 /**
  * @brief Gets a handle to operate a "GstInputSelector / GstOutputSelector" node of nnstreamer pipelines.
- * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gst-plugins-bad-plugins/html/gst-plugins-bad-plugins-input-selector.html for input selectors.
+ * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-input-selector.html for input selectors.
  *         Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
  * @remarks If the function succeeds, @a h handle must be released using nns_pipeline_switch_put_handle().
  * @param[in] pipe The pipeline to be managed.


### PR DESCRIPTION
This PR modifies the API and its related thing to comply with Tizen ACR process.
Detailed items are as below.

* Use the word `function` instead of `API` in documentation 
* Fix the broken link

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Self evaluation:
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped