### PR TITLE
[Tizen/Api] add appsink to handle sink event

### DIFF
--- a/tizen-api/include/nnstreamer.h
+++ b/tizen-api/include/nnstreamer.h
@@ -279,6 +279,7 @@ int nns_pipeline_stop (nns_pipeline_h pipe);
  * @param[in] pdata Private data for the callback. This value is passed to the callback when it's invoked.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #NNS_ERROR_NONE Successful
+ * @retval #NNS_ERROR_STREAMS_PIPE Failed to connect a signal to sink element.
  * @retval #NNS_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL, sink_name is not found, or sink_name has an invalid type.)
  */
 int nns_pipeline_sink_register (nns_pipeline_h pipe, const char *sink_name, nns_sink_cb cb, nns_sink_h *h, void *pdata);

--- a/tizen-api/include/tizen-api-private.h
+++ b/tizen-api/include/tizen-api-private.h
@@ -29,8 +29,20 @@
 #include <gst/gst.h>
 #include "nnstreamer.h"
 #include <tizen_error.h>
+#include <dlog.h>
 #include <nnstreamer/tensor_typedef.h>
 #include <gst/app/gstappsrc.h>
+
+#define DLOG_TAG "nnstreamer-capi-pipeline"
+
+#define dlogi(...) \
+    dlog_print (DLOG_INFO, DLOG_TAG, __VA_ARGS__)
+
+#define dlogw(...) \
+    dlog_print (DLOG_WARN, DLOG_TAG, __VA_ARGS__)
+
+#define dloge(...) \
+    dlog_print (DLOG_ERROR, DLOG_TAG, __VA_ARGS__)
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,8 +54,9 @@ extern "C" {
 typedef enum {
   NNSAPI_UNKNOWN = 0x0,
   NNSAPI_SINK = 0x1,
-  NNSAPI_SRC = 0x2,
-  NNSAPI_VALVE = 0x3,
+  NNSAPI_APP_SRC = 0x2,
+  NNSAPI_APP_SINK = 0x3,
+  NNSAPI_VALVE = 0x4,
   NNSAPI_SWITCH_INPUT = 0x8,
   NNSAPI_SWITCH_OUTPUT = 0x9,
 } elementType;
@@ -68,6 +81,7 @@ typedef struct _element {
 
   GList *handles;
   int maxid; /**< to allocate id for each handle */
+  gulong handle_id;
 
   GMutex lock; /**< Lock for internal values */
 } element;


### PR DESCRIPTION
1. Register the appsink as a sink element. User can register appsink and tensor-sink as a sink element.
2. Move logging macro to private header.
3. Add testcases to test appsink element.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
