### PR TITLE
Update .gitignore to ignore files generated by Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ debian/.debhelper/*
 debian/tmp/*
 debian/nnstreamer/*
 debian/nnstreamer-dev/*
+
+# Visual Studio & csapi
+*.exe
+*.dll
+*.csproj.user
+*.lock.json
+.vs/
+bin/
+obj/


### PR DESCRIPTION
This patch updates .gitignore to exclude files generated by Visual
Studio for C# APIs.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
