### PR TITLE
[Common/Test] minor update

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -967,6 +967,11 @@ gst_tensor_get_type (const gchar * typestr)
 
   len = strlen (type_string);
 
+  if (len == 0) {
+    g_free (type_string);
+    return _NNS_END;
+  }
+
   if (type_string[0] == 'u' || type_string[0] == 'U') {
     /**
      * Let's believe the developer and the following three letters are "int"

--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -31,6 +31,7 @@ TEST (common_get_tensor_type, int32)
   EXPECT_EQ (gst_tensor_get_type ("InT32"), _NNS_INT32);
   EXPECT_EQ (gst_tensor_get_type ("InT322"), _NNS_END);
   EXPECT_EQ (gst_tensor_get_type ("int3"), _NNS_END);
+  EXPECT_EQ (gst_tensor_get_type (""), _NNS_END);
 }
 
 /**

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -304,6 +304,7 @@ _new_data_cb (GstElement * element, GstBuffer * buffer, gpointer user_data)
     /** copy current caps */
     g_test_data.current_caps = gst_caps_copy (caps);
     gst_caps_unref (caps);
+    gst_object_unref (sink_pad);
   }
 }
 


### PR DESCRIPTION
1. check string len while checking data type.
2. unref pad instance in testcases.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
