### PR TITLE
[Subplugin] define function to find subplugin

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_decoder.h
@@ -60,18 +60,26 @@ typedef struct _GstTensorDecoderDef
 
 /* extern functions for subplugin management, exist in tensor_decoder.c */
 /**
- * @brief decoder's subplugins should call this function to register
- * @param[in] decoder The decoder subplugin instance
+ * @brief Decoder's sub-plugin should call this function to register itself.
+ * @param[in] decoder Decoder sub-plugin to be registered.
+ * @return TRUE if registered. FALSE is failed or duplicated.
  */
-extern gboolean
+extern int
 nnstreamer_decoder_probe (GstTensorDecoderDef * decoder);
 
 /**
- * @brief decoder's subplugin may call this to unregister
- * @param[in] name the name of decoder (modename)
+ * @brief Decoder's sub-plugin may call this to unregister itself.
+ * @param[in] name The name of decoder sub-plugin.
  */
 extern void
-nnstreamer_decoder_exit (const gchar * name);
+nnstreamer_decoder_exit (const char *name);
 
+/**
+ * @brief Find decoder sub-plugin with the name.
+ * @param[in] name The name of decoder sub-plugin.
+ * @return NULL if not found or the sub-plugin object has an error.
+ */
+extern const GstTensorDecoderDef *
+nnstreamer_decoder_find (const char *name);
 
 #endif /* __NNS_PLUGIN_API_DECODER_H__ */

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -139,18 +139,26 @@ typedef struct _GstTensorFilterFramework
 
 /* extern functions for subplugin management, exist in tensor_filter.c */
 /**
- * @brief Filter subplugin should call this to register itself
- * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered
+ * @brief Filter's sub-plugin should call this function to register itself.
+ * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered.
  * @return TRUE if registered. FALSE is failed or duplicated.
  */
 extern int
 nnstreamer_filter_probe (GstTensorFilterFramework * tfsp);
 
 /**
- * @brief filter sub-plugin may call this to unregister itself
- * @param[in] name the name of filter sub-plugin
+ * @brief Filter's sub-plugin may call this to unregister itself.
+ * @param[in] name The name of filter sub-plugin.
  */
 extern void
-nnstreamer_filter_exit (const char * name);
+nnstreamer_filter_exit (const char *name);
+
+/**
+ * @brief Find filter sub-plugin with the name.
+ * @param[in] name The name of filter sub-plugin.
+ * @return NULL if not found or the sub-plugin object has an error.
+ */
+extern const GstTensorFilterFramework *
+nnstreamer_filter_find (const char *name);
 
 #endif /* __NNS_PLUGIN_API_FILTER_H__ */

--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -168,10 +168,11 @@ nnstreamer_decoder_validate (const GstTensorDecoderDef * decoder)
 }
 
 /**
- * @brief decoder's subplugins should call this function to register
- * @param[in] decoder The decoder subplugin instance
+ * @brief Decoder's sub-plugin should call this function to register itself.
+ * @param[in] decoder Decoder sub-plugin to be registered.
+ * @return TRUE if registered. FALSE is failed or duplicated.
  */
-gboolean
+int
 nnstreamer_decoder_probe (GstTensorDecoderDef * decoder)
 {
   g_return_val_if_fail (nnstreamer_decoder_validate (decoder), FALSE);
@@ -179,21 +180,22 @@ nnstreamer_decoder_probe (GstTensorDecoderDef * decoder)
 }
 
 /**
- * @brief decoder's subplugin may call this to unregister
- * @param[in] name the name of decoder (modename)
+ * @brief Decoder's sub-plugin may call this to unregister itself.
+ * @param[in] name The name of decoder sub-plugin.
  */
 void
-nnstreamer_decoder_exit (const gchar * name)
+nnstreamer_decoder_exit (const char *name)
 {
   unregister_subplugin (NNS_SUBPLUGIN_DECODER, name);
 }
 
 /**
- * @brief Find decoders subplugin with the name
- * @param[in] name the name of decoder (modename)
+ * @brief Find decoder sub-plugin with the name.
+ * @param[in] name The name of decoder sub-plugin.
+ * @return NULL if not found or the sub-plugin object has an error.
  */
-static const GstTensorDecoderDef *
-nnstreamer_decoder_find (const gchar * name)
+const GstTensorDecoderDef *
+nnstreamer_decoder_find (const char *name)
 {
   return get_subplugin (NNS_SUBPLUGIN_DECODER, name);
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -135,8 +135,8 @@ nnstreamer_filter_validate (const GstTensorFilterFramework * tfsp)
 }
 
 /**
- * @brief Filter subplugin should call this to register itself
- * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered
+ * @brief Filter's sub-plugin should call this function to register itself.
+ * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered.
  * @return TRUE if registered. FALSE is failed or duplicated.
  */
 int
@@ -147,8 +147,8 @@ nnstreamer_filter_probe (GstTensorFilterFramework * tfsp)
 }
 
 /**
- * @brief filter sub-plugin may call this to unregister itself
- * @param[in] name the name of filter sub-plugin
+ * @brief Filter's sub-plugin may call this to unregister itself.
+ * @param[in] name The name of filter sub-plugin.
  */
 void
 nnstreamer_filter_exit (const char *name)
@@ -157,12 +157,12 @@ nnstreamer_filter_exit (const char *name)
 }
 
 /**
- * @brief Find filter sub-plugin with the name
- * @param[in] name The name of tensor_filter sub-plugin
- * @return NULL if not found or the sub-plugin object.
+ * @brief Find filter sub-plugin with the name.
+ * @param[in] name The name of filter sub-plugin.
+ * @return NULL if not found or the sub-plugin object has an error.
  */
-static const GstTensorFilterFramework *
-nnstreamer_filter_find (const gchar * name)
+const GstTensorFilterFramework *
+nnstreamer_filter_find (const char *name)
 {
   return get_subplugin (NNS_SUBPLUGIN_FILTER, name);
 }


### PR DESCRIPTION
1. add definition to find filter/decoder sub-plugins instance.
2. check duplicated name when registering sub-plugin.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
