### PR TITLE
[Conf] If CONFFILE path is not available, use the default @open sesame 6/25 17:25

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -274,6 +274,12 @@ nnsconf_loadconf (gboolean force_reload)
     conf.conffile = _strdup_getenv (NNSTREAMER_ENVVAR_CONF_FILE);
   }
 
+  if (conf.conffile == NULL)
+    conf.conffile = g_strdup (NNSTREAMER_DEFAULT_CONF_FILE);
+
+  g_assert (key_file != NULL);
+  g_assert (conf.conffile != NULL);
+
   /* Read the conf file. It's ok even if we cannot load it. */
   if (g_key_file_load_from_file (key_file, conf.conffile, G_KEY_FILE_NONE,
           NULL)) {
@@ -467,6 +473,8 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
     /* 2. Read ini */
     if (NULL == value && conf.conffile) {
       g_autoptr (GKeyFile) key_file = g_key_file_new ();
+
+      g_assert (key_file != NULL);
 
       if (g_key_file_load_from_file (key_file, conf.conffile, G_KEY_FILE_NONE,
               NULL)) {


### PR DESCRIPTION
If conffile path is not available in envvar, use the default.
We had this feature before and... somehow, this feature
has been removed at some point.
I'm reviving this feature as this makes errors in some systems.

I've added g_assert to avoid similar errors without
detected at the point of failure.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
