### PR TITLE
Unittest-coverage: apply the changed paths of CAPI files

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -194,7 +194,7 @@ ninja -C build %{?_smp_mflags}
     ./tests/unittest_sink --gst-plugin-path=.
     ./tests/unittest_plugins --gst-plugin-path=.
     ./tests/unittest_src_iio --gst-plugin-path=.
-    LD_LIBRARY_PATH=tizen-api ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=.
+    ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=.
     popd
     pushd tests
     ssat -n
@@ -218,7 +218,7 @@ DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
 # tests: We are not going to show testcoverage of the test code itself or example applications
 
 %if %{with tizen}
-%define testtarget $(pwd)/tizen-api
+%define testtarget $(pwd)/api/capi
 %else
 %define testtarget
 %endif


### PR DESCRIPTION
CAPI files have been moved from tizen-capi to api/capi.

Note that C-API will support all other general Linux distros
and we will support C# and Java APIs as well.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped
