### PR TITLE
[C-Api] check nnfw with file extension

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1475,14 +1475,22 @@ TEST (nnstreamer_capi_singleshot, failure_01)
   out_info.info[0].dimension[2] = 1;
   out_info.info[0].dimension[3] = 1;
 
-  /* unknown fw type */
+  /* invalid file extension */
   status = ml_single_open (&single, test_model, &in_info, &out_info,
-      ML_NNFW_UNKNOWN, ML_NNFW_HW_DO_NOT_CARE);
-  EXPECT_EQ (status, ML_ERROR_NOT_SUPPORTED);
+      ML_NNFW_TENSORFLOW, ML_NNFW_HW_DO_NOT_CARE);
+  EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid handle */
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
+
+  /* Successfully opened unknown fw type (tf-lite) */
+  status = ml_single_open (&single, test_model, &in_info, &out_info,
+      ML_NNFW_UNKNOWN, ML_NNFW_HW_DO_NOT_CARE);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_single_close (single);
+  EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_free (test_model);
 }


### PR DESCRIPTION
Check given model file has valid file extension.
If the param nnfw is unknown and file ext is valid, determine fw with the ext.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
