### PR TITLE
[C-Api] tensor data handle and API defines @open sesame 7/5 17:55

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -72,6 +72,8 @@
  * To ensure your application is only running on the device with specific
  * features, please define the features in your manifest file using the manifest
  * editor in the SDK.\n
+ * For example, your application accesses to the camera device,
+ * then you have to add 'http://tizen.org/privilege/camera' into the manifest of your application.\n
  * More details on featuring your application can be found from
  * <a href="https://developer.tizen.org/development/tizen-studio/native-tools/configuring-your-app/manifest-text-editor#feature">
  *    <b>Feature Element</b>.
@@ -107,6 +109,8 @@
  * To ensure your application is only running on the device with specific
  * features, please define the features in your manifest file using the manifest
  * editor in the SDK.\n
+ * For example, your application accesses to the camera device,
+ * then you have to add 'http://tizen.org/privilege/camera' into the manifest of your application.\n
  * More details on featuring your application can be found from
  * <a href="https://developer.tizen.org/development/tizen-studio/native-tools/configuring-your-app/manifest-text-editor#feature">
  *    <b>Feature Element</b>.

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -151,7 +151,7 @@ typedef struct _ml_pipeline_element {
 
 /**
  * @brief Internal private representation of pipeline handle.
- * @detail This should not be exposed to applications
+ * @details This should not be exposed to applications
  */
 struct _ml_pipeline {
   GstElement *element;    /**< The pipeline itself (GstPipeline) */
@@ -161,7 +161,7 @@ struct _ml_pipeline {
 
 /**
  * @brief Internal private representation of sink handle of GstTensorSink and GstAppSink
- * @detail This represents a single instance of callback registration. This should not be exposed to applications.
+ * @details This represents a single instance of callback registration. This should not be exposed to applications.
  */
 typedef struct _ml_pipeline_sink {
   ml_pipeline *pipe; /**< The pipeline, which is the owner of this ml_pipeline_sink */
@@ -173,7 +173,7 @@ typedef struct _ml_pipeline_sink {
 
 /**
  * @brief Internal private representation of src handle of GstAppSrc
- * @detail This represents a single instance of registration. This should not be exposed to applications.
+ * @details This represents a single instance of registration. This should not be exposed to applications.
  */
 typedef struct _ml_pipeline_src {
   ml_pipeline *pipe;
@@ -183,7 +183,7 @@ typedef struct _ml_pipeline_src {
 
 /**
  * @brief Internal private representation of switch handle (GstInputSelector, GstOutputSelector)
- * @detail This represents a single instance of registration. This should not be exposed to applications.
+ * @details This represents a single instance of registration. This should not be exposed to applications.
  */
 typedef struct _ml_pipeline_switch {
   ml_pipeline *pipe;
@@ -193,7 +193,7 @@ typedef struct _ml_pipeline_switch {
 
 /**
  * @brief Internal private representation of valve handle (GstValve)
- * @detail This represents a single instance of registration. This should not be exposed to applications.
+ * @details This represents a single instance of registration. This should not be exposed to applications.
  */
 typedef struct _ml_pipeline_valve {
   ml_pipeline *pipe;

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -94,6 +94,24 @@ typedef struct {
 } ml_tensors_info_s;
 
 /**
+ * @brief An instance of a single input or output frame.
+ * @since_tizen 5.5
+ */
+typedef struct {
+  void *tensor; /**< The instance of tensor data. */
+  size_t size; /**< The size of tensor. */
+} ml_tensor_data_s;
+
+/**
+ * @brief An instance of input or output frames. #ml_tensors_info_h is the handle for tensors metadata.
+ * @since_tizen 5.5
+ */
+typedef struct {
+  unsigned int num_tensors; /**< The number of tensors. */
+  ml_tensor_data_s tensors[ML_TENSOR_SIZE_LIMIT]; /**< The list of tensor data. NULL for unused tensors. */
+} ml_tensors_data_s;
+
+/**
  * @brief Possible controls on elements of a pipeline.
  */
 typedef enum {
@@ -182,11 +200,6 @@ typedef struct _ml_pipeline_valve {
   ml_pipeline_element *element;
   guint32 id;
 } ml_pipeline_valve;
-
-/**
- * @brief Sets the last error code.
- */
-void ml_util_set_error (int error_code);
 
 /**
  * @brief Gets the byte size of the given tensor info.

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -155,6 +155,10 @@ typedef struct _ml_pipeline_element {
  */
 struct _ml_pipeline {
   GstElement *element;    /**< The pipeline itself (GstPipeline) */
+  GstBus *bus;            /**< The bus of the pipeline */
+  gulong signal_msg;      /**< The message signal (connected to bus) */
+  ml_pipeline_state_cb cb;
+  void *pdata;
   GMutex lock;            /**< Lock for pipeline operations */
   GHashTable *namednodes; /**< hash table of "element"s. */
 };

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -55,7 +55,7 @@
       __android_log_print (ANDROID_LOG_INFO, TAG_NAME, __VA_ARGS__)
 
   #define ml_logw(...) \
-      __android_log_print (ANDROID_LOG_WARNING, TAG_NAME, __VA_ARGS__)
+      __android_log_print (ANDROID_LOG_WARN, TAG_NAME, __VA_ARGS__)
 
   #define ml_loge(...) \
       __android_log_print (ANDROID_LOG_ERROR, TAG_NAME, __VA_ARGS__)
@@ -73,6 +73,25 @@
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+/**
+ * @brief Data structure for tensor information.
+ * @since_tizen 5.5
+ */
+typedef struct {
+  char *name;              /**< Name of each element in the tensor. */
+  ml_tensor_type_e type;   /**< Type of each element in the tensor. */
+  ml_tensor_dimension dimension;     /**< Dimension information. */
+} ml_tensor_info_s;
+
+/**
+ * @brief Data structure for tensors information, which contains multiple tensors.
+ * @since_tizen 5.5
+ */
+typedef struct {
+  unsigned int num_tensors; /**< The number of tensors. */
+  ml_tensor_info_s info[ML_TENSOR_SIZE_LIMIT];  /**< The list of tensor info. */
+} ml_tensors_info_s;
 
 /**
  * @brief Possible controls on elements of a pipeline.
@@ -170,6 +189,28 @@ typedef struct _ml_pipeline_valve {
 void ml_util_set_error (int error_code);
 
 /**
+ * @brief Gets the byte size of the given tensor info.
+ */
+size_t ml_util_get_tensor_size (const ml_tensor_info_s *info);
+
+/**
+ * @brief Initializes the tensors information with default value.
+ * @since_tizen 5.5
+ * @param[in] info The tensors info pointer to be initialized.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_initialize_tensors_info (ml_tensors_info_s *info);
+
+/**
+ * @brief Frees the tensors info pointer.
+ * @since_tizen 5.5
+ * @param[in] info The tensors info pointer to be freed.
+ */
+void ml_util_free_tensors_info (ml_tensors_info_s *info);
+
+/**
  * @brief Copies tensor metadata from gst tensors info.
  */
 void ml_util_copy_tensors_info_from_gst (ml_tensors_info_s *ml_info, const GstTensorsInfo *gst_info);
@@ -178,6 +219,11 @@ void ml_util_copy_tensors_info_from_gst (ml_tensors_info_s *ml_info, const GstTe
  * @brief Copies tensor metadata from ml tensors info.
  */
 void ml_util_copy_tensors_info_from_ml (GstTensorsInfo *gst_info, const ml_tensors_info_s *ml_info);
+
+/**
+ * @brief Gets caps from tensors info.
+ */
+GstCaps *ml_util_get_caps_from_tensors_info (const ml_tensors_info_s *info);
 
 #ifdef __cplusplus
 }

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -204,7 +204,7 @@ typedef struct _ml_pipeline_valve {
 /**
  * @brief Gets the byte size of the given tensor info.
  */
-size_t ml_util_get_tensor_size (const ml_tensor_info_s *info);
+size_t ml_tensor_info_get_size (const ml_tensor_info_s *info);
 
 /**
  * @brief Initializes the tensors information with default value.
@@ -214,29 +214,29 @@ size_t ml_util_get_tensor_size (const ml_tensor_info_s *info);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_initialize_tensors_info (ml_tensors_info_s *info);
+int ml_tensors_info_initialize (ml_tensors_info_s *info);
 
 /**
  * @brief Frees the tensors info pointer.
  * @since_tizen 5.5
  * @param[in] info The tensors info pointer to be freed.
  */
-void ml_util_free_tensors_info (ml_tensors_info_s *info);
+void ml_tensors_info_free (ml_tensors_info_s *info);
 
 /**
  * @brief Copies tensor metadata from gst tensors info.
  */
-void ml_util_copy_tensors_info_from_gst (ml_tensors_info_s *ml_info, const GstTensorsInfo *gst_info);
+void ml_tensors_info_copy_from_gst (ml_tensors_info_s *ml_info, const GstTensorsInfo *gst_info);
 
 /**
  * @brief Copies tensor metadata from ml tensors info.
  */
-void ml_util_copy_tensors_info_from_ml (GstTensorsInfo *gst_info, const ml_tensors_info_s *ml_info);
+void ml_tensors_info_copy_from_ml (GstTensorsInfo *gst_info, const ml_tensors_info_s *ml_info);
 
 /**
  * @brief Gets caps from tensors info.
  */
-GstCaps *ml_util_get_caps_from_tensors_info (const ml_tensors_info_s *info);
+GstCaps * ml_tensors_info_get_caps (const ml_tensors_info_s *info);
 
 #ifdef __cplusplus
 }

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -22,7 +22,7 @@
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @bug No known bugs except for NYI items
  *
- * @detail This is targetting Tizen 5.5 M2.
+ * @details This is targetting Tizen 5.5 M2.
  */
 
 #ifndef __TIZEN_MACHINELEARNING_NNSTREAMER_SINGLE_H__
@@ -61,18 +61,17 @@ typedef void *ml_single_h;
  *                      It is required by some custom filters of NNStreamer.
  *                      You may set NULL if it's not required.
  * @param[in] output_info This is required if the given model has flexible output dimension.
- * @param[in] nnfw The nerual network framework used to open the given
- *                 #model_path. Set #ML_NNFW_TYPE_ANY to let it auto-detect.
- * @param[in] hw Tell the corresponding @nnfw to use a specific hardware.
+ * @param[in] nnfw The neural network framework used to open the given @a model.
+ *                 Set #ML_NNFW_TYPE_ANY to let it auto-detect.
+ * @param[in] hw Tell the corresponding @a nnfw to use a specific hardware.
  *               Set #ML_NNFW_HW_ANY if it does not matter.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
  *
- * @detail Even if the model has flexible input data dimensions,
- *         input data frames of an instance of a model should share the
- *         same dimension.
+ * @details Even if the model has flexible input data dimensions,
+ *          input data frames of an instance of a model should share the same dimension.
  */
 int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw);
 
@@ -91,16 +90,15 @@ int ml_single_close (ml_single_h single);
  * @since_tizen 5.5
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.
- * @param[out] output The output buffer allocated. Caller is responsible to free the output buffer with ml_util_destroy_tensors_data().
+ * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_util_destroy_tensors_data().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Cannot push a buffer into source element.
  * @retval #ML_ERROR_TIMED_OUT Failed to get the result from sink element.
  *
- * @detail Even if the model has flexible input data dimensions,
- *         input data frames of an instance of a model should share the
- *         same dimension.
+ * @details Even if the model has flexible input data dimensions,
+ *          input data frames of an instance of a model should share the same dimension.
  */
 int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h *output);
 
@@ -109,15 +107,12 @@ int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_t
  *************/
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of required input
- *        data for the given handle.
- * @detail Note that a model may not have such
- *         information if its input type is flexible.
- *         Besides, names of tensors may be not available while dimensions and
- *         types are available.
+ * @brief Gets the type (tensor dimension, type, name and so on) of required input data for the given model.
+ * @details Note that a model may not have such information if its input type is flexible.
+ *          Besides, names of tensors may be not available while dimensions and types are available.
  * @since_tizen 5.5
- * @param[in] single The model handle to be investigated.
- * @param[out] info The handle of input tensors information. Caller is responsible to free the information with ml_util_destroy_tensors_info().
+ * @param[in] single The model handle.
+ * @param[out] info The handle of input tensors information. The caller is responsible for freeing the information with ml_util_destroy_tensors_info().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
@@ -125,16 +120,12 @@ int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_t
 int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of output
- *        data for the given handle.
- * @detail Note that a model may not have such
- *         information if its input type is flexible and output type is
- *         not determined statically.
- *         Besides, names of tensors may be not available while dimensions and
- *         types are available.
+ * @brief Gets the type (tensor dimension, type, name and so on) of output data for the given model.
+ * @details Note that a model may not have such information if its output type is flexible and output type is not determined statically.
+ *          Besides, names of tensors may be not available while dimensions and types are available.
  * @since_tizen 5.5
- * @param[in] single The model handle to be investigated.
- * @param[out] info The handle of output tensors information. Caller is responsible to free the returned with ml_util_destroy_tensors_info().
+ * @param[in] single The model handle.
+ * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_util_destroy_tensors_info().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -91,12 +91,8 @@ int ml_single_close (ml_single_h single);
  * @since_tizen 5.5
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.
- * @param[out] output The output buffer. Set NULL if you want to let
- *                    this function to allocate a new output buffer.
- * @return @c The output buffer. If @output is NULL, this is a newly
- *         allocated buffer; thus, the user needs to free it.
- *         If there is an error, this is set NULL. Check ml_util_get_last_error()
- *         of tizen_error.h in such cases.
+ * @param[out] output The output buffer allocated. Caller is responsible to free the output buffer with ml_util_destroy_tensors_data().
+ * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Cannot push a buffer into source element.
@@ -106,7 +102,7 @@ int ml_single_close (ml_single_h single);
  *         input data frames of an instance of a model should share the
  *         same dimension.
  */
-ml_tensors_data_s * ml_single_inference (ml_single_h single, const ml_tensors_data_s *input, ml_tensors_data_s *output);
+int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h *output);
 
 /*************
  * UTILITIES *

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -52,6 +52,8 @@ typedef void *ml_single_h;
  * @details Even if the model has flexible input data dimensions,
  *          input data frames of an instance of a model should share the same dimension.
  * @since_tizen 5.5
+ * @remarks http://tizen.org/privilege/mediastorage is needed if @a model is relevant to media storage.
+ * @remarks http://tizen.org/privilege/externalstorage is needed if @a model is relevant to external storage.
  * @param[out] single This is the model handle opened. Users are required to close
  *                   the given instance with ml_single_close().
  * @param[in] model This is the path to the neural network model file.

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -52,7 +52,7 @@ typedef void *ml_single_h;
  * @since_tizen 5.5
  * @param[out] single This is the model handle opened. Users are required to close
  *                   the given instance with ml_single_close().
- * @param[in] model_path This is the path to the neural network model file.
+ * @param[in] model This is the path to the neural network model file.
  * @param[in] input_info This is required if the given model has flexible input
  *                      dimension, where the input dimension MUST be given
  *                      before executing the model.
@@ -62,17 +62,19 @@ typedef void *ml_single_h;
  *                      You may set NULL if it's not required.
  * @param[in] output_info This is required if the given model has flexible output dimension.
  * @param[in] nnfw The nerual network framework used to open the given
- *                 #model_path. Set ML_NNFW_UNKNOWN to let it auto-detect.
+ *                 #model_path. Set #ML_NNFW_TYPE_ANY to let it auto-detect.
  * @param[in] hw Tell the corresponding @nnfw to use a specific hardware.
- *               Set ML_NNFW_HW_DO_NOT_CARE if it does not matter.
+ *               Set #ML_NNFW_HW_ANY if it does not matter.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
  *
  * @detail Even if the model has flexible input data dimensions,
  *         input data frames of an instance of a model should share the
  *         same dimension.
  */
-int ml_single_open (ml_single_h *single, const char *model_path, const ml_tensors_info_s *input_info, const ml_tensors_info_s *output_info, ml_nnfw_e nnfw, ml_nnfw_hw_e hw);
+int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw);
 
 /**
  * @brief Closes the opened model handle.
@@ -119,12 +121,12 @@ ml_tensors_data_s * ml_single_inference (ml_single_h single, const ml_tensors_da
  *         types are available.
  * @since_tizen 5.5
  * @param[in] single The model handle to be investigated.
- * @param[out] input_info The struct of input tensors info. Caller is responsible to free the information with ml_util_free_tensors_info().
+ * @param[out] info The handle of input tensors information. Caller is responsible to free the information with ml_util_destroy_tensors_info().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
-int ml_single_get_input_info (ml_single_h single, ml_tensors_info_s *input_info);
+int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
 
 /**
  * @brief Gets the type (tensor dimension, type, name and so on) of output
@@ -136,12 +138,12 @@ int ml_single_get_input_info (ml_single_h single, ml_tensors_info_s *input_info)
  *         types are available.
  * @since_tizen 5.5
  * @param[in] single The model handle to be investigated.
- * @param[out] output_info The struct of output tensors info. Caller is responsible to free the returned with ml_util_free_tensors_info().
+ * @param[out] info The handle of output tensors information. Caller is responsible to free the returned with ml_util_destroy_tensors_info().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
-int ml_single_get_output_info (ml_single_h single, ml_tensors_info_s *output_info);
+int ml_single_get_output_info (ml_single_h single, ml_tensors_info_h *info);
 
 /**
  * @}

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -90,7 +90,7 @@ int ml_single_close (ml_single_h single);
  * @since_tizen 5.5
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.
- * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_util_destroy_tensors_data().
+ * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_tensors_data_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
@@ -112,7 +112,7 @@ int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_t
  *          Besides, names of tensors may be not available while dimensions and types are available.
  * @since_tizen 5.5
  * @param[in] single The model handle.
- * @param[out] info The handle of input tensors information. The caller is responsible for freeing the information with ml_util_destroy_tensors_info().
+ * @param[out] info The handle of input tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
@@ -125,7 +125,7 @@ int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
  *          Besides, names of tensors may be not available while dimensions and types are available.
  * @since_tizen 5.5
  * @param[in] single The model handle.
- * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_util_destroy_tensors_info().
+ * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -49,6 +49,8 @@ typedef void *ml_single_h;
  *************/
 /**
  * @brief Opens an ML model and returns the instance as a handle.
+ * @details Even if the model has flexible input data dimensions,
+ *          input data frames of an instance of a model should share the same dimension.
  * @since_tizen 5.5
  * @param[out] single This is the model handle opened. Users are required to close
  *                   the given instance with ml_single_close().
@@ -70,8 +72,6 @@ typedef void *ml_single_h;
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
  *
- * @details Even if the model has flexible input data dimensions,
- *          input data frames of an instance of a model should share the same dimension.
  */
 int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw);
 
@@ -87,6 +87,8 @@ int ml_single_close (ml_single_h single);
 
 /**
  * @brief Invokes the model with the given input data.
+ * @details Even if the model has flexible input data dimensions,
+ *          input data frames of an instance of a model should share the same dimension.
  * @since_tizen 5.5
  * @param[in] single The model handle to be inferred.
  * @param[in] input The input data to be inferred.
@@ -97,19 +99,17 @@ int ml_single_close (ml_single_h single);
  * @retval #ML_ERROR_STREAMS_PIPE Cannot push a buffer into source element.
  * @retval #ML_ERROR_TIMED_OUT Failed to get the result from sink element.
  *
- * @details Even if the model has flexible input data dimensions,
- *          input data frames of an instance of a model should share the same dimension.
  */
-int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h *output);
+int ml_single_invoke (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h *output);
 
 /*************
  * UTILITIES *
  *************/
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of required input data for the given model.
+ * @brief Gets the information (tensor dimension, type, name and so on) of required input data for the given model.
  * @details Note that a model may not have such information if its input type is flexible.
- *          Besides, names of tensors may be not available while dimensions and types are available.
+ *          The name of tensors are sometimes unavailable (optional), while its dimensions and types are always available.
  * @since_tizen 5.5
  * @param[in] single The model handle.
  * @param[out] info The handle of input tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
@@ -120,9 +120,9 @@ int ml_single_inference (ml_single_h single, const ml_tensors_data_h input, ml_t
 int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of output data for the given model.
+ * @brief Gets the information (tensor dimension, type, name and so on) of output data for the given model.
  * @details Note that a model may not have such information if its output type is flexible and output type is not determined statically.
- *          Besides, names of tensors may be not available while dimensions and types are available.
+ *          The name of tensors are sometimes unavailable (optional), while its dimensions and types are always available.
  * @since_tizen 5.5
  * @param[in] single The model handle.
  * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -54,7 +54,7 @@ extern "C" {
 #define ML_TENSOR_SIZE_LIMIT  (16)
 
 /**
- * @brief Dimension information that NNStreamer support.
+ * @brief The dimensions of a tensor that NNStreamer supports.
  * @since_tizen 5.5
  */
 typedef unsigned int ml_tensor_dimension[ML_TENSOR_RANK_LIMIT];
@@ -106,10 +106,10 @@ typedef void *ml_pipeline_valve_h;
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_NNFW_TYPE_ANY = 0, /**< determines the nnfw with file extension. */
-  ML_NNFW_TYPE_CUSTOM_FILTER, /**< custom filter (independent shared object). */
-  ML_NNFW_TYPE_TENSORFLOW_LITE, /**< tensorflow-lite (.tflite). */
-  ML_NNFW_TYPE_TENSORFLOW, /**< tensorflow (.pb). */
+  ML_NNFW_TYPE_ANY = 0, /**< NNHW is not specified (Try to determine the NNFW with file extension). */
+  ML_NNFW_TYPE_CUSTOM_FILTER, /**< Custom filter (Independent shared object). */
+  ML_NNFW_TYPE_TENSORFLOW_LITE, /**< Tensorflow-lite (.tflite). */
+  ML_NNFW_TYPE_TENSORFLOW, /**< Tensorflow (.pb). */
 } ml_nnfw_type_e;
 
 /**
@@ -170,8 +170,8 @@ typedef enum {
 /**
  * @brief Enumeration for pipeline state.
  * @since_tizen 5.5
- * @detail Refer to https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html.
- *         The state diagram of pipeline looks like this, assuming that there are no errors.
+ * @details Refer to https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html.
+ *          The state diagram of pipeline looks like this, assuming that there are no errors.
  *
  *          [ UNKNOWN ] "new null object"
  *               | "ml_pipeline_construct" starts
@@ -199,7 +199,7 @@ typedef enum {
 
 /**
  * @brief Enumeration for switch types
- * @detail This designates different GStreamer filters, "GstInputSelector"/"GetOutputSelector".
+ * @details This designates different GStreamer filters, "GstInputSelector"/"GetOutputSelector".
  * @since_tizen 5.5
  */
 typedef enum {
@@ -209,7 +209,7 @@ typedef enum {
 
 /**
  * @brief Callback for sink element of NNStreamer pipelines (pipeline's output)
- * @detail If an application wants to accept data outputs of an NNStreamer stream, use this callback to get data from the stream. Note that the buffer may be deallocated after the return and this is synchronously called. Thus, if you need the data afterwards, copy the data to another buffer and return fast. Do not hold too much time in the callback. It is recommended to use very small tensors at sinks.
+ * @details If an application wants to accept data outputs of an NNStreamer stream, use this callback to get data from the stream. Note that the buffer may be deallocated after the return and this is synchronously called. Thus, if you need the data afterwards, copy the data to another buffer and return fast. Do not spend too much time in the callback. It is recommended to use very small tensors at sinks.
  * @since_tizen 5.5
  * @remarks The @a data can be used only in the callback. To use outside, make a copy.
  * @remarks The @a info can be used only in the callback. To use outside, make a copy.
@@ -224,7 +224,7 @@ typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tens
  ****************************************************/
 /**
  * @brief Constructs the pipeline (GStreamer + NNStreamer)
- * @detail Uses this function to create a gst_parse_launch compatible NNStreamer pipelines.
+ * @details Use this function to create gst_parse_launch compatible NNStreamer pipelines.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a pipe handle must be released using ml_pipeline_destroy().
  * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (github.com/nnsuite/nnstreamer) documentation for examples and the grammar.
@@ -238,7 +238,7 @@ int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_h *pipe
 
 /**
  * @brief Destroys the pipeline
- * @detail Uses this function to destroy the pipeline constructed with ml_pipeline_construct().
+ * @details Use this function to destroy the pipeline constructed with ml_pipeline_construct().
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be destroyed.
  * @return @c 0 on success. Otherwise a negative error value.
@@ -250,9 +250,9 @@ int ml_pipeline_destroy (ml_pipeline_h pipe);
 
 /**
  * @brief Gets the state of pipeline
- * @detail Gets the state of the pipeline handle returned by ml_pipeline_construct().
+ * @details Gets the state of the pipeline handle returned by ml_pipeline_construct().
  * @since_tizen 5.5
- * @param[in] pipe The pipeline to be monitored.
+ * @param[in] pipe The pipeline handle.
  * @param[out] state The pipeline state.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -266,10 +266,10 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
  ****************************************************/
 /**
  * @brief Starts the pipeline
- * @detail The pipeline handle returned by ml_pipeline_construct() is started.
- *         Note that this is asynchronous function. State might be "pending".
+ * @details The pipeline handle returned by ml_pipeline_construct() is started.
+ *          Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
- * @param[in] pipe The pipeline to be started.
+ * @param[in] pipe The pipeline handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
@@ -279,14 +279,14 @@ int ml_pipeline_start (ml_pipeline_h pipe);
 
 /**
  * @brief Stops the pipeline
- * @detail The pipeline handle returned by ml_pipeline_construct() is stopped.
- *         Note that this is asynchronous function. State might be "pending".
+ * @details The pipeline handle returned by ml_pipeline_construct() is stopped.
+ *          Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be stopped.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
- * @retval #ML_ERROR_STREAMS_PIPE Failed to start.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to stop the pipeline.
  */
 int ml_pipeline_stop (ml_pipeline_h pipe);
 
@@ -296,57 +296,57 @@ int ml_pipeline_stop (ml_pipeline_h pipe);
 /**
  * @brief Registers a callback for sink (tensor_sink) of NNStreamer pipelines.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a h handle must be unregistered using ml_pipeline_sink_unregister().
+ * @remarks If the function succeeds, @a sink_handle handle must be unregistered using ml_pipeline_sink_unregister().
  * @param[in] pipe The pipeline to be attached with a sink node.
  * @param[in] sink_name The name of sink node, described with ml_pipeline_construct().
  * @param[in] cb The function to be called by the sink node.
- * @param[out] h The sink handle.
  * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.
+ * @param[out] sink_handle The sink handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL, sink_name is not found, or sink_name has an invalid type.)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to connect a signal to sink element.
  */
-int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pipeline_sink_cb cb, ml_pipeline_sink_h *h, void *user_data);
+int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pipeline_sink_cb cb, void *user_data, ml_pipeline_sink_h *sink_handle);
 
 /**
  * @brief Unregisters a callback for sink (tensor_sink) of NNStreamer pipelines.
  * @since_tizen 5.5
- * @param[in] h The sink handle to be unregistered (destroyed)
+ * @param[in] sink_handle The sink handle to be unregistered (destroyed)
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_sink_unregister (ml_pipeline_sink_h h);
+int ml_pipeline_sink_unregister (ml_pipeline_sink_h sink_handle);
 
 /**
  * @brief Gets a handle to operate as a src node of NNStreamer pipelines.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a h handle must be released using ml_pipeline_src_put_handle().
+ * @remarks If the function succeeds, @a src_handle handle must be released using ml_pipeline_src_put_handle().
  * @param[in] pipe The pipeline to be attached with a src node.
  * @param[in] src_name The name of src node, described with ml_pipeline_construct().
- * @param[out] h The src handle.
+ * @param[out] src_handle The src handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Fail to get SRC element.
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
-int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_pipeline_src_h *h);
+int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_pipeline_src_h *src_handle);
 
 /**
  * @brief Closes the given handle of a src node of NNStreamer pipelines.
  * @since_tizen 5.5
- * @param[in] h The src handle to be put (closed).
+ * @param[in] src_handle The src handle to be closed.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_src_put_handle (ml_pipeline_src_h h);
+int ml_pipeline_src_put_handle (ml_pipeline_src_h src_handle);
 
 /**
- * @brief Puts an input data frame.
- * @param[in] h The source handle returned by ml_pipeline_src_get_handle().
+ * @brief Adds an input data frame.
+ * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[in] data The handle of input tensors, in the format of tensors info given by ml_pipeline_src_get_tensors_info().
  * @param[in] policy The policy of buf deallocation.
  * @return 0 on success. Otherwise a negative error value.
@@ -355,13 +355,13 @@ int ml_pipeline_src_put_handle (ml_pipeline_src_h h);
  * @retval #ML_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
-int ml_pipeline_src_input_data (ml_pipeline_src_h h, const ml_tensors_data_h data, ml_pipeline_buf_policy_e policy);
+int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h data, ml_pipeline_buf_policy_e policy);
 
 /**
  * @brief Gets a handle for the tensors information of given src node.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a info_h handle must be released using ml_util_destroy_tensors_info().
- * @param[in] h The source handle returned by ml_pipeline_src_get_handle().
+ * @remarks If the function succeeds, @a info handle must be released using ml_util_destroy_tensors_info().
+ * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[out] info The handle of tensors information.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -369,7 +369,7 @@ int ml_pipeline_src_input_data (ml_pipeline_src_h h, const ml_tensors_data_h dat
  * @retval #ML_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
-int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h h, ml_tensors_info_h *info);
+int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h src_handle, ml_tensors_info_h *info);
 
 /****************************************************
  ** NNStreamer Pipeline Switch/Valve Control       **
@@ -377,80 +377,80 @@ int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h h, ml_tensors_info_h *in
 
 /**
  * @brief Gets a handle to operate a "GstInputSelector / GstOutputSelector" node of NNStreamer pipelines.
- * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-input-selector.html for input selectors.
- *         Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
- * @remarks If the function succeeds, @a h handle must be released using ml_pipeline_switch_put_handle().
+ * @details Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-input-selector.html for input selectors.
+ *          Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
+ * @remarks If the function succeeds, @a switch_handle handle must be released using ml_pipeline_switch_put_handle().
  * @param[in] pipe The pipeline to be managed.
  * @param[in] switch_name The name of switch (InputSelector/OutputSelector)
  * @param[out] type The type of the switch. If NULL, it is ignored.
- * @param[out] h The switch handle.
+ * @param[out] switch_handle The switch handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, ml_pipeline_switch_e *type, ml_pipeline_switch_h *h);
+int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, ml_pipeline_switch_e *type, ml_pipeline_switch_h *switch_handle);
 
 /**
  * @brief Closes the given switch handle.
- * @param[in] h The handle to be closed.
+ * @param[in] switch_handle The handle to be closed.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_switch_put_handle (ml_pipeline_switch_h h);
+int ml_pipeline_switch_put_handle (ml_pipeline_switch_h switch_handle);
 
 /**
  * @brief Controls the switch with the given handle to select input/output nodes(pads).
- * @param[in] h The switch handle returned by ml_pipeline_switch_get_handle()
+ * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle()
  * @param[in] pad_name The name of the chosen pad to be activated. Use ml_pipeline_switch_get_pad_list() to list the available pad names.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_switch_select (ml_pipeline_switch_h h, const char *pad_name);
+int ml_pipeline_switch_select (ml_pipeline_switch_h switch_handle, const char *pad_name);
 
 /**
  * @brief Gets the pad names of a switch.
- * @param[in] h The switch handle returned by ml_pipeline_switch_get_handle()
+ * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle()
  * @param[out] list NULL terminated array of char*. The caller must free each string (char*) in the list and free the list itself.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE The element is not both input and output switch (Internal data inconsistency).
  */
-int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h h, char ***list);
+int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h switch_handle, char ***list);
 
 /**
  * @brief Gets a handle to operate a "GstValve" node of NNStreamer pipelines.
- * @detail Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-valve.html for more info.
- * @remarks If the function succeeds, @a h handle must be released using ml_pipeline_valve_put_handle().
+ * @details Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-valve.html for more info.
+ * @remarks If the function succeeds, @a valve_handle handle must be released using ml_pipeline_valve_put_handle().
  * @param[in] pipe The pipeline to be managed.
  * @param[in] valve_name The name of valve (Valve)
- * @param[out] h The valve handle.
+ * @param[out] valve_handle The valve handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name, ml_pipeline_valve_h *h);
+int ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name, ml_pipeline_valve_h *valve_handle);
 
 /**
  * @brief Closes the given valve handle.
- * @param[in] h The handle to be closed.
+ * @param[in] valve_handle The handle to be closed.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_valve_put_handle (ml_pipeline_valve_h h);
+int ml_pipeline_valve_put_handle (ml_pipeline_valve_h valve_handle);
 
 /**
  * @brief Controls the valve with the given handle.
- * @param[in] h The valve handle returned by ml_pipeline_valve_get_handle()
+ * @param[in] valve_handle The valve handle returned by ml_pipeline_valve_get_handle()
  * @param[in] open @c true to open(let the flow pass), @c false to close (drop & stop the flow)
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_valve_set_open (ml_pipeline_valve_h h, bool open);
+int ml_pipeline_valve_set_open (ml_pipeline_valve_h valve_handle, bool open);
 
 /****************************************************
  ** NNStreamer Utilities                           **
@@ -476,14 +476,16 @@ int ml_util_allocate_tensors_info (ml_tensors_info_h *info);
 int ml_util_destroy_tensors_info (ml_tensors_info_h info);
 
 /**
- * @brief Validates the given tensors information is valid.
+ * @brief Validates the given tensors information.
+ * @details If the function returns an error, @a valid is not changed.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information to be validated.
+ * @param[out] valid @c true if it's valid, @c false if if it's invalid.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_validate_tensors_info (const ml_tensors_info_h info);
+int ml_util_validate_tensors_info (const ml_tensors_info_h info, bool *valid);
 
 /**
  * @brief Copies the tensors information.
@@ -505,7 +507,7 @@ int ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h s
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensors_count (ml_tensors_info_h info, const unsigned int count);
+int ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count);
 
 /**
  * @brief Gets the number of tensors with given handle of tensors information.
@@ -522,78 +524,78 @@ int ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count);
  * @brief Sets the tensor name with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta to be updated.
+ * @param[in] index The index of the tensor to be updated.
  * @param[in] name The tensor name to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_name (ml_tensors_info_h info, const unsigned int index, const char *name);
+int ml_util_set_tensor_name (ml_tensors_info_h info, unsigned int index, const char *name);
 
 /**
  * @brief Gets the tensor name with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta.
+ * @param[in] index The index of the tensor.
  * @param[out] name The tensor name.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_name (ml_tensors_info_h info, const unsigned int index, char **name);
+int ml_util_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **name);
 
 /**
  * @brief Sets the tensor type with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta to be updated.
+ * @param[in] index The index of the tensor to be updated.
  * @param[in] type The tensor type to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_type (ml_tensors_info_h info, const unsigned int index, const ml_tensor_type_e type);
+int ml_util_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type);
 
 /**
  * @brief Gets the tensor type with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta.
+ * @param[in] index The index of the tensor.
  * @param[out] type The tensor type.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_type (ml_tensors_info_h info, const unsigned int index, ml_tensor_type_e *type);
+int ml_util_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tensor_type_e *type);
 
 /**
  * @brief Sets the tensor dimension with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta to be updated.
+ * @param[in] index The index of the tensor to be updated.
  * @param[in] dimension The tensor dimension to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_dimension (ml_tensors_info_h info, const unsigned int index, const ml_tensor_dimension dimension);
+int ml_util_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, const ml_tensor_dimension dimension);
 
 /**
  * @brief Gets the tensor dimension with given handle of tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information.
- * @param[in] index The index of tensor meta.
+ * @param[in] index The index of the tensor.
  * @param[out] dimension The tensor dimension.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_dimension (ml_tensors_info_h info, const unsigned int index, ml_tensor_dimension dimension);
+int ml_util_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension);
 
 /**
  * @brief Gets the byte size of the given tensors type.
  * @since_tizen 5.5
- * @param[in] info The handle of tensors information to be investigated.
+ * @param[in] info The tensors' information handle.
  * @return @c >= 0 on success with byte size.
  */
 size_t ml_util_get_tensors_size (const ml_tensors_info_h info);
@@ -602,7 +604,7 @@ size_t ml_util_get_tensors_size (const ml_tensors_info_h info);
  * @brief Allocates a tensor data frame with the given tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information for the allocation.
- * @param[out] data The handle of tensors data allocated. Caller is responsible to free the allocated data with ml_util_destroy_tensors_data().
+ * @param[out] data The handle of tensors data. The caller is responsible for freeing the allocated data with ml_util_destroy_tensors_data().
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
@@ -611,7 +613,7 @@ size_t ml_util_get_tensors_size (const ml_tensors_info_h info);
 int ml_util_allocate_tensors_data (const ml_tensors_info_h info, ml_tensors_data_h *data);
 
 /**
- * @brief Frees the given handle of a tensors data.
+ * @brief Frees the given tensors' data handle.
  * @since_tizen 5.5
  * @param[in] data The handle of tensors data.
  * @return @c 0 on success. Otherwise a negative error value.
@@ -624,27 +626,27 @@ int ml_util_destroy_tensors_data (ml_tensors_data_h data);
  * @brief Gets a tensor data of given handle.
  * @since_tizen 5.5
  * @param[in] data The handle of tensors data.
- * @param[in] index The index of tensor in tensors data.
+ * @param[in] index The index of the tensor.
  * @param[out] raw_data Raw tensor data in the handle.
  * @param[out] data_size Byte size of tensor data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_data (ml_tensors_data_h data, const unsigned int index, void **raw_data, size_t *data_size);
+int ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **raw_data, size_t *data_size);
 
 /**
  * @brief Copies a tensor data to given handle.
  * @since_tizen 5.5
  * @param[in] data The handle of tensors data.
- * @param[in] index The index of tensor in tensors data.
+ * @param[in] index The index of the tensor.
  * @param[out] raw_data Raw tensor data to be copied.
  * @param[out] data_size Byte size of raw data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_copy_tensor_data (ml_tensors_data_h data, const unsigned int index, const void *raw_data, const size_t data_size);
+int ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
 
 /**
  * @brief Checks the availability of the given execution environments.

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -213,7 +213,7 @@ typedef enum {
  * @since_tizen 5.5
  * @remarks The @a data can be used only in the callback. To use outside, make a copy.
  * @remarks The @a info can be used only in the callback. To use outside, make a copy.
- * @param[out] data The handle of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by ml_util_get_tensors_count() with the handle 'info'. Note that max num_tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
+ * @param[out] data The handle of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by ml_tensors_info_get_count() with the handle 'info'. Note that max num_tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
  * @param[out] info The handle of tensors information (cardinality, dimension, and type of given tensor/tensors).
  * @param[in,out] user_data User Application's Private Data.
  */
@@ -360,7 +360,7 @@ int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h 
 /**
  * @brief Gets a handle for the tensors information of given src node.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a info handle must be released using ml_util_destroy_tensors_info().
+ * @remarks If the function succeeds, @a info handle must be released using ml_tensors_info_destroy().
  * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[out] info The handle of tensors information.
  * @return 0 on success. Otherwise a negative error value.
@@ -456,14 +456,14 @@ int ml_pipeline_valve_set_open (ml_pipeline_valve_h valve_handle, bool open);
  ** NNStreamer Utilities                           **
  ****************************************************/
 /**
- * @brief Allocates a tensors information handle with default value.
+ * @brief Creates a tensors information handle with default value.
  * @since_tizen 5.5
  * @param[out] info The handle of tensors information.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_allocate_tensors_info (ml_tensors_info_h *info);
+int ml_tensors_info_create (ml_tensors_info_h *info);
 
 /**
  * @brief Frees the given handle of a tensors information.
@@ -473,7 +473,7 @@ int ml_util_allocate_tensors_info (ml_tensors_info_h *info);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_destroy_tensors_info (ml_tensors_info_h info);
+int ml_tensors_info_destroy (ml_tensors_info_h info);
 
 /**
  * @brief Validates the given tensors information.
@@ -485,7 +485,7 @@ int ml_util_destroy_tensors_info (ml_tensors_info_h info);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_validate_tensors_info (const ml_tensors_info_h info, bool *valid);
+int ml_tensors_info_validate (const ml_tensors_info_h info, bool *valid);
 
 /**
  * @brief Copies the tensors information.
@@ -496,7 +496,7 @@ int ml_util_validate_tensors_info (const ml_tensors_info_h info, bool *valid);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src);
+int ml_tensors_info_clone (ml_tensors_info_h dest, const ml_tensors_info_h src);
 
 /**
  * @brief Sets the number of tensors with given handle of tensors information.
@@ -507,7 +507,7 @@ int ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h s
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count);
+int ml_tensors_info_set_count (ml_tensors_info_h info, unsigned int count);
 
 /**
  * @brief Gets the number of tensors with given handle of tensors information.
@@ -518,7 +518,7 @@ int ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count);
+int ml_tensors_info_get_count (ml_tensors_info_h info, unsigned int *count);
 
 /**
  * @brief Sets the tensor name with given handle of tensors information.
@@ -530,7 +530,7 @@ int ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_name (ml_tensors_info_h info, unsigned int index, const char *name);
+int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index, const char *name);
 
 /**
  * @brief Gets the tensor name with given handle of tensors information.
@@ -542,7 +542,7 @@ int ml_util_set_tensor_name (ml_tensors_info_h info, unsigned int index, const c
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **name);
+int ml_tensors_info_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **name);
 
 /**
  * @brief Sets the tensor type with given handle of tensors information.
@@ -554,7 +554,7 @@ int ml_util_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type);
+int ml_tensors_info_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type);
 
 /**
  * @brief Gets the tensor type with given handle of tensors information.
@@ -566,7 +566,7 @@ int ml_util_set_tensor_type (ml_tensors_info_h info, unsigned int index, const m
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tensor_type_e *type);
+int ml_tensors_info_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tensor_type_e *type);
 
 /**
  * @brief Sets the tensor dimension with given handle of tensors information.
@@ -578,7 +578,7 @@ int ml_util_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tens
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, const ml_tensor_dimension dimension);
+int ml_tensors_info_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, const ml_tensor_dimension dimension);
 
 /**
  * @brief Gets the tensor dimension with given handle of tensors information.
@@ -590,7 +590,7 @@ int ml_util_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, co
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension);
+int ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension);
 
 /**
  * @brief Gets the byte size of the given tensors type.
@@ -598,19 +598,19 @@ int ml_util_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml
  * @param[in] info The tensors' information handle.
  * @return @c >= 0 on success with byte size.
  */
-size_t ml_util_get_tensors_size (const ml_tensors_info_h info);
+size_t ml_tensors_info_get_size (const ml_tensors_info_h info);
 
 /**
- * @brief Allocates a tensor data frame with the given tensors information.
+ * @brief Creates a tensor data frame with the given tensors information.
  * @since_tizen 5.5
  * @param[in] info The handle of tensors information for the allocation.
- * @param[out] data The handle of tensors data. The caller is responsible for freeing the allocated data with ml_util_destroy_tensors_data().
+ * @param[out] data The handle of tensors data. The caller is responsible for freeing the allocated data with ml_tensors_data_destroy().
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to allocate new memory.
  */
-int ml_util_allocate_tensors_data (const ml_tensors_info_h info, ml_tensors_data_h *data);
+int ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h *data);
 
 /**
  * @brief Frees the given tensors' data handle.
@@ -620,7 +620,7 @@ int ml_util_allocate_tensors_data (const ml_tensors_info_h info, ml_tensors_data
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_destroy_tensors_data (ml_tensors_data_h data);
+int ml_tensors_data_destroy (ml_tensors_data_h data);
 
 /**
  * @brief Gets a tensor data of given handle.
@@ -633,7 +633,7 @@ int ml_util_destroy_tensors_data (ml_tensors_data_h data);
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **raw_data, size_t *data_size);
+int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **raw_data, size_t *data_size);
 
 /**
  * @brief Copies a tensor data to given handle.
@@ -646,7 +646,7 @@ int ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
+int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
 
 /**
  * @brief Checks the availability of the given execution environments.
@@ -661,7 +661,7 @@ int ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index, const 
  * @retval #ML_ERROR_NONE Successful and the environments are available.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw, bool *available);
+int ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw, bool *available);
 
 /**
  * @}

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -349,6 +349,7 @@ int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
  * @since_tizen 5.5
  * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[in] data The handle of input tensors, in the format of tensors info given by ml_pipeline_src_get_tensors_info().
+ *                 This function takes ownership of the data if @a policy is #ML_PIPELINE_BUF_POLICY_AUTO_FREE.
  * @param[in] policy The policy of buf deallocation.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -236,6 +236,8 @@ typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data
  * @details Use this function to create gst_parse_launch compatible NNStreamer pipelines.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a pipe handle must be released using ml_pipeline_destroy().
+ * @remarks http://tizen.org/privilege/mediastorage is needed if @a pipeline_description is relevant to media storage.
+ * @remarks http://tizen.org/privilege/externalstorage is needed if @a pipeline_description is relevant to external storage.
  * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (github.com/nnsuite/nnstreamer) documentation for examples and the grammar.
  * @param[in] cb The function to be called when the pipeline state is changed. You may set NULL if it's not required.
  * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -219,6 +219,15 @@ typedef enum {
  */
 typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data);
 
+/**
+ * @brief Callback for the change of pipeline state.
+ * @details If an application wants to get the change of pipeline state, use this callback. This callback can be registered when constructing the pipeline using ml_pipeline_construct(). Do not spend too much time in the callback.
+ * @since_tizen 5.5
+ * @param[out] state The new state of the pipeline.
+ * @param[out] user_data User application's private data.
+ */
+typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data);
+
 /****************************************************
  ** NNStreamer Pipeline Construction (gst-parse)   **
  ****************************************************/
@@ -228,13 +237,15 @@ typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tens
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a pipe handle must be released using ml_pipeline_destroy().
  * @param[in] pipeline_description The pipeline description compatible with GStreamer gst_parse_launch(). Refer to GStreamer manual or NNStreamer (github.com/nnsuite/nnstreamer) documentation for examples and the grammar.
+ * @param[in] cb The function to be called when the pipeline state is changed. You may set NULL if it's not required.
+ * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.
  * @param[out] pipe The NNStreamer pipeline handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Pipeline construction is failed because of wrong parameter or initialization failure.
  */
-int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_h *pipe);
+int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_state_cb cb, void *user_data, ml_pipeline_h *pipe);
 
 /**
  * @brief Destroys the pipeline.
@@ -265,9 +276,10 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
  ** NNStreamer Pipeline Start/Stop Control         **
  ****************************************************/
 /**
- * @brief Starts the pipeline.
+ * @brief Starts the pipeline, asynchronously.
  * @details The pipeline handle returned by ml_pipeline_construct() is started.
  *          Note that this is asynchronous function. State might be "pending".
+ *          If you need to get the changed state, add a callback while constructing a pipeline with ml_pipeline_construct().
  * @since_tizen 5.5
  * @param[in] pipe The pipeline handle.
  * @return @c 0 on success. Otherwise a negative error value.
@@ -278,9 +290,10 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
 int ml_pipeline_start (ml_pipeline_h pipe);
 
 /**
- * @brief Stops the pipeline.
+ * @brief Stops the pipeline, asynchronously.
  * @details The pipeline handle returned by ml_pipeline_construct() is stopped.
  *          Note that this is asynchronous function. State might be "pending".
+ *          If you need to get the changed state, add a callback while constructing a pipeline with ml_pipeline_construct().
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be stopped.
  * @return @c 0 on success. Otherwise a negative error value.

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -169,7 +169,6 @@ typedef enum {
 
 /**
  * @brief Enumeration for pipeline state.
- * @since_tizen 5.5
  * @details Refer to https://gstreamer.freedesktop.org/documentation/plugin-development/basics/states.html.
  *          The state diagram of pipeline looks like this, assuming that there are no errors.
  *
@@ -188,6 +187,7 @@ typedef enum {
  *               V                          |                      |
  *          [ PLAYING ] --------------------+----------------------+
  *
+ * @since_tizen 5.5
  */
 typedef enum {
   ML_PIPELINE_STATE_UNKNOWN				= 0, /**< Unknown state. Maybe not constructed? */
@@ -198,7 +198,7 @@ typedef enum {
 } ml_pipeline_state_e;
 
 /**
- * @brief Enumeration for switch types
+ * @brief Enumeration for switch types.
  * @details This designates different GStreamer filters, "GstInputSelector"/"GetOutputSelector".
  * @since_tizen 5.5
  */
@@ -208,14 +208,14 @@ typedef enum {
 } ml_pipeline_switch_e;
 
 /**
- * @brief Callback for sink element of NNStreamer pipelines (pipeline's output)
+ * @brief Callback for sink element of NNStreamer pipelines (pipeline's output).
  * @details If an application wants to accept data outputs of an NNStreamer stream, use this callback to get data from the stream. Note that the buffer may be deallocated after the return and this is synchronously called. Thus, if you need the data afterwards, copy the data to another buffer and return fast. Do not spend too much time in the callback. It is recommended to use very small tensors at sinks.
  * @since_tizen 5.5
  * @remarks The @a data can be used only in the callback. To use outside, make a copy.
  * @remarks The @a info can be used only in the callback. To use outside, make a copy.
  * @param[out] data The handle of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by ml_tensors_info_get_count() with the handle 'info'. Note that max num_tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
  * @param[out] info The handle of tensors information (cardinality, dimension, and type of given tensor/tensors).
- * @param[in,out] user_data User Application's Private Data.
+ * @param[out] user_data User application's private data.
  */
 typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tensors_info_h info, void *user_data);
 
@@ -223,7 +223,7 @@ typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tens
  ** NNStreamer Pipeline Construction (gst-parse)   **
  ****************************************************/
 /**
- * @brief Constructs the pipeline (GStreamer + NNStreamer)
+ * @brief Constructs the pipeline (GStreamer + NNStreamer).
  * @details Use this function to create gst_parse_launch compatible NNStreamer pipelines.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a pipe handle must be released using ml_pipeline_destroy().
@@ -237,7 +237,7 @@ typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_h data, const ml_tens
 int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_h *pipe);
 
 /**
- * @brief Destroys the pipeline
+ * @brief Destroys the pipeline.
  * @details Use this function to destroy the pipeline constructed with ml_pipeline_construct().
  * @since_tizen 5.5
  * @param[in] pipe The pipeline to be destroyed.
@@ -249,7 +249,7 @@ int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_h *pipe
 int ml_pipeline_destroy (ml_pipeline_h pipe);
 
 /**
- * @brief Gets the state of pipeline
+ * @brief Gets the state of pipeline.
  * @details Gets the state of the pipeline handle returned by ml_pipeline_construct().
  * @since_tizen 5.5
  * @param[in] pipe The pipeline handle.
@@ -265,7 +265,7 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
  ** NNStreamer Pipeline Start/Stop Control         **
  ****************************************************/
 /**
- * @brief Starts the pipeline
+ * @brief Starts the pipeline.
  * @details The pipeline handle returned by ml_pipeline_construct() is started.
  *          Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
@@ -278,7 +278,7 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
 int ml_pipeline_start (ml_pipeline_h pipe);
 
 /**
- * @brief Stops the pipeline
+ * @brief Stops the pipeline.
  * @details The pipeline handle returned by ml_pipeline_construct() is stopped.
  *          Note that this is asynchronous function. State might be "pending".
  * @since_tizen 5.5
@@ -294,7 +294,7 @@ int ml_pipeline_stop (ml_pipeline_h pipe);
  ** NNStreamer Pipeline Sink/Src Control           **
  ****************************************************/
 /**
- * @brief Registers a callback for sink (tensor_sink) of NNStreamer pipelines.
+ * @brief Registers a callback for sink node of NNStreamer pipelines.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a sink_handle handle must be unregistered using ml_pipeline_sink_unregister().
  * @param[in] pipe The pipeline to be attached with a sink node.
@@ -310,9 +310,9 @@ int ml_pipeline_stop (ml_pipeline_h pipe);
 int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pipeline_sink_cb cb, void *user_data, ml_pipeline_sink_h *sink_handle);
 
 /**
- * @brief Unregisters a callback for sink (tensor_sink) of NNStreamer pipelines.
+ * @brief Unregisters a callback for sink node of NNStreamer pipelines.
  * @since_tizen 5.5
- * @param[in] sink_handle The sink handle to be unregistered (destroyed)
+ * @param[in] sink_handle The sink handle to be unregistered.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
@@ -322,7 +322,7 @@ int ml_pipeline_sink_unregister (ml_pipeline_sink_h sink_handle);
 /**
  * @brief Gets a handle to operate as a src node of NNStreamer pipelines.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a src_handle handle must be released using ml_pipeline_src_put_handle().
+ * @remarks If the function succeeds, @a src_handle handle must be released using ml_pipeline_src_release_handle().
  * @param[in] pipe The pipeline to be attached with a src node.
  * @param[in] src_name The name of src node, described with ml_pipeline_construct().
  * @param[out] src_handle The src handle.
@@ -335,17 +335,18 @@ int ml_pipeline_sink_unregister (ml_pipeline_sink_h sink_handle);
 int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_pipeline_src_h *src_handle);
 
 /**
- * @brief Closes the given handle of a src node of NNStreamer pipelines.
+ * @brief Releases the given src handle.
  * @since_tizen 5.5
- * @param[in] src_handle The src handle to be closed.
+ * @param[in] src_handle The src handle to be released.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_src_put_handle (ml_pipeline_src_h src_handle);
+int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
 
 /**
  * @brief Adds an input data frame.
+ * @since_tizen 5.5
  * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().
  * @param[in] data The handle of input tensors, in the format of tensors info given by ml_pipeline_src_get_tensors_info().
  * @param[in] policy The policy of buf deallocation.
@@ -379,29 +380,32 @@ int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h src_handle, ml_tensors_i
  * @brief Gets a handle to operate a "GstInputSelector / GstOutputSelector" node of NNStreamer pipelines.
  * @details Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-input-selector.html for input selectors.
  *          Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-output-selector.html for output selectors.
- * @remarks If the function succeeds, @a switch_handle handle must be released using ml_pipeline_switch_put_handle().
+ * @since_tizen 5.5
+ * @remarks If the function succeeds, @a switch_handle handle must be released using ml_pipeline_switch_release_handle().
  * @param[in] pipe The pipeline to be managed.
- * @param[in] switch_name The name of switch (InputSelector/OutputSelector)
- * @param[out] type The type of the switch. If NULL, it is ignored.
+ * @param[in] switch_name The name of switch (InputSelector/OutputSelector).
+ * @param[out] switch_type The type of the switch. If NULL, it is ignored.
  * @param[out] switch_handle The switch handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, ml_pipeline_switch_e *type, ml_pipeline_switch_h *switch_handle);
+int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, ml_pipeline_switch_e *switch_type, ml_pipeline_switch_h *switch_handle);
 
 /**
- * @brief Closes the given switch handle.
- * @param[in] switch_handle The handle to be closed.
+ * @brief Releases the given switch handle.
+ * @since_tizen 5.5
+ * @param[in] switch_handle The handle to be released.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_switch_put_handle (ml_pipeline_switch_h switch_handle);
+int ml_pipeline_switch_release_handle (ml_pipeline_switch_h switch_handle);
 
 /**
  * @brief Controls the switch with the given handle to select input/output nodes(pads).
- * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle()
+ * @since_tizen 5.5
+ * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle().
  * @param[in] pad_name The name of the chosen pad to be activated. Use ml_pipeline_switch_get_pad_list() to list the available pad names.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -411,7 +415,8 @@ int ml_pipeline_switch_select (ml_pipeline_switch_h switch_handle, const char *p
 
 /**
  * @brief Gets the pad names of a switch.
- * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle()
+ * @since_tizen 5.5
+ * @param[in] switch_handle The switch handle returned by ml_pipeline_switch_get_handle().
  * @param[out] list NULL terminated array of char*. The caller must free each string (char*) in the list and free the list itself.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -423,9 +428,10 @@ int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h switch_handle, char **
 /**
  * @brief Gets a handle to operate a "GstValve" node of NNStreamer pipelines.
  * @details Refer to https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-plugins/html/gstreamer-plugins-valve.html for more info.
- * @remarks If the function succeeds, @a valve_handle handle must be released using ml_pipeline_valve_put_handle().
+ * @since_tizen 5.5
+ * @remarks If the function succeeds, @a valve_handle handle must be released using ml_pipeline_valve_release_handle().
  * @param[in] pipe The pipeline to be managed.
- * @param[in] valve_name The name of valve (Valve)
+ * @param[in] valve_name The name of valve (Valve).
  * @param[out] valve_handle The valve handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -434,18 +440,20 @@ int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h switch_handle, char **
 int ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name, ml_pipeline_valve_h *valve_handle);
 
 /**
- * @brief Closes the given valve handle.
- * @param[in] valve_handle The handle to be closed.
+ * @brief Releases the given valve handle.
+ * @since_tizen 5.5
+ * @param[in] valve_handle The handle to be released.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_valve_put_handle (ml_pipeline_valve_h valve_handle);
+int ml_pipeline_valve_release_handle (ml_pipeline_valve_h valve_handle);
 
 /**
  * @brief Controls the valve with the given handle.
- * @param[in] valve_handle The valve handle returned by ml_pipeline_valve_get_handle()
- * @param[in] open @c true to open(let the flow pass), @c false to close (drop & stop the flow)
+ * @since_tizen 5.5
+ * @param[in] valve_handle The valve handle returned by ml_pipeline_valve_get_handle().
+ * @param[in] open @c true to open(let the flow pass), @c false to close (drop & stop the flow).
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
@@ -640,8 +648,8 @@ int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index,
  * @since_tizen 5.5
  * @param[in] data The handle of tensors data.
  * @param[in] index The index of the tensor.
- * @param[out] raw_data Raw tensor data to be copied.
- * @param[out] data_size Byte size of raw data.
+ * @param[in] raw_data Raw tensor data to be copied.
+ * @param[in] data_size Byte size of raw data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -25,6 +25,8 @@
 #define __TIZEN_MACHINELEARNING_NNSTREAMER_H__
 
 #include <stddef.h>
+#include <stdbool.h>
+
 /**
  *  Apply modify_nnstreamer_h_for_nontizen.sh if you want to use
  * in non-Tizen Linux machines
@@ -55,7 +57,13 @@ extern "C" {
  * @brief Dimension information that NNStreamer support.
  * @since_tizen 5.5
  */
-typedef unsigned int ml_tensor_dim[ML_TENSOR_RANK_LIMIT];
+typedef unsigned int ml_tensor_dimension[ML_TENSOR_RANK_LIMIT];
+
+/**
+ * @brief A handle of a tensors metadata instance.
+ * @since_tizen 5.5
+ */
+typedef void *ml_tensors_info_h;
 
 /**
  * @brief A handle of an NNStreamer pipeline.
@@ -92,19 +100,19 @@ typedef void *ml_pipeline_valve_h;
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_NNFW_UNKNOWN = 0, /**< it is unknown or we do not care this value. */
-  ML_NNFW_CUSTOM_FILTER, /**< custom filter (independent shared object). */
-  ML_NNFW_TENSORFLOW_LITE, /**< tensorflow-lite (.tflite). */
-  ML_NNFW_TENSORFLOW, /**< tensorflow (.pb). */
-} ml_nnfw_e;
+  ML_NNFW_TYPE_ANY = 0, /**< determines the nnfw with file extension. */
+  ML_NNFW_TYPE_CUSTOM_FILTER, /**< custom filter (independent shared object). */
+  ML_NNFW_TYPE_TENSORFLOW_LITE, /**< tensorflow-lite (.tflite). */
+  ML_NNFW_TYPE_TENSORFLOW, /**< tensorflow (.pb). */
+} ml_nnfw_type_e;
 
 /**
- * @brief Types of NNFWs. Note that if the affinity (nnn) is not supported by the driver or hardware, it is ignored.
+ * @brief Types of hardware resources to be used for NNFWs. Note that if the affinity (nnn) is not supported by the driver or hardware, it is ignored.
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_NNFW_HW_DO_NOT_CARE = 0, /**< Hardware resource is not specified. */
-  ML_NNFW_HW_AUTO = 1, /**< Try to schedule and optimize if possible. */
+  ML_NNFW_HW_ANY = 0,      /**< Hardware resource is not specified. */
+  ML_NNFW_HW_AUTO = 1,     /**< Try to schedule and optimize if possible. */
   ML_NNFW_HW_CPU = 0x1000, /**< 0x1000: any CPU. 0x1nnn: CPU # nnn-1. */
   ML_NNFW_HW_GPU = 0x2000, /**< 0x2000: any GPU. 0x2nnn: GPU # nnn-1. */
   ML_NNFW_HW_NPU = 0x3000, /**< 0x3000: any NPU. 0x3nnn: NPU # nnn-1. */
@@ -126,7 +134,7 @@ typedef enum _ml_tensor_type_e
   ML_TENSOR_TYPE_FLOAT32,        /**< Float 32bit */
   ML_TENSOR_TYPE_INT64,          /**< Integer 64bit */
   ML_TENSOR_TYPE_UINT64,         /**< Unsigned integer 64bit */
-  ML_TENSOR_TYPE_UNKNOWN          /**< Unknown type */
+  ML_TENSOR_TYPE_UNKNOWN         /**< Unknown type */
 } ml_tensor_type_e;
 
 /**
@@ -194,25 +202,6 @@ typedef enum {
 } ml_pipeline_switch_e;
 
 /**
- * @brief Data structure for tensor information.
- * @since_tizen 5.5
- */
-typedef struct {
-  char * name;              /**< Name of each element in the tensor. */
-  ml_tensor_type_e type;   /**< Type of each element in the tensor. */
-  ml_tensor_dim dimension;     /**< Dimension information. */
-} ml_tensor_info_s;
-
-/**
- * @brief Data structure for tensors information, which contains multiple tensors.
- * @since_tizen 5.5
- */
-typedef struct {
-  unsigned int num_tensors; /**< The number of tensors. */
-  ml_tensor_info_s info[ML_TENSOR_SIZE_LIMIT];  /**< The list of tensor info. */
-} ml_tensors_info_s;
-
-/**
  * @brief An instance of a single input or output frame.
  * @since_tizen 5.5
  */
@@ -222,7 +211,7 @@ typedef struct {
 } ml_tensor_data_s;
 
 /**
- * @brief An instance of input or output frames. #ml_tensors_info_s is the metadata.
+ * @brief An instance of input or output frames. #ml_tensors_info_h is the handle for tensors metadata.
  * @since_tizen 5.5
  */
 typedef struct {
@@ -236,11 +225,11 @@ typedef struct {
  * @since_tizen 5.5
  * @remarks The @a data can be used only in the callback. To use outside, make a copy.
  * @remarks The @a info can be used only in the callback. To use outside, make a copy.
- * @param[in] data The contents of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by data->num_tensors. Note that max num_tensors is 16 (ML_TENSOR_SIZE_LIMIT).
- * @param[in] info The cardinality, dimension, and type of given tensor/tensors.
+ * @param[out] data The contents of the tensor output (a single frame. tensor/tensors). Number of tensors is determined by data->num_tensors. Note that max num_tensors is 16 (#ML_TENSOR_SIZE_LIMIT).
+ * @param[out] info The handle of tensors information (cardinality, dimension, and type of given tensor/tensors).
  * @param[in,out] user_data User Application's Private Data.
  */
-typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_s *data, const ml_tensors_info_s *info, void *user_data);
+typedef void (*ml_pipeline_sink_cb) (const ml_tensors_data_s *data, const ml_tensors_info_h info, void *user_data);
 
 /****************************************************
  ** NNStreamer Pipeline Construction (gst-parse)   **
@@ -296,7 +285,7 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
- * @retval #ML_ERROR_STREAMS_PIPE Failed to start.
+ * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
  */
 int ml_pipeline_start (ml_pipeline_h pipe);
 
@@ -319,18 +308,18 @@ int ml_pipeline_stop (ml_pipeline_h pipe);
 /**
  * @brief Registers a callback for sink (tensor_sink) of NNStreamer pipelines.
  * @since_tizen 5.5
- * @remarks If the function succeeds, @a h handle must be unregistered using ml_pipeline_sink_unregister.
+ * @remarks If the function succeeds, @a h handle must be unregistered using ml_pipeline_sink_unregister().
  * @param[in] pipe The pipeline to be attached with a sink node.
  * @param[in] sink_name The name of sink node, described with ml_pipeline_construct().
  * @param[in] cb The function to be called by the sink node.
  * @param[out] h The sink handle.
- * @param[in] pdata Private data for the callback. This value is passed to the callback when it's invoked.
+ * @param[in] user_data Private data for the callback. This value is passed to the callback when it's invoked.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL, sink_name is not found, or sink_name has an invalid type.)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to connect a signal to sink element.
  */
-int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pipeline_sink_cb cb, ml_pipeline_sink_h *h, void *pdata);
+int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pipeline_sink_cb cb, ml_pipeline_sink_h *h, void *user_data);
 
 /**
  * @brief Unregisters a callback for sink (tensor_sink) of NNStreamer pipelines.
@@ -348,7 +337,6 @@ int ml_pipeline_sink_unregister (ml_pipeline_sink_h h);
  * @remarks If the function succeeds, @a h handle must be released using ml_pipeline_src_put_handle().
  * @param[in] pipe The pipeline to be attached with a src node.
  * @param[in] src_name The name of src node, described with ml_pipeline_construct().
- * @param[out] tensors_info The cardinality, dimension, and type of given tensor/tensors.
  * @param[out] h The src handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -356,7 +344,7 @@ int ml_pipeline_sink_unregister (ml_pipeline_sink_h h);
  * @retval #ML_ERROR_STREAMS_PIPE Fail to get SRC element.
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
-int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_tensors_info_s *tensors_info, ml_pipeline_src_h *h);
+int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_pipeline_src_h *h);
 
 /**
  * @brief Closes the given handle of a src node of NNStreamer pipelines.
@@ -371,7 +359,7 @@ int ml_pipeline_src_put_handle (ml_pipeline_src_h h);
 /**
  * @brief Puts an input data frame.
  * @param[in] h The source handle returned by ml_pipeline_src_get_handle().
- * @param[in] data The input tensors, in the format of tensors info given by ml_pipeline_src_get_handle().
+ * @param[in] data The input tensors, in the format of tensors info given by ml_pipeline_src_get_tensors_info().
  * @param[in] policy The policy of buf deallocation.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
@@ -380,6 +368,20 @@ int ml_pipeline_src_put_handle (ml_pipeline_src_h h);
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
  */
 int ml_pipeline_src_input_data (ml_pipeline_src_h h, const ml_tensors_data_s *data, ml_pipeline_buf_policy_e policy);
+
+/**
+ * @brief Gets a handle for the tensors information of given src node.
+ * @since_tizen 5.5
+ * @remarks If the function succeeds, @a info_h handle must be released using ml_util_destroy_tensors_info().
+ * @param[in] h The source handle returned by ml_pipeline_src_get_handle().
+ * @param[out] info The handle of tensors information.
+ * @return 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ * @retval #ML_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
+ * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
+ */
+int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h h, ml_tensors_info_h *info);
 
 /****************************************************
  ** NNStreamer Pipeline Switch/Valve Control       **
@@ -412,7 +414,7 @@ int ml_pipeline_switch_put_handle (ml_pipeline_switch_h h);
 /**
  * @brief Controls the switch with the given handle to select input/output nodes(pads).
  * @param[in] h The switch handle returned by ml_pipeline_switch_get_handle()
- * @param[in] pad_name The name of the chosen pad to be activated. Use ml_pipeline_switch_nodelist to list the available pad names.
+ * @param[in] pad_name The name of the chosen pad to be activated. Use ml_pipeline_switch_get_pad_list() to list the available pad names.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
@@ -428,7 +430,7 @@ int ml_pipeline_switch_select (ml_pipeline_switch_h h, const char *pad_name);
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE The element is not both input and output switch (Internal data inconsistency).
  */
-int ml_pipeline_switch_nodelist (ml_pipeline_switch_h h, char *** list);
+int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h h, char ***list);
 
 /**
  * @brief Gets a handle to operate a "GstValve" node of NNStreamer pipelines.
@@ -455,73 +457,158 @@ int ml_pipeline_valve_put_handle (ml_pipeline_valve_h h);
 /**
  * @brief Controls the valve with the given handle.
  * @param[in] h The valve handle returned by ml_pipeline_valve_get_handle()
- * @param[in] drop 1 to close (drop & stop the flow). 0 to open (let the flow pass)
+ * @param[in] open @c true to open(let the flow pass), @c false to close (drop & stop the flow)
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_pipeline_valve_control (ml_pipeline_valve_h h, int drop);
+int ml_pipeline_valve_set_open (ml_pipeline_valve_h h, bool open);
 
 /****************************************************
  ** NNStreamer Utilities                           **
  ****************************************************/
 /**
- * @brief Initializes the tensors info.
+ * @brief Allocates a tensors information handle with default value.
  * @since_tizen 5.5
- * @param[in] info The tensors information to be initialized.
- */
-void ml_util_initialize_tensors_info (ml_tensors_info_s *info);
-
-/**
- * @brief Validates the given tensor info is valid.
- * @since_tizen 5.5
- * @param[in] info The tensor information to be validated.
+ * @param[out] info The handle of tensors information.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_validate_tensor_info (const ml_tensor_info_s *info);
+int ml_util_allocate_tensors_info (ml_tensors_info_h *info);
 
 /**
- * @brief Validates the given tensors info is valid.
+ * @brief Frees the given handle of a tensors information.
  * @since_tizen 5.5
- * @param[in] info The tensors information to be validated.
+ * @param[in] info The handle of tensors information.
+ * @return 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_destroy_tensors_info (ml_tensors_info_h info);
+
+/**
+ * @brief Validates the given tensors information is valid.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information to be validated.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_validate_tensors_info (const ml_tensors_info_s *info);
+int ml_util_validate_tensors_info (const ml_tensors_info_h info);
 
 /**
- * @brief Copies tensor meta info.
+ * @brief Copies the tensors information.
  * @since_tizen 5.5
- * @param[out] dest Newly allocated tensors information.
+ * @param[out] dest A destination handle of tensors information.
  * @param[in] src The tensors information to be copied.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-void ml_util_copy_tensors_info (ml_tensors_info_s *dest, const ml_tensors_info_s *src);
+int ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src);
 
 /**
- * @brief Gets the byte size of the given tensor type.
+ * @brief Sets the number of tensors with given handle of tensors information.
  * @since_tizen 5.5
- * @param[in] info The tensor information to be investigated.
- * @return @c >= 0 on success with byte size.
+ * @param[in] info The handle of tensors information.
+ * @param[in] count The number of tensors.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-size_t ml_util_get_tensor_size (const ml_tensor_info_s *info);
+int ml_util_set_tensors_count (ml_tensors_info_h info, const unsigned int count);
+
+/**
+ * @brief Gets the number of tensors with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[out] count The number of tensors.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count);
+
+/**
+ * @brief Sets the tensor name with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta to be updated.
+ * @param[in] name The tensor name to be set.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_set_tensor_name (ml_tensors_info_h info, const unsigned int index, const char *name);
+
+/**
+ * @brief Gets the tensor name with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta.
+ * @param[out] name The tensor name.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_get_tensor_name (ml_tensors_info_h info, const unsigned int index, char **name);
+
+/**
+ * @brief Sets the tensor type with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta to be updated.
+ * @param[in] type The tensor type to be set.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_set_tensor_type (ml_tensors_info_h info, const unsigned int index, const ml_tensor_type_e type);
+
+/**
+ * @brief Gets the tensor type with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta.
+ * @param[out] type The tensor type.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_get_tensor_type (ml_tensors_info_h info, const unsigned int index, ml_tensor_type_e *type);
+
+/**
+ * @brief Sets the tensor dimension with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta to be updated.
+ * @param[in] dimension The tensor dimension to be set.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_set_tensor_dimension (ml_tensors_info_h info, const unsigned int index, const ml_tensor_dimension dimension);
+
+/**
+ * @brief Gets the tensor dimension with given handle of tensors information.
+ * @since_tizen 5.5
+ * @param[in] info The handle of tensors information.
+ * @param[in] index The index of tensor meta.
+ * @param[out] dimension The tensor dimension.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_util_get_tensor_dimension (ml_tensors_info_h info, const unsigned int index, ml_tensor_dimension dimension);
 
 /**
  * @brief Gets the byte size of the given tensors type.
  * @since_tizen 5.5
- * @param[in] info The tensors information to be investigated.
+ * @param[in] info The handle of tensors information to be investigated.
  * @return @c >= 0 on success with byte size.
  */
-size_t ml_util_get_tensors_size (const ml_tensors_info_s *info);
-
-/**
- * @brief Frees the tensors info pointer.
- * @since_tizen 5.5
- * @param[in] info The tensors info pointer to be freed.
- */
-void ml_util_free_tensors_info (ml_tensors_info_s *info);
+size_t ml_util_get_tensors_size (const ml_tensors_info_h info);
 
 /**
  * @brief Frees the tensors data pointer.
@@ -531,28 +618,28 @@ void ml_util_free_tensors_info (ml_tensors_info_s *info);
 void ml_util_free_tensors_data (ml_tensors_data_s **data);
 
 /**
- * @brief Allocates a tensor data frame with the given tensors type.
+ * @brief Allocates a tensor data frame with the given tensors information.
  * @since_tizen 5.5
- * @param[in] info The tensors information for the allocation.
+ * @param[in] info The handle of tensors information for the allocation.
  * @return @c Tensors data pointer allocated. Null if error. Caller is responsible to free the allocated data with ml_util_free_tensors_data().
  * @retval NULL There is an error. Call ml_util_get_last_error() to get specific error code.
  */
-ml_tensors_data_s *ml_util_allocate_tensors_data (const ml_tensors_info_s *info);
+ml_tensors_data_s *ml_util_allocate_tensors_data (const ml_tensors_info_h info);
 
 /**
  * @brief Checks the availability of the given execution environments.
+ * @details If the function returns an error, @a available is not changed.
  * @since_tizen 5.5
  * @param[in] nnfw Check if the nnfw is available in the system.
- *               Set #ML_NNFW_UNKNOWN to skip checking nnfw.
+ *               Set #ML_NNFW_TYPE_ANY to skip checking nnfw.
  * @param[in] hw Check if the hardware is available in the system.
- *               Set #ML_NNFW_HW_DO_NOT_CARE to skip checking hardware.
- * @return @c 0 if it's available. 1 if it's not available.
- *            negative value if there is an error.
+ *               Set #ML_NNFW_HW_ANY to skip checking hardware.
+ * @param[out] available @c true if it's available, @c false if if it's not available.
+ * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful and the environments are available.
- * @retval #ML_ERROR_NOT_SUPPORTED The given option is not available.
- * @retval 1 Successful but the environments are not available.
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_util_check_nnfw (ml_nnfw_e nnfw, ml_nnfw_hw_e hw);
+int ml_util_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw, bool *available);
 
 /**
  * @brief Gets the last error code.

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -438,7 +438,7 @@ ml_pipeline_destroy (ml_pipeline_h pipe)
 {
   ml_pipeline *p = pipe;
   GstStateChangeReturn scret;
-  GstState state, pending;
+  GstState state;
 
   if (p == NULL)
     return ML_ERROR_INVALID_PARAMETER;
@@ -446,7 +446,7 @@ ml_pipeline_destroy (ml_pipeline_h pipe)
   g_mutex_lock (&p->lock);
 
   /* if it's PLAYING, PAUSE it. */
-  scret = gst_element_get_state (p->element, &state, &pending, 10000000UL);     /* 10ms */
+  scret = gst_element_get_state (p->element, &state, NULL, 10 * GST_MSECOND);     /* 10ms */
   if (scret != GST_STATE_CHANGE_FAILURE && state == GST_STATE_PLAYING) {
     /* Pause the pipeline if it's Playing */
     scret = gst_element_set_state (p->element, GST_STATE_PAUSED);
@@ -488,7 +488,6 @@ ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e * state)
 {
   ml_pipeline *p = pipe;
   GstState _state;
-  GstState pending;
   GstStateChangeReturn scret;
 
   if (p == NULL || state == NULL)
@@ -497,7 +496,7 @@ ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e * state)
   *state = ML_PIPELINE_STATE_UNKNOWN;
 
   g_mutex_lock (&p->lock);
-  scret = gst_element_get_state (p->element, &_state, &pending, 100000UL);      /* Do it within 100us! */
+  scret = gst_element_get_state (p->element, &_state, NULL, GST_MSECOND);      /* Do it within 1ms! */
   g_mutex_unlock (&p->lock);
 
   if (scret == GST_STATE_CHANGE_FAILURE)

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -561,7 +561,7 @@ ml_pipeline_stop (ml_pipeline_h pipe)
  */
 int
 ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name,
-    ml_pipeline_sink_cb cb, ml_pipeline_sink_h * h, void *user_data)
+    ml_pipeline_sink_cb cb, void *user_data, ml_pipeline_sink_h * h)
 {
   ml_pipeline_element *elem;
   ml_pipeline *p = pipe;
@@ -836,7 +836,7 @@ ml_pipeline_src_put_handle (ml_pipeline_src_h h)
  * @brief Push a data frame to a src (more info in nnstreamer.h)
  */
 int
-ml_pipeline_src_input_data (ml_pipeline_src_h h, const ml_tensors_data_h data,
+ml_pipeline_src_input_data (ml_pipeline_src_h h, ml_tensors_data_h data,
     ml_pipeline_buf_policy_e policy)
 {
   /** @todo NYI */

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -822,7 +822,7 @@ unlock_return:
  * @brief Close a src node (more info in nnstreamer.h)
  */
 int
-ml_pipeline_src_put_handle (ml_pipeline_src_h h)
+ml_pipeline_src_release_handle (ml_pipeline_src_h h)
 {
   handle_init (src, src, h);
 
@@ -1022,7 +1022,7 @@ unlock_return:
  * @brief Close the given switch handle (more info in nnstreamer.h)
  */
 int
-ml_pipeline_switch_put_handle (ml_pipeline_switch_h h)
+ml_pipeline_switch_release_handle (ml_pipeline_switch_h h)
 {
   handle_init (switch, swtc, h);
 
@@ -1241,7 +1241,7 @@ unlock_return:
  * @brief Close the given valve handle (more info in nnstreamer.h)
  */
 int
-ml_pipeline_valve_put_handle (ml_pipeline_valve_h h)
+ml_pipeline_valve_release_handle (ml_pipeline_valve_h h)
 {
   handle_init (valve, valve, h);
 

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -81,7 +81,7 @@ construct_element (GstElement * e, ml_pipeline * p, const char *name,
   ret->handles = NULL;
   ret->src = NULL;
   ret->sink = NULL;
-  ml_util_initialize_tensors_info (&ret->tensors_info);
+  ml_tensors_info_initialize (&ret->tensors_info);
   ret->size = 0;
   ret->maxid = 0;
   ret->handle_id = 0;
@@ -100,7 +100,7 @@ get_tensors_info_from_caps (GstCaps * caps, ml_tensors_info_s * info)
   guint i, n_caps;
   gboolean found = FALSE;
 
-  ml_util_initialize_tensors_info (info);
+  ml_tensors_info_initialize (info);
   n_caps = gst_caps_get_size (caps);
 
   for (i = 0; i < n_caps; i++) {
@@ -108,7 +108,7 @@ get_tensors_info_from_caps (GstCaps * caps, ml_tensors_info_s * info)
     found = gst_tensors_config_from_structure (&config, s);
 
     if (found) {
-      ml_util_copy_tensors_info_from_gst (info, &config.info);
+      ml_tensors_info_copy_from_gst (info, &config.info);
       break;
     }
   }
@@ -188,7 +188,7 @@ cb_sink_event (GstElement * e, GstBuffer * b, gpointer user_data)
           }
 
           for (i = 0; i < elem->tensors_info.num_tensors; i++) {
-            size_t sz = ml_util_get_tensor_size (&elem->tensors_info.info[i]);
+            size_t sz = ml_tensor_info_get_size (&elem->tensors_info.info[i]);
 
             if (sz != data->tensors[i].size) {
               ml_loge
@@ -289,7 +289,7 @@ cleanup_node (gpointer data)
     g_list_free_full (e->handles, g_free);
   e->handles = NULL;
 
-  ml_util_free_tensors_info (&e->tensors_info);
+  ml_tensors_info_free (&e->tensors_info);
 
   g_mutex_unlock (&e->lock);
   g_mutex_clear (&e->lock);
@@ -732,7 +732,7 @@ ml_pipeline_src_parse_tensors_info (ml_pipeline_element * elem)
 
       if (found) {
         for (i = 0; i < elem->tensors_info.num_tensors; i++) {
-          sz = ml_util_get_tensor_size (&elem->tensors_info.info[i]);
+          sz = ml_tensor_info_get_size (&elem->tensors_info.info[i]);
           elem->size += sz;
         }
       } else {
@@ -879,7 +879,7 @@ ml_pipeline_src_input_data (ml_pipeline_src_h h, ml_tensors_data_h data,
   }
 
   for (i = 0; i < elem->tensors_info.num_tensors; i++) {
-    size_t sz = ml_util_get_tensor_size (&elem->tensors_info.info[i]);
+    size_t sz = ml_tensor_info_get_size (&elem->tensors_info.info[i]);
 
     if (sz != _data->tensors[i].size) {
       ml_loge
@@ -933,8 +933,8 @@ ml_pipeline_src_get_tensors_info (ml_pipeline_src_h h,
   ret = ml_pipeline_src_parse_tensors_info (elem);
 
   if (ret == ML_ERROR_NONE) {
-    ml_util_allocate_tensors_info (info);
-    ml_util_copy_tensors_info (*info, &elem->tensors_info);
+    ml_tensors_info_create (info);
+    ml_tensors_info_clone (*info, &elem->tensors_info);
   }
 
   handle_exit (h);

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -45,48 +45,12 @@ typedef struct
 } ml_single;
 
 /**
- * @brief Gets caps from tensors info.
- */
-static GstCaps *
-ml_single_get_caps_from_tensors_info (const ml_tensors_info_s * info)
-{
-  GstCaps *caps;
-  GstTensorsConfig config;
-
-  if (!info)
-    return NULL;
-
-  ml_util_copy_tensors_info_from_ml (&config.info, info);
-
-  /* set framerate 0/1 */
-  config.rate_n = 0;
-  config.rate_d = 1;
-
-  /* Supposed input type is single tensor if the number of tensors is 1. */
-  if (config.info.num_tensors == 1) {
-    GstTensorConfig c;
-
-    gst_tensor_info_copy (&c.info, &config.info.info[0]);
-    c.rate_n = 0;
-    c.rate_d = 1;
-
-    caps = gst_tensor_caps_from_config (&c);
-    gst_tensor_info_free (&c.info);
-  } else {
-    caps = gst_tensors_caps_from_config (&config);
-  }
-
-  gst_tensors_info_free (&config.info);
-  return caps;
-}
-
-/**
  * @brief Opens an ML model and returns the instance as a handle.
  */
 int
-ml_single_open (ml_single_h * single, const char *model_path,
-    const ml_tensors_info_s * input_info, const ml_tensors_info_s * output_info,
-    ml_nnfw_e nnfw, ml_nnfw_hw_e hw)
+ml_single_open (ml_single_h * single, const char *model,
+    const ml_tensors_info_h input_info, const ml_tensors_info_h output_info,
+    ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw)
 {
   ml_single *single_h;
   ml_pipeline_h pipe;
@@ -96,6 +60,8 @@ ml_single_open (ml_single_h * single, const char *model_path,
   int status = ML_ERROR_NONE;
   gchar *pipeline_desc = NULL;
   gchar *path_down;
+  ml_tensors_info_s *in_tensors_info, *out_tensors_info;
+  bool available = false;
 
   /* Validate the params */
   if (!single) {
@@ -106,50 +72,53 @@ ml_single_open (ml_single_h * single, const char *model_path,
   /* init null */
   *single = NULL;
 
-  if (input_info &&
-      ml_util_validate_tensors_info (input_info) != ML_ERROR_NONE) {
+  in_tensors_info = (ml_tensors_info_s *) input_info;
+  out_tensors_info = (ml_tensors_info_s *) output_info;
+
+  if (in_tensors_info &&
+      ml_util_validate_tensors_info (in_tensors_info) != ML_ERROR_NONE) {
     ml_loge ("The given param, input tensor info is invalid.");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
-  if (output_info &&
-      ml_util_validate_tensors_info (output_info) != ML_ERROR_NONE) {
+  if (out_tensors_info &&
+      ml_util_validate_tensors_info (out_tensors_info) != ML_ERROR_NONE) {
     ml_loge ("The given param, output tensor info is invalid.");
     return ML_ERROR_INVALID_PARAMETER;
   }
 
   /* 1. Determine nnfw */
   /* Check file extention. */
-  path_down = g_ascii_strdown (model_path, -1);
+  path_down = g_ascii_strdown (model, -1);
 
   switch (nnfw) {
-    case ML_NNFW_UNKNOWN:
+    case ML_NNFW_TYPE_ANY:
       if (g_str_has_suffix (path_down, ".tflite")) {
-        ml_logi ("The given model [%s] is supposed a tensorflow-lite model.", model_path);
-        nnfw = ML_NNFW_TENSORFLOW_LITE;
+        ml_logi ("The given model [%s] is supposed a tensorflow-lite model.", model);
+        nnfw = ML_NNFW_TYPE_TENSORFLOW_LITE;
       } else if (g_str_has_suffix (path_down, ".pb")) {
-        ml_logi ("The given model [%s] is supposed a tensorflow model.", model_path);
-        nnfw = ML_NNFW_TENSORFLOW;
+        ml_logi ("The given model [%s] is supposed a tensorflow model.", model);
+        nnfw = ML_NNFW_TYPE_TENSORFLOW;
       } else {
-        ml_loge ("The given model [%s] has unknown extension.", model_path);
+        ml_loge ("The given model [%s] has unknown extension.", model);
         status = ML_ERROR_INVALID_PARAMETER;
       }
       break;
-    case ML_NNFW_CUSTOM_FILTER:
+    case ML_NNFW_TYPE_CUSTOM_FILTER:
       if (!g_str_has_suffix (path_down, ".so")) {
-        ml_loge ("The given model [%s] has invalid extension.", model_path);
+        ml_loge ("The given model [%s] has invalid extension.", model);
         status = ML_ERROR_INVALID_PARAMETER;
       }
       break;
-    case ML_NNFW_TENSORFLOW_LITE:
+    case ML_NNFW_TYPE_TENSORFLOW_LITE:
       if (!g_str_has_suffix (path_down, ".tflite")) {
-        ml_loge ("The given model [%s] has invalid extension.", model_path);
+        ml_loge ("The given model [%s] has invalid extension.", model);
         status = ML_ERROR_INVALID_PARAMETER;
       }
       break;
-    case ML_NNFW_TENSORFLOW:
+    case ML_NNFW_TYPE_TENSORFLOW:
       if (!g_str_has_suffix (path_down, ".pb")) {
-        ml_loge ("The given model [%s] has invalid extension.", model_path);
+        ml_loge ("The given model [%s] has invalid extension.", model);
         status = ML_ERROR_INVALID_PARAMETER;
       }
       break;
@@ -161,16 +130,16 @@ ml_single_open (ml_single_h * single, const char *model_path,
   if (status != ML_ERROR_NONE)
     return status;
 
-  if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
+  if (!g_file_test (model, G_FILE_TEST_IS_REGULAR)) {
     ml_loge ("The given param, model path [%s] is invalid.",
-        GST_STR_NULL (model_path));
+        GST_STR_NULL (model));
     return ML_ERROR_INVALID_PARAMETER;
   }
 
   /* 2. Determine hw */
   /** @todo Now the param hw is ignored. (Supposed CPU only) Support others later. */
-  status = ml_util_check_nnfw (nnfw, hw);
-  if (status < 0) {
+  status = ml_util_check_nnfw_availability (nnfw, hw, &available);
+  if (status != ML_ERROR_NONE || !available) {
     ml_loge ("The given nnfw is not available.");
     return status;
   }
@@ -178,27 +147,27 @@ ml_single_open (ml_single_h * single, const char *model_path,
   /* 3. Construct a pipeline */
   /* Set the pipeline desc with nnfw. */
   switch (nnfw) {
-    case ML_NNFW_CUSTOM_FILTER:
+    case ML_NNFW_TYPE_CUSTOM_FILTER:
       pipeline_desc =
           g_strdup_printf
           ("appsrc name=srcx ! tensor_filter name=filterx framework=custom model=%s ! appsink name=sinkx sync=false",
-          model_path);
+          model);
       break;
-    case ML_NNFW_TENSORFLOW_LITE:
+    case ML_NNFW_TYPE_TENSORFLOW_LITE:
       /* We can get the tensor meta from tf-lite model. */
       pipeline_desc =
           g_strdup_printf
           ("appsrc name=srcx ! tensor_filter name=filterx framework=tensorflow-lite model=%s ! appsink name=sinkx sync=false",
-          model_path);
+          model);
       break;
-    case ML_NNFW_TENSORFLOW:
-      if (input_info && output_info) {
+    case ML_NNFW_TYPE_TENSORFLOW:
+      if (in_tensors_info && out_tensors_info) {
         GstTensorsInfo in_info, out_info;
         gchar *str_dim, *str_type, *str_name;
         gchar *in_option, *out_option;
 
-        ml_util_copy_tensors_info_from_ml (&in_info, input_info);
-        ml_util_copy_tensors_info_from_ml (&out_info, output_info);
+        ml_util_copy_tensors_info_from_ml (&in_info, in_tensors_info);
+        ml_util_copy_tensors_info_from_ml (&out_info, out_tensors_info);
 
         /* Set input option */
         str_dim = gst_tensors_info_get_dimensions_string (&in_info);
@@ -223,7 +192,7 @@ ml_single_open (ml_single_h * single, const char *model_path,
         pipeline_desc =
             g_strdup_printf
             ("appsrc name=srcx ! tensor_filter name=filterx framework=tensorflow model=%s %s %s ! appsink name=sinkx sync=false",
-            model_path, in_option, out_option);
+            model, in_option, out_option);
 
         g_free (in_option);
         g_free (out_option);
@@ -264,11 +233,15 @@ ml_single_open (ml_single_h * single, const char *model_path,
   ml_util_initialize_tensors_info (&single_h->out_info);
 
   /* 5. Set in/out caps and metadata */
-  if (input_info) {
-    caps = ml_single_get_caps_from_tensors_info (input_info);
-    ml_util_copy_tensors_info (&single_h->in_info, input_info);
+  if (in_tensors_info) {
+    caps = ml_util_get_caps_from_tensors_info (in_tensors_info);
+    ml_util_copy_tensors_info (&single_h->in_info, in_tensors_info);
   } else {
-    ml_single_get_input_info (single_h, &single_h->in_info);
+    ml_tensors_info_h in_info;
+
+    ml_single_get_input_info (single_h, &in_info);
+    ml_util_copy_tensors_info (&single_h->in_info, in_info);
+    ml_util_destroy_tensors_info (in_info);
 
     status = ml_util_validate_tensors_info (&single_h->in_info);
     if (status != ML_ERROR_NONE) {
@@ -276,17 +249,21 @@ ml_single_open (ml_single_h * single, const char *model_path,
       goto error;
     }
 
-    caps = ml_single_get_caps_from_tensors_info (&single_h->in_info);
+    caps = ml_util_get_caps_from_tensors_info (&single_h->in_info);
   }
 
   gst_app_src_set_caps (GST_APP_SRC (appsrc), caps);
   gst_caps_unref (caps);
 
-  if (output_info) {
-    caps = ml_single_get_caps_from_tensors_info (output_info);
-    ml_util_copy_tensors_info (&single_h->out_info, output_info);
+  if (out_tensors_info) {
+    caps = ml_util_get_caps_from_tensors_info (out_tensors_info);
+    ml_util_copy_tensors_info (&single_h->out_info, out_tensors_info);
   } else {
-    ml_single_get_output_info (single_h, &single_h->out_info);
+    ml_tensors_info_h out_info;
+
+    ml_single_get_output_info (single_h, &out_info);
+    ml_util_copy_tensors_info (&single_h->out_info, out_info);
+    ml_util_destroy_tensors_info (out_info);
 
     status = ml_util_validate_tensors_info (&single_h->out_info);
     if (status != ML_ERROR_NONE) {
@@ -294,7 +271,7 @@ ml_single_open (ml_single_h * single, const char *model_path,
       goto error;
     }
 
-    caps = ml_single_get_caps_from_tensors_info (&single_h->out_info);
+    caps = ml_util_get_caps_from_tensors_info (&single_h->out_info);
   }
 
   gst_app_sink_set_caps (GST_APP_SINK (appsink), caps);
@@ -322,7 +299,7 @@ int
 ml_single_close (ml_single_h single)
 {
   ml_single *single_h;
-  int ret;
+  int status;
 
   if (!single) {
     ml_loge ("The given param, single is invalid.");
@@ -349,9 +326,9 @@ ml_single_close (ml_single_h single)
   ml_util_free_tensors_info (&single_h->in_info);
   ml_util_free_tensors_info (&single_h->out_info);
 
-  ret = ml_pipeline_destroy (single_h->pipe);
+  status = ml_pipeline_destroy (single_h->pipe);
   g_free (single_h);
-  return ret;
+  return status;
 }
 
 /**
@@ -463,46 +440,50 @@ error:
  * @brief Gets the type (tensor dimension, type, name and so on) of required input data for the given handle.
  */
 int
-ml_single_get_input_info (ml_single_h single,
-    ml_tensors_info_s * input_info)
+ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
 {
   ml_single *single_h;
-  GstTensorsInfo info;
+  ml_tensors_info_s *input_info;
+  GstTensorsInfo gst_info;
   gchar *val;
   guint rank;
 
-  if (!single || !input_info)
+  if (!single || !info)
     return ML_ERROR_INVALID_PARAMETER;
 
   single_h = (ml_single *) single;
 
-  gst_tensors_info_init (&info);
+  /* allocate handle for tensors info */
+  ml_util_allocate_tensors_info (info);
+  input_info = (ml_tensors_info_s *) (*info);
+
+  gst_tensors_info_init (&gst_info);
 
   g_object_get (single_h->filter, "input", &val, NULL);
-  rank = gst_tensors_info_parse_dimensions_string (&info, val);
+  rank = gst_tensors_info_parse_dimensions_string (&gst_info, val);
   g_free (val);
 
   /* set the number of tensors */
-  info.num_tensors = rank;
+  gst_info.num_tensors = rank;
 
   g_object_get (single_h->filter, "inputtype", &val, NULL);
-  rank = gst_tensors_info_parse_types_string (&info, val);
+  rank = gst_tensors_info_parse_types_string (&gst_info, val);
   g_free (val);
 
-  if (info.num_tensors != rank) {
+  if (gst_info.num_tensors != rank) {
     ml_logw ("Invalid state, input tensor type is mismatched in filter.");
   }
 
   g_object_get (single_h->filter, "inputname", &val, NULL);
-  rank = gst_tensors_info_parse_names_string (&info, val);
+  rank = gst_tensors_info_parse_names_string (&gst_info, val);
   g_free (val);
 
-  if (info.num_tensors != rank) {
+  if (gst_info.num_tensors != rank) {
     ml_logw ("Invalid state, input tensor name is mismatched in filter.");
   }
 
-  ml_util_copy_tensors_info_from_gst (input_info, &info);
-  gst_tensors_info_free (&info);
+  ml_util_copy_tensors_info_from_gst (input_info, &gst_info);
+  gst_tensors_info_free (&gst_info);
   return ML_ERROR_NONE;
 }
 
@@ -510,45 +491,49 @@ ml_single_get_input_info (ml_single_h single,
  * @brief Gets the type (tensor dimension, type, name and so on) of output data for the given handle.
  */
 int
-ml_single_get_output_info (ml_single_h single,
-    ml_tensors_info_s * output_info)
+ml_single_get_output_info (ml_single_h single, ml_tensors_info_h * info)
 {
   ml_single *single_h;
-  GstTensorsInfo info;
+  ml_tensors_info_s *output_info;
+  GstTensorsInfo gst_info;
   gchar *val;
   guint rank;
 
-  if (!single || !output_info)
+  if (!single || !info)
     return ML_ERROR_INVALID_PARAMETER;
 
   single_h = (ml_single *) single;
 
-  gst_tensors_info_init (&info);
+  /* allocate handle for tensors info */
+  ml_util_allocate_tensors_info (info);
+  output_info = (ml_tensors_info_s *) (*info);
+
+  gst_tensors_info_init (&gst_info);
 
   g_object_get (single_h->filter, "output", &val, NULL);
-  rank = gst_tensors_info_parse_dimensions_string (&info, val);
+  rank = gst_tensors_info_parse_dimensions_string (&gst_info, val);
   g_free (val);
 
   /* set the number of tensors */
-  info.num_tensors = rank;
+  gst_info.num_tensors = rank;
 
   g_object_get (single_h->filter, "outputtype", &val, NULL);
-  rank = gst_tensors_info_parse_types_string (&info, val);
+  rank = gst_tensors_info_parse_types_string (&gst_info, val);
   g_free (val);
 
-  if (info.num_tensors != rank) {
+  if (gst_info.num_tensors != rank) {
     ml_logw ("Invalid state, output tensor type is mismatched in filter.");
   }
 
   g_object_get (single_h->filter, "outputname", &val, NULL);
-  gst_tensors_info_parse_names_string (&info, val);
+  gst_tensors_info_parse_names_string (&gst_info, val);
   g_free (val);
 
-  if (info.num_tensors != rank) {
+  if (gst_info.num_tensors != rank) {
     ml_logw ("Invalid state, output tensor name is mismatched in filter.");
   }
 
-  ml_util_copy_tensors_info_from_gst (output_info, &info);
-  gst_tensors_info_free (&info);
+  ml_util_copy_tensors_info_from_gst (output_info, &gst_info);
+  gst_tensors_info_free (&gst_info);
   return ML_ERROR_NONE;
 }

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -342,7 +342,7 @@ ml_single_close (ml_single_h single)
  * @brief Invokes the model with the given input data.
  */
 int
-ml_single_inference (ml_single_h single,
+ml_single_invoke (ml_single_h single,
     const ml_tensors_data_h input, ml_tensors_data_h * output)
 {
   ml_single *single_h;

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -216,7 +216,7 @@ ml_single_open (ml_single_h * single, const char *model,
       return ML_ERROR_NOT_SUPPORTED;
   }
 
-  status = ml_pipeline_construct (pipeline_desc, &pipe);
+  status = ml_pipeline_construct (pipeline_desc, NULL, NULL, &pipe);
   g_free (pipeline_desc);
   if (status != ML_ERROR_NONE) {
     /* Failed to construct pipeline. */

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -62,6 +62,7 @@ ml_single_open (ml_single_h * single, const char *model,
   gchar *path_down;
   ml_tensors_info_s *in_tensors_info, *out_tensors_info;
   bool available = false;
+  bool valid = false;
 
   /* Validate the params */
   if (!single) {
@@ -75,16 +76,22 @@ ml_single_open (ml_single_h * single, const char *model,
   in_tensors_info = (ml_tensors_info_s *) input_info;
   out_tensors_info = (ml_tensors_info_s *) output_info;
 
-  if (in_tensors_info &&
-      ml_util_validate_tensors_info (in_tensors_info) != ML_ERROR_NONE) {
-    ml_loge ("The given param, input tensor info is invalid.");
-    return ML_ERROR_INVALID_PARAMETER;
+  if (input_info) {
+    /* Validate input tensor info. */
+    if (ml_util_validate_tensors_info (input_info, &valid) != ML_ERROR_NONE ||
+        valid == false) {
+      ml_loge ("The given param, input tensor info is invalid.");
+      return ML_ERROR_INVALID_PARAMETER;
+    }
   }
 
-  if (out_tensors_info &&
-      ml_util_validate_tensors_info (out_tensors_info) != ML_ERROR_NONE) {
-    ml_loge ("The given param, output tensor info is invalid.");
-    return ML_ERROR_INVALID_PARAMETER;
+  if (output_info) {
+    /* Validate output tensor info. */
+    if (ml_util_validate_tensors_info (output_info, &valid) != ML_ERROR_NONE ||
+        valid == false) {
+      ml_loge ("The given param, output tensor info is invalid.");
+      return ML_ERROR_INVALID_PARAMETER;
+    }
   }
 
   /* 1. Determine nnfw */
@@ -243,8 +250,8 @@ ml_single_open (ml_single_h * single, const char *model,
     ml_util_copy_tensors_info (&single_h->in_info, in_info);
     ml_util_destroy_tensors_info (in_info);
 
-    status = ml_util_validate_tensors_info (&single_h->in_info);
-    if (status != ML_ERROR_NONE) {
+    status = ml_util_validate_tensors_info (&single_h->in_info, &valid);
+    if (status != ML_ERROR_NONE || valid == false) {
       ml_loge ("Failed to get the input tensor info.");
       goto error;
     }
@@ -265,8 +272,8 @@ ml_single_open (ml_single_h * single, const char *model,
     ml_util_copy_tensors_info (&single_h->out_info, out_info);
     ml_util_destroy_tensors_info (out_info);
 
-    status = ml_util_validate_tensors_info (&single_h->out_info);
-    if (status != ML_ERROR_NONE) {
+    status = ml_util_validate_tensors_info (&single_h->out_info, &valid);
+    if (status != ML_ERROR_NONE || valid == false) {
       ml_loge ("Failed to get the output tensor info.");
       goto error;
     }

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -31,7 +31,7 @@
  * @brief Allocates a tensors information handle with default value.
  */
 int
-ml_util_allocate_tensors_info (ml_tensors_info_h * info)
+ml_tensors_info_create (ml_tensors_info_h * info)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -39,7 +39,7 @@ ml_util_allocate_tensors_info (ml_tensors_info_h * info)
     return ML_ERROR_INVALID_PARAMETER;
 
   *info = tensors_info = g_new0 (ml_tensors_info_s, 1);
-  ml_util_initialize_tensors_info (tensors_info);
+  ml_tensors_info_initialize (tensors_info);
 
   return ML_ERROR_NONE;
 }
@@ -48,7 +48,7 @@ ml_util_allocate_tensors_info (ml_tensors_info_h * info)
  * @brief Frees the given handle of a tensors information.
  */
 int
-ml_util_destroy_tensors_info (ml_tensors_info_h info)
+ml_tensors_info_destroy (ml_tensors_info_h info)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -57,7 +57,7 @@ ml_util_destroy_tensors_info (ml_tensors_info_h info)
   if (!tensors_info)
     return ML_ERROR_INVALID_PARAMETER;
 
-  ml_util_free_tensors_info (tensors_info);
+  ml_tensors_info_free (tensors_info);
   g_free (tensors_info);
 
   return ML_ERROR_NONE;
@@ -67,7 +67,7 @@ ml_util_destroy_tensors_info (ml_tensors_info_h info)
  * @brief Initializes the tensors information with default value.
  */
 int
-ml_util_initialize_tensors_info (ml_tensors_info_s * info)
+ml_tensors_info_initialize (ml_tensors_info_s * info)
 {
   guint i, j;
 
@@ -92,7 +92,7 @@ ml_util_initialize_tensors_info (ml_tensors_info_s * info)
  * @brief Validates the given tensor info is valid.
  */
 static int
-ml_util_validate_tensor_info (const ml_tensor_info_s * info)
+ml_tensor_info_validate (const ml_tensor_info_s * info)
 {
   guint i;
 
@@ -114,7 +114,7 @@ ml_util_validate_tensor_info (const ml_tensor_info_s * info)
  * @brief Validates the given tensors info is valid.
  */
 int
-ml_util_validate_tensors_info (const ml_tensors_info_h info, bool * valid)
+ml_tensors_info_validate (const ml_tensors_info_h info, bool * valid)
 {
   ml_tensors_info_s *tensors_info;
   guint i;
@@ -132,7 +132,7 @@ ml_util_validate_tensors_info (const ml_tensors_info_h info, bool * valid)
 
   for (i = 0; i < tensors_info->num_tensors; i++) {
     /* Failed if returned value is not 0 (ML_ERROR_NONE) */
-    if (ml_util_validate_tensor_info (&tensors_info->info[i]) != ML_ERROR_NONE)
+    if (ml_tensor_info_validate (&tensors_info->info[i]) != ML_ERROR_NONE)
       goto done;
   }
 
@@ -146,7 +146,7 @@ done:
  * @brief Sets the number of tensors with given handle of tensors information.
  */
 int
-ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count)
+ml_tensors_info_set_count (ml_tensors_info_h info, unsigned int count)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -163,7 +163,7 @@ ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count)
  * @brief Gets the number of tensors with given handle of tensors information.
  */
 int
-ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count)
+ml_tensors_info_get_count (ml_tensors_info_h info, unsigned int *count)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -180,7 +180,7 @@ ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count)
  * @brief Sets the tensor name with given handle of tensors information.
  */
 int
-ml_util_set_tensor_name (ml_tensors_info_h info,
+ml_tensors_info_set_tensor_name (ml_tensors_info_h info,
     unsigned int index, const char *name)
 {
   ml_tensors_info_s *tensors_info;
@@ -208,7 +208,7 @@ ml_util_set_tensor_name (ml_tensors_info_h info,
  * @brief Gets the tensor name with given handle of tensors information.
  */
 int
-ml_util_get_tensor_name (ml_tensors_info_h info,
+ml_tensors_info_get_tensor_name (ml_tensors_info_h info,
     unsigned int index, char **name)
 {
   ml_tensors_info_s *tensors_info;
@@ -230,7 +230,7 @@ ml_util_get_tensor_name (ml_tensors_info_h info,
  * @brief Sets the tensor type with given handle of tensors information.
  */
 int
-ml_util_set_tensor_type (ml_tensors_info_h info,
+ml_tensors_info_set_tensor_type (ml_tensors_info_h info,
     unsigned int index, const ml_tensor_type_e type)
 {
   ml_tensors_info_s *tensors_info;
@@ -252,7 +252,7 @@ ml_util_set_tensor_type (ml_tensors_info_h info,
  * @brief Gets the tensor type with given handle of tensors information.
  */
 int
-ml_util_get_tensor_type (ml_tensors_info_h info,
+ml_tensors_info_get_tensor_type (ml_tensors_info_h info,
     unsigned int index, ml_tensor_type_e * type)
 {
   ml_tensors_info_s *tensors_info;
@@ -274,7 +274,7 @@ ml_util_get_tensor_type (ml_tensors_info_h info,
  * @brief Sets the tensor dimension with given handle of tensors information.
  */
 int
-ml_util_set_tensor_dimension (ml_tensors_info_h info,
+ml_tensors_info_set_tensor_dimension (ml_tensors_info_h info,
     unsigned int index, const ml_tensor_dimension dimension)
 {
   ml_tensors_info_s *tensors_info;
@@ -299,7 +299,7 @@ ml_util_set_tensor_dimension (ml_tensors_info_h info,
  * @brief Gets the tensor dimension with given handle of tensors information.
  */
 int
-ml_util_get_tensor_dimension (ml_tensors_info_h info,
+ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info,
     unsigned int index, ml_tensor_dimension dimension)
 {
   ml_tensors_info_s *tensors_info;
@@ -324,7 +324,7 @@ ml_util_get_tensor_dimension (ml_tensors_info_h info,
  * @brief Gets the byte size of the given tensor info.
  */
 size_t
-ml_util_get_tensor_size (const ml_tensor_info_s * info)
+ml_tensor_info_get_size (const ml_tensor_info_s * info)
 {
   size_t tensor_size;
   gint i;
@@ -367,7 +367,7 @@ ml_util_get_tensor_size (const ml_tensor_info_s * info)
  * @brief Gets the byte size of the given tensors info.
  */
 size_t
-ml_util_get_tensors_size (const ml_tensors_info_h info)
+ml_tensors_info_get_size (const ml_tensors_info_h info)
 {
   ml_tensors_info_s *tensors_info;
   size_t tensor_size;
@@ -380,7 +380,7 @@ ml_util_get_tensors_size (const ml_tensors_info_h info)
 
   tensor_size = 0;
   for (i = 0; i < tensors_info->num_tensors; i++) {
-    tensor_size += ml_util_get_tensor_size (&tensors_info->info[i]);
+    tensor_size += ml_tensor_info_get_size (&tensors_info->info[i]);
   }
 
   return tensor_size;
@@ -390,7 +390,7 @@ ml_util_get_tensors_size (const ml_tensors_info_h info)
  * @brief Frees the tensors info pointer.
  */
 void
-ml_util_free_tensors_info (ml_tensors_info_s * info)
+ml_tensors_info_free (ml_tensors_info_s * info)
 {
   gint i;
 
@@ -404,14 +404,14 @@ ml_util_free_tensors_info (ml_tensors_info_s * info)
     }
   }
 
-  ml_util_initialize_tensors_info (info);
+  ml_tensors_info_initialize (info);
 }
 
 /**
  * @brief Frees the tensors data pointer.
  */
 int
-ml_util_destroy_tensors_data (ml_tensors_data_h data)
+ml_tensors_data_destroy (ml_tensors_data_h data)
 {
   ml_tensors_data_s *_data;
   guint i;
@@ -436,7 +436,7 @@ ml_util_destroy_tensors_data (ml_tensors_data_h data)
  * @brief Allocates a tensor data frame with the given tensors info. (more info in nnstreamer.h)
  */
 int
-ml_util_allocate_tensors_data (const ml_tensors_info_h info,
+ml_tensors_data_create (const ml_tensors_info_h info,
     ml_tensors_data_h * data)
 {
   ml_tensors_data_s *_data;
@@ -457,7 +457,7 @@ ml_util_allocate_tensors_data (const ml_tensors_info_h info,
 
   _data->num_tensors = tensors_info->num_tensors;
   for (i = 0; i < _data->num_tensors; i++) {
-    _data->tensors[i].size = ml_util_get_tensor_size (&tensors_info->info[i]);
+    _data->tensors[i].size = ml_tensor_info_get_size (&tensors_info->info[i]);
     _data->tensors[i].tensor = g_malloc0 (_data->tensors[i].size);
     if (_data->tensors[i].tensor == NULL)
       goto failed;
@@ -481,7 +481,7 @@ failed:
  * @brief Gets a tensor data of given handle.
  */
 int
-ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index,
+ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index,
     void **raw_data, size_t * data_size)
 {
   ml_tensors_data_s *_data;
@@ -504,7 +504,7 @@ ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index,
  * @brief Copies a tensor data to given handle.
  */
 int
-ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index,
+ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index,
     const void *raw_data, const size_t data_size)
 {
   ml_tensors_data_s *_data;
@@ -528,7 +528,7 @@ ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index,
  * @brief Copies tensor meta info.
  */
 int
-ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src)
+ml_tensors_info_clone (ml_tensors_info_h dest, const ml_tensors_info_h src)
 {
   ml_tensors_info_s *dest_info, *src_info;
   guint i, j;
@@ -539,7 +539,7 @@ ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src)
   if (!dest_info || !src_info)
     return ML_ERROR_INVALID_PARAMETER;
 
-  ml_util_initialize_tensors_info (dest_info);
+  ml_tensors_info_initialize (dest_info);
 
   dest_info->num_tensors = src_info->num_tensors;
 
@@ -559,7 +559,7 @@ ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src)
  * @brief Copies tensor meta info from gst tensors info.
  */
 void
-ml_util_copy_tensors_info_from_gst (ml_tensors_info_s * ml_info,
+ml_tensors_info_copy_from_gst (ml_tensors_info_s * ml_info,
     const GstTensorsInfo * gst_info)
 {
   guint i, j;
@@ -568,7 +568,7 @@ ml_util_copy_tensors_info_from_gst (ml_tensors_info_s * ml_info,
   if (!ml_info || !gst_info)
     return;
 
-  ml_util_initialize_tensors_info (ml_info);
+  ml_tensors_info_initialize (ml_info);
   max_dim = MIN (ML_TENSOR_RANK_LIMIT, NNS_TENSOR_RANK_LIMIT);
 
   ml_info->num_tensors = gst_info->num_tensors;
@@ -631,7 +631,7 @@ ml_util_copy_tensors_info_from_gst (ml_tensors_info_s * ml_info,
  * @brief Copies tensor meta info from gst tensors info.
  */
 void
-ml_util_copy_tensors_info_from_ml (GstTensorsInfo * gst_info,
+ml_tensors_info_copy_from_ml (GstTensorsInfo * gst_info,
     const ml_tensors_info_s * ml_info)
 {
   guint i, j;
@@ -703,7 +703,7 @@ ml_util_copy_tensors_info_from_ml (GstTensorsInfo * gst_info,
  * @brief Gets caps from tensors info.
  */
 GstCaps *
-ml_util_get_caps_from_tensors_info (const ml_tensors_info_s * info)
+ml_tensors_info_get_caps (const ml_tensors_info_s * info)
 {
   GstCaps *caps;
   GstTensorsConfig config;
@@ -711,7 +711,7 @@ ml_util_get_caps_from_tensors_info (const ml_tensors_info_s * info)
   if (!info)
     return NULL;
 
-  ml_util_copy_tensors_info_from_ml (&config.info, info);
+  ml_tensors_info_copy_from_ml (&config.info, info);
 
   /* set framerate 0/1 */
   config.rate_n = 0;
@@ -739,7 +739,7 @@ ml_util_get_caps_from_tensors_info (const ml_tensors_info_s * info)
  * @brief Checks the availability of the given execution environments.
  */
 int
-ml_util_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
+ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
     bool * available)
 {
   if (!available)

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -114,22 +114,31 @@ ml_util_validate_tensor_info (const ml_tensor_info_s * info)
  * @brief Validates the given tensors info is valid.
  */
 int
-ml_util_validate_tensors_info (const ml_tensors_info_h info)
+ml_util_validate_tensors_info (const ml_tensors_info_h info, bool * valid)
 {
   ml_tensors_info_s *tensors_info;
   guint i;
+
+  if (!valid)
+    return ML_ERROR_INVALID_PARAMETER;
 
   tensors_info = (ml_tensors_info_s *) info;
 
   if (!tensors_info || tensors_info->num_tensors < 1)
     return ML_ERROR_INVALID_PARAMETER;
 
+  /* init false */
+  *valid = false;
+
   for (i = 0; i < tensors_info->num_tensors; i++) {
     /* Failed if returned value is not 0 (ML_ERROR_NONE) */
     if (ml_util_validate_tensor_info (&tensors_info->info[i]) != ML_ERROR_NONE)
-      return ML_ERROR_INVALID_PARAMETER;
+      goto done;
   }
 
+  *valid = true;
+
+done:
   return ML_ERROR_NONE;
 }
 
@@ -137,7 +146,7 @@ ml_util_validate_tensors_info (const ml_tensors_info_h info)
  * @brief Sets the number of tensors with given handle of tensors information.
  */
 int
-ml_util_set_tensors_count (ml_tensors_info_h info, const unsigned int count)
+ml_util_set_tensors_count (ml_tensors_info_h info, unsigned int count)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -172,7 +181,7 @@ ml_util_get_tensors_count (ml_tensors_info_h info, unsigned int *count)
  */
 int
 ml_util_set_tensor_name (ml_tensors_info_h info,
-    const unsigned int index, const char *name)
+    unsigned int index, const char *name)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -200,7 +209,7 @@ ml_util_set_tensor_name (ml_tensors_info_h info,
  */
 int
 ml_util_get_tensor_name (ml_tensors_info_h info,
-    const unsigned int index, char **name)
+    unsigned int index, char **name)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -222,7 +231,7 @@ ml_util_get_tensor_name (ml_tensors_info_h info,
  */
 int
 ml_util_set_tensor_type (ml_tensors_info_h info,
-    const unsigned int index, const ml_tensor_type_e type)
+    unsigned int index, const ml_tensor_type_e type)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -244,7 +253,7 @@ ml_util_set_tensor_type (ml_tensors_info_h info,
  */
 int
 ml_util_get_tensor_type (ml_tensors_info_h info,
-    const unsigned int index, ml_tensor_type_e * type)
+    unsigned int index, ml_tensor_type_e * type)
 {
   ml_tensors_info_s *tensors_info;
 
@@ -266,7 +275,7 @@ ml_util_get_tensor_type (ml_tensors_info_h info,
  */
 int
 ml_util_set_tensor_dimension (ml_tensors_info_h info,
-    const unsigned int index, const ml_tensor_dimension dimension)
+    unsigned int index, const ml_tensor_dimension dimension)
 {
   ml_tensors_info_s *tensors_info;
   guint i;
@@ -291,7 +300,7 @@ ml_util_set_tensor_dimension (ml_tensors_info_h info,
  */
 int
 ml_util_get_tensor_dimension (ml_tensors_info_h info,
-    const unsigned int index, ml_tensor_dimension dimension)
+    unsigned int index, ml_tensor_dimension dimension)
 {
   ml_tensors_info_s *tensors_info;
   guint i;
@@ -472,7 +481,7 @@ failed:
  * @brief Gets a tensor data of given handle.
  */
 int
-ml_util_get_tensor_data (ml_tensors_data_h data, const unsigned int index,
+ml_util_get_tensor_data (ml_tensors_data_h data, unsigned int index,
     void **raw_data, size_t * data_size)
 {
   ml_tensors_data_s *_data;
@@ -495,7 +504,7 @@ ml_util_get_tensor_data (ml_tensors_data_h data, const unsigned int index,
  * @brief Copies a tensor data to given handle.
  */
 int
-ml_util_copy_tensor_data (ml_tensors_data_h data, const unsigned int index,
+ml_util_copy_tensor_data (ml_tensors_data_h data, unsigned int index,
     const void *raw_data, const size_t data_size)
 {
   ml_tensors_data_s *_data;
@@ -547,7 +556,7 @@ ml_util_copy_tensors_info (ml_tensors_info_h dest, const ml_tensors_info_h src)
 }
 
 /**
- * @brief Copies tensor meta info from gst tensots info.
+ * @brief Copies tensor meta info from gst tensors info.
  */
 void
 ml_util_copy_tensors_info_from_gst (ml_tensors_info_s * ml_info,
@@ -619,7 +628,7 @@ ml_util_copy_tensors_info_from_gst (ml_tensors_info_s * ml_info,
 }
 
 /**
- * @brief Copies tensor meta info from gst tensots info.
+ * @brief Copies tensor meta info from gst tensors info.
  */
 void
 ml_util_copy_tensors_info_from_ml (GstTensorsInfo * gst_info,

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -375,8 +375,7 @@ TEST (nnstreamer_capi_sink, dummy_01)
   int status = ml_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_dm01,
-      &sinkhandle, file2);
+  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_dm01, file2, &sinkhandle);
 
   status = ml_pipeline_start (handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -432,7 +431,7 @@ TEST (nnstreamer_capi_sink, dummy_02)
   status = ml_pipeline_construct (pipeline, &handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -484,30 +483,30 @@ TEST (nnstreamer_capi_sink, failure_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   /* invalid param : pipe */
-  status = ml_pipeline_sink_register (NULL, "sinkx", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (NULL, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid param : name */
-  status = ml_pipeline_sink_register (handle, NULL, test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, NULL, test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid param : wrong name */
-  status = ml_pipeline_sink_register (handle, "wrongname", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "wrongname", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid param : invalid type */
-  status = ml_pipeline_sink_register (handle, "valvex", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "valvex", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid param : callback */
-  status = ml_pipeline_sink_register (handle, "sinkx", NULL, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "sinkx", NULL, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
   /* invalid param : handle */
-  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, NULL, count_sink);
+  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, count_sink, NULL);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_start (handle);
@@ -826,7 +825,7 @@ TEST (nnstreamer_capi_switch, dummy_01)
     EXPECT_EQ (idx, 2U);
   }
 
-  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, &sinkhandle, count_sink);
+  status = ml_pipeline_sink_register (handle, "sinkx", test_sink_callback_count, count_sink, &sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_switch_select (switchhandle, "sink_1");
@@ -906,10 +905,10 @@ TEST (nnstreamer_capi_switch, dummy_02)
     EXPECT_EQ (idx, 2U);
   }
 
-  status = ml_pipeline_sink_register (handle, "sink0", test_sink_callback_count, &sinkhandle0, count_sink0);
+  status = ml_pipeline_sink_register (handle, "sink0", test_sink_callback_count, count_sink0, &sinkhandle0);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_sink_register (handle, "sink1", test_sink_callback_count, &sinkhandle1, count_sink1);
+  status = ml_pipeline_sink_register (handle, "sink1", test_sink_callback_count, count_sink1, &sinkhandle1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_switch_select (switchhandle, "src_1");

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -82,7 +82,7 @@ TEST (nnstreamer_capi_construct_destruct, failed_02)
  */
 TEST (nnstreamer_capi_playstop, dummy_01)
 {
-  const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
+  const char *pipeline = "videotestsrc is-live=true ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
   ml_pipeline_h handle;
   ml_pipeline_state_e state;
   int status = ml_pipeline_construct (pipeline, &handle);
@@ -118,7 +118,7 @@ TEST (nnstreamer_capi_playstop, dummy_01)
  */
 TEST (nnstreamer_capi_playstop, dummy_02)
 {
-  const char *pipeline = "videotestsrc is-live=true num-buffers=30 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
+  const char *pipeline = "videotestsrc is-live=true ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=224,height=224,framerate=60/1 ! tensor_converter ! valve name=valvex ! valve name=valvey ! input-selector name=is01 ! tensor_sink name=sinkx";
   ml_pipeline_h handle;
   ml_pipeline_state_e state;
   int status = ml_pipeline_construct (pipeline, &handle);
@@ -174,7 +174,7 @@ TEST (nnstreamer_capi_valve, test01)
   gchar *file1 = g_build_path ("/", dir, "valve1", NULL);
   gchar *pipeline =
       g_strdup_printf
-      ("videotestsrc is-live=true num-buffers=20 ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=60/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
+      ("videotestsrc is-live=true ! videoconvert ! videoscale ! video/x-raw,format=RGBx,width=16,height=16,framerate=60/1 ! tensor_converter ! queue ! valve name=valve1 ! filesink location=\"%s\"",
       file1);
   GStatBuf buf;
 
@@ -190,10 +190,10 @@ TEST (nnstreamer_capi_valve, test01)
   status = ml_pipeline_valve_get_handle (handle, "valve1", &valve1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_start (handle);
+  status = ml_pipeline_valve_set_open (valve1, false); /* close */
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_valve_set_open (valve1, false); /* close */
+  status = ml_pipeline_start (handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_get_state (handle, &state);
@@ -214,6 +214,7 @@ TEST (nnstreamer_capi_valve, test01)
 
   status = ml_pipeline_valve_set_open (valve1, true); /* open */
   EXPECT_EQ (status, ML_ERROR_NONE);
+
   status = ml_pipeline_valve_put_handle (valve1); /* release valve handle */
   EXPECT_EQ (status, ML_ERROR_NONE);
 

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -423,7 +423,7 @@ TEST (nnstreamer_capi_sink, dummy_02)
   guint *count_sink;
 
   /* pipeline with appsink */
-  pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! valve name=valvex ! tensor_converter ! appsink name=sinkx");
+  pipeline = g_strdup ("videotestsrc num-buffers=3 ! videoconvert ! tensor_converter ! appsink name=sinkx");
 
   count_sink = (guint *) g_malloc (sizeof (guint));
   *count_sink = 0;

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -215,7 +215,7 @@ TEST (nnstreamer_capi_valve, test01)
   status = ml_pipeline_valve_set_open (valve1, true); /* open */
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_valve_put_handle (valve1); /* release valve handle */
+  status = ml_pipeline_valve_release_handle (valve1); /* release valve handle */
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_usleep (50000); /* 50ms. Let a few frames flow. */
@@ -620,7 +620,7 @@ TEST (nnstreamer_capi_src, dummy_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   g_usleep (50000); /* 50ms. Wait a bit. */
 
-  status = ml_pipeline_src_put_handle (srchandle);
+  status = ml_pipeline_src_release_handle (srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_src_get_handle (handle, "srcx", &srchandle);
@@ -660,7 +660,7 @@ TEST (nnstreamer_capi_src, dummy_01)
     g_usleep (50000); /* 50ms. Wait a bit. */
   }
 
-  status = ml_pipeline_src_put_handle (srchandle);
+  status = ml_pipeline_src_release_handle (srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_usleep (50000); /* Wait for the pipeline to flush all */
@@ -769,7 +769,7 @@ TEST (nnstreamer_capi_src, failure_03)
   status = ml_pipeline_src_input_data (srchandle, NULL, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_pipeline_src_put_handle (srchandle);
+  status = ml_pipeline_src_release_handle (srchandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_stop (handle);
@@ -842,7 +842,7 @@ TEST (nnstreamer_capi_switch, dummy_01)
   status = ml_pipeline_sink_unregister (sinkhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_switch_put_handle (switchhandle);
+  status = ml_pipeline_switch_release_handle (switchhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_destroy (handle);
@@ -928,7 +928,7 @@ TEST (nnstreamer_capi_switch, dummy_02)
   status = ml_pipeline_sink_unregister (sinkhandle1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_pipeline_switch_put_handle (switchhandle);
+  status = ml_pipeline_switch_release_handle (switchhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_destroy (handle);
@@ -997,7 +997,7 @@ TEST (nnstreamer_capi_switch, failure_01)
   status = ml_pipeline_switch_select (switchhandle, "wrongpadname");
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_pipeline_switch_put_handle (switchhandle);
+  status = ml_pipeline_switch_release_handle (switchhandle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_destroy (handle);
@@ -1109,7 +1109,7 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_single_inference (single, input, &output);
+  status = ml_single_invoke (single, input, &output);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
@@ -1179,7 +1179,7 @@ TEST (nnstreamer_capi_singleshot, invoke_02)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_single_inference (single, input, &output);
+  status = ml_single_invoke (single, input, &output);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
@@ -1263,7 +1263,7 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
     ((float *) data_ptr)[i] = f32;
   }
 
-  status = ml_single_inference (single, input, &output);
+  status = ml_single_invoke (single, input, &output);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
@@ -1412,7 +1412,7 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   status = ml_tensors_data_set_tensor_data (input, 0, contents, len);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_single_inference (single, input, &output);
+  status = ml_single_invoke (single, input, &output);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -295,10 +295,10 @@ test_sink_callback_dm01 (const ml_tensors_data_h data,
   if (fp == NULL)
     return;
 
-  ml_util_get_tensors_count (info, &num);
+  ml_tensors_info_get_count (info, &num);
 
   for (i = 0; i < num; i++) {
-    status = ml_util_get_tensor_data (data, i, &data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (data, i, &data_ptr, &data_size);
     if (status == ML_ERROR_NONE)
       fwrite (data_ptr, data_size, 1, fp);
   }
@@ -592,24 +592,24 @@ TEST (nnstreamer_capi_src, dummy_01)
   status = ml_pipeline_src_get_tensors_info (srchandle, &info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  ml_util_get_tensors_count (info, &count);
+  ml_tensors_info_get_count (info, &count);
   EXPECT_EQ (count, 1U);
 
-  ml_util_get_tensor_type (info, 0, &type);
+  ml_tensors_info_get_tensor_type (info, 0, &type);
   EXPECT_EQ (type, ML_TENSOR_TYPE_UINT8);
 
-  ml_util_get_tensor_dimension (info, 0, dim);
+  ml_tensors_info_get_tensor_dimension (info, 0, dim);
   EXPECT_EQ (dim[0], 4U);
   EXPECT_EQ (dim[1], 1U);
   EXPECT_EQ (dim[2], 1U);
   EXPECT_EQ (dim[3], 1U);
 
-  status = ml_util_allocate_tensors_data (info, &data1);
+  status = ml_tensors_data_create (info, &data1);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  ml_util_destroy_tensors_info (info);
+  ml_tensors_info_destroy (info);
 
-  status = ml_util_copy_tensor_data (data1, 0, uintarray1[0], 4);
+  status = ml_tensors_data_set_tensor_data (data1, 0, uintarray1[0], 4);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_pipeline_src_input_data (srchandle, data1, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
@@ -629,29 +629,29 @@ TEST (nnstreamer_capi_src, dummy_01)
   status = ml_pipeline_src_get_tensors_info (srchandle, &info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  ml_util_get_tensors_count (info, &count);
+  ml_tensors_info_get_count (info, &count);
   EXPECT_EQ (count, 1U);
 
-  ml_util_get_tensor_type (info, 0, &type);
+  ml_tensors_info_get_tensor_type (info, 0, &type);
   EXPECT_EQ (type, ML_TENSOR_TYPE_UINT8);
 
-  ml_util_get_tensor_dimension (info, 0, dim);
+  ml_tensors_info_get_tensor_dimension (info, 0, dim);
   EXPECT_EQ (dim[0], 4U);
   EXPECT_EQ (dim[1], 1U);
   EXPECT_EQ (dim[2], 1U);
   EXPECT_EQ (dim[3], 1U);
 
   for (i = 0; i < 10; i++) {
-    status = ml_util_copy_tensor_data (data1, 0, uintarray1[i], 4);
+    status = ml_tensors_data_set_tensor_data (data1, 0, uintarray1[i], 4);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
     status = ml_pipeline_src_input_data (srchandle, data1, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    status = ml_util_allocate_tensors_data (info, &data2);
+    status = ml_tensors_data_create (info, &data2);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
-    status = ml_util_copy_tensor_data (data2, 0, uintarray2[i], 4);
+    status = ml_tensors_data_set_tensor_data (data2, 0, uintarray2[i], 4);
     EXPECT_EQ (status, ML_ERROR_NONE);
 
     status = ml_pipeline_src_input_data (srchandle, data2, ML_PIPELINE_BUF_POLICY_AUTO_FREE);
@@ -685,8 +685,8 @@ TEST (nnstreamer_capi_src, dummy_01)
   }
 
   g_free (content);
-  ml_util_destroy_tensors_info (info);
-  ml_util_destroy_tensors_data (data1);
+  ml_tensors_info_destroy (info);
+  ml_tensors_data_destroy (data1);
 }
 
 /**
@@ -763,7 +763,7 @@ TEST (nnstreamer_capi_src, failure_03)
   status = ml_pipeline_src_get_tensors_info (srchandle, &info);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_allocate_tensors_data (info, &data);
+  status = ml_tensors_data_create (info, &data);
 
   /* null data */
   status = ml_pipeline_src_input_data (srchandle, NULL, ML_PIPELINE_BUF_POLICY_DO_NOT_FREE);
@@ -778,7 +778,7 @@ TEST (nnstreamer_capi_src, failure_03)
   status = ml_pipeline_destroy (handle);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_destroy_tensors_data (data);
+  status = ml_tensors_data_destroy (data);
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
@@ -1033,26 +1033,26 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  ml_util_allocate_tensors_info (&in_info);
-  ml_util_allocate_tensors_info (&out_info);
-  ml_util_allocate_tensors_info (&in_res);
-  ml_util_allocate_tensors_info (&out_res);
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+  ml_tensors_info_create (&in_res);
+  ml_tensors_info_create (&out_res);
 
   in_dim[0] = 3;
   in_dim[1] = 224;
   in_dim[2] = 224;
   in_dim[3] = 1;
-  ml_util_set_tensors_count (in_info, 1);
-  ml_util_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (in_info, 0, in_dim);
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   out_dim[0] = 1001;
   out_dim[1] = 1;
   out_dim[2] = 1;
   out_dim[3] = 1;
-  ml_util_set_tensors_count (out_info, 1);
-  ml_util_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (out_info, 0, out_dim);
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   status = ml_single_open (&single, test_model, in_info, out_info,
       ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY);
@@ -1062,19 +1062,19 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   status = ml_single_get_input_info (single, &in_res);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_get_tensors_count (in_res, &count);
+  status = ml_tensors_info_get_count (in_res, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 1U);
 
-  status = ml_util_get_tensor_name (in_res, 0, &name);
+  status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (name == NULL);
 
-  status = ml_util_get_tensor_type (in_res, 0, &type);
+  status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_UINT8);
 
-  ml_util_get_tensor_dimension (in_res, 0, res_dim);
+  ml_tensors_info_get_tensor_dimension (in_res, 0, res_dim);
   EXPECT_TRUE (in_dim[0] == res_dim[0]);
   EXPECT_TRUE (in_dim[1] == res_dim[1]);
   EXPECT_TRUE (in_dim[2] == res_dim[2]);
@@ -1084,19 +1084,19 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   status = ml_single_get_output_info (single, &out_res);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_get_tensors_count (out_res, &count);
+  status = ml_tensors_info_get_count (out_res, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 1U);
 
-  status = ml_util_get_tensor_name (out_res, 0, &name);
+  status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (name == NULL);
 
-  status = ml_util_get_tensor_type (out_res, 0, &type);
+  status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_UINT8);
 
-  ml_util_get_tensor_dimension (out_res, 0, res_dim);
+  ml_tensors_info_get_tensor_dimension (out_res, 0, res_dim);
   EXPECT_TRUE (out_dim[0] == res_dim[0]);
   EXPECT_TRUE (out_dim[1] == res_dim[1]);
   EXPECT_TRUE (out_dim[2] == res_dim[2]);
@@ -1105,7 +1105,7 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   input = output = NULL;
 
   /* generate dummy data */
-  status = ml_util_allocate_tensors_data (in_info, &input);
+  status = ml_tensors_data_create (in_info, &input);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
@@ -1113,17 +1113,17 @@ TEST (nnstreamer_capi_singleshot, invoke_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  ml_util_destroy_tensors_data (output);
-  ml_util_destroy_tensors_data (input);
+  ml_tensors_data_destroy (output);
+  ml_tensors_data_destroy (input);
 
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_free (test_model);
-  ml_util_destroy_tensors_info (in_info);
-  ml_util_destroy_tensors_info (out_info);
-  ml_util_destroy_tensors_info (in_res);
-  ml_util_destroy_tensors_info (out_res);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+  ml_tensors_info_destroy (in_res);
+  ml_tensors_info_destroy (out_res);
 }
 
 /**
@@ -1149,24 +1149,24 @@ TEST (nnstreamer_capi_singleshot, invoke_02)
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  ml_util_allocate_tensors_info (&in_info);
-  ml_util_allocate_tensors_info (&out_info);
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
 
   in_dim[0] = 3;
   in_dim[1] = 224;
   in_dim[2] = 224;
   in_dim[3] = 1;
-  ml_util_set_tensors_count (in_info, 1);
-  ml_util_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (in_info, 0, in_dim);
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   out_dim[0] = 1001;
   out_dim[1] = 1;
   out_dim[2] = 1;
   out_dim[3] = 1;
-  ml_util_set_tensors_count (out_info, 1);
-  ml_util_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (out_info, 0, out_dim);
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   status = ml_single_open (&single, test_model, NULL, NULL,
       ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY);
@@ -1175,7 +1175,7 @@ TEST (nnstreamer_capi_singleshot, invoke_02)
   input = output = NULL;
 
   /* generate dummy data */
-  status = ml_util_allocate_tensors_data (in_info, &input);
+  status = ml_tensors_data_create (in_info, &input);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
@@ -1183,15 +1183,15 @@ TEST (nnstreamer_capi_singleshot, invoke_02)
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (output != NULL);
 
-  ml_util_destroy_tensors_data (output);
-  ml_util_destroy_tensors_data (input);
+  ml_tensors_data_destroy (output);
+  ml_tensors_data_destroy (input);
 
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_free (test_model);
-  ml_util_destroy_tensors_info (in_info);
-  ml_util_destroy_tensors_info (out_info);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
 }
 #endif /* ENABLE_TENSORFLOW_LITE */
 
@@ -1221,23 +1221,23 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
       "libnnstreamer_customfilter_passthrough_variable.so", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  ml_util_allocate_tensors_info (&in_info);
-  ml_util_allocate_tensors_info (&out_info);
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
 
-  ml_util_set_tensors_count (in_info, 2);
+  ml_tensors_info_set_count (in_info, 2);
 
   in_dim[0] = 10;
   in_dim[1] = 1;
   in_dim[2] = 1;
   in_dim[3] = 1;
 
-  ml_util_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
-  ml_util_set_tensor_dimension (in_info, 0, in_dim);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
-  ml_util_set_tensor_type (in_info, 1, ML_TENSOR_TYPE_FLOAT32);
-  ml_util_set_tensor_dimension (in_info, 1, in_dim);
+  ml_tensors_info_set_tensor_type (in_info, 1, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (in_info, 1, in_dim);
 
-  ml_util_copy_tensors_info (out_info, in_info);
+  ml_tensors_info_clone (out_info, in_info);
 
   status = ml_single_open (&single, test_model, in_info, out_info,
       ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY);
@@ -1246,7 +1246,7 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
   input = output = NULL;
 
   /* generate input data */
-  status = ml_util_allocate_tensors_data (in_info, &input);
+  status = ml_tensors_data_create (in_info, &input);
   EXPECT_EQ (status, ML_ERROR_NONE);
   ASSERT_TRUE (input != NULL);
 
@@ -1254,11 +1254,11 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
     int16_t i16 = (int16_t) (i + 1);
     float f32 = (float) (i + .1);
 
-    status = ml_util_get_tensor_data (input, 0, &data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 0, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     ((int16_t *) data_ptr)[i] = i16;
 
-    status = ml_util_get_tensor_data (input, 1, &data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (input, 1, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     ((float *) data_ptr)[i] = f32;
   }
@@ -1271,24 +1271,24 @@ TEST (nnstreamer_capi_singleshot, invoke_03)
     int16_t i16 = (int16_t) (i + 1);
     float f32 = (float) (i + .1);
 
-    status = ml_util_get_tensor_data (output, 0, &data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_EQ (((int16_t *) data_ptr)[i], i16);
 
-    status = ml_util_get_tensor_data (output, 1, &data_ptr, &data_size);
+    status = ml_tensors_data_get_tensor_data (output, 1, &data_ptr, &data_size);
     EXPECT_EQ (status, ML_ERROR_NONE);
     EXPECT_FLOAT_EQ (((float *) data_ptr)[i], f32);
   }
 
-  ml_util_destroy_tensors_data (output);
-  ml_util_destroy_tensors_data (input);
+  ml_tensors_data_destroy (output);
+  ml_tensors_data_destroy (input);
 
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_free (test_model);
-  ml_util_destroy_tensors_info (in_info);
-  ml_util_destroy_tensors_info (out_info);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
 }
 
 #ifdef ENABLE_TENSORFLOW
@@ -1328,31 +1328,31 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
       "yes.wav", NULL);
   ASSERT_TRUE (g_file_test (test_file, G_FILE_TEST_EXISTS));
 
-  ml_util_allocate_tensors_info (&in_info);
-  ml_util_allocate_tensors_info (&out_info);
-  ml_util_allocate_tensors_info (&in_res);
-  ml_util_allocate_tensors_info (&out_res);
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
+  ml_tensors_info_create (&in_res);
+  ml_tensors_info_create (&out_res);
 
   in_dim[0] = 1;
   in_dim[1] = 16022;
   in_dim[2] = 1;
   in_dim[3] = 1;
-  ml_util_set_tensors_count (in_info, 1);
-  ml_util_set_tensor_name (in_info, 0, "wav_data");
-  ml_util_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
-  ml_util_set_tensor_dimension (in_info, 0, in_dim);
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_name (in_info, 0, "wav_data");
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_INT16);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   out_dim[0] = 12;
   out_dim[1] = 1;
   out_dim[2] = 1;
   out_dim[3] = 1;
-  ml_util_set_tensors_count (out_info, 1);
-  ml_util_set_tensor_name (out_info, 0, "labels_softmax");
-  ml_util_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
-  ml_util_set_tensor_dimension (out_info, 0, out_dim);
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_name (out_info, 0, "labels_softmax");
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_FLOAT32);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   ASSERT_TRUE (g_file_get_contents (test_file, &contents, &len, NULL));
-  ASSERT_TRUE (len == ml_util_get_tensors_size (in_info));
+  ASSERT_TRUE (len == ml_tensors_info_get_size (in_info));
 
   status = ml_single_open (&single, test_model, in_info, out_info,
       ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_ANY);
@@ -1362,19 +1362,19 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   status = ml_single_get_input_info (single, &in_res);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_get_tensors_count (in_res, &count);
+  status = ml_tensors_info_get_count (in_res, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 1U);
 
-  status = ml_util_get_tensor_name (in_res, 0, &name);
+  status = ml_tensors_info_get_tensor_name (in_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (g_str_equal (name, "wav_data"));
 
-  status = ml_util_get_tensor_type (in_res, 0, &type);
+  status = ml_tensors_info_get_tensor_type (in_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_INT16);
 
-  ml_util_get_tensor_dimension (in_res, 0, res_dim);
+  ml_tensors_info_get_tensor_dimension (in_res, 0, res_dim);
   EXPECT_TRUE (in_dim[0] == res_dim[0]);
   EXPECT_TRUE (in_dim[1] == res_dim[1]);
   EXPECT_TRUE (in_dim[2] == res_dim[2]);
@@ -1384,19 +1384,19 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   status = ml_single_get_output_info (single, &out_res);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
-  status = ml_util_get_tensors_count (out_res, &count);
+  status = ml_tensors_info_get_count (out_res, &count);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (count, 1U);
 
-  status = ml_util_get_tensor_name (out_res, 0, &name);
+  status = ml_tensors_info_get_tensor_name (out_res, 0, &name);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (g_str_equal (name, "labels_softmax"));
 
-  status = ml_util_get_tensor_type (out_res, 0, &type);
+  status = ml_tensors_info_get_tensor_type (out_res, 0, &type);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_EQ (type, ML_TENSOR_TYPE_FLOAT32);
 
-  ml_util_get_tensor_dimension (out_res, 0, res_dim);
+  ml_tensors_info_get_tensor_dimension (out_res, 0, res_dim);
   EXPECT_TRUE (out_dim[0] == res_dim[0]);
   EXPECT_TRUE (out_dim[1] == res_dim[1]);
   EXPECT_TRUE (out_dim[2] == res_dim[2]);
@@ -1405,11 +1405,11 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   input = output = NULL;
 
   /* generate input data */
-  status = ml_util_allocate_tensors_data (in_info, &input);
+  status = ml_tensors_data_create (in_info, &input);
   EXPECT_EQ (status, ML_ERROR_NONE);
   EXPECT_TRUE (input != NULL);
 
-  status = ml_util_copy_tensor_data (input, 0, contents, len);
+  status = ml_tensors_data_set_tensor_data (input, 0, contents, len);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   status = ml_single_inference (single, input, &output);
@@ -1417,10 +1417,10 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   EXPECT_TRUE (output != NULL);
 
   /* check result (max score index is 2) */
-  status = ml_util_get_tensor_data (output, 1, &data_ptr, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 1, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_INVALID_PARAMETER);
 
-  status = ml_util_get_tensor_data (output, 0, &data_ptr, &data_size);
+  status = ml_tensors_data_get_tensor_data (output, 0, &data_ptr, &data_size);
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   max_score = .0;
@@ -1435,8 +1435,8 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
 
   EXPECT_EQ (max_score_index, 2);
 
-  ml_util_destroy_tensors_data (output);
-  ml_util_destroy_tensors_data (input);
+  ml_tensors_data_destroy (output);
+  ml_tensors_data_destroy (input);
 
   status = ml_single_close (single);
   EXPECT_EQ (status, ML_ERROR_NONE);
@@ -1444,10 +1444,10 @@ TEST (nnstreamer_capi_singleshot, invoke_04)
   g_free (test_model);
   g_free (test_file);
   g_free (contents);
-  ml_util_destroy_tensors_info (in_info);
-  ml_util_destroy_tensors_info (out_info);
-  ml_util_destroy_tensors_info (in_res);
-  ml_util_destroy_tensors_info (out_res);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
+  ml_tensors_info_destroy (in_res);
+  ml_tensors_info_destroy (out_res);
 }
 #endif /* ENABLE_TENSORFLOW */
 
@@ -1474,8 +1474,8 @@ TEST (nnstreamer_capi_singleshot, failure_01)
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
-  ml_util_allocate_tensors_info (&in_info);
-  ml_util_allocate_tensors_info (&out_info);
+  ml_tensors_info_create (&in_info);
+  ml_tensors_info_create (&out_info);
 
   /* invalid file path */
   status = ml_single_open (&single, "wrong_file_name", in_info, out_info,
@@ -1501,9 +1501,9 @@ TEST (nnstreamer_capi_singleshot, failure_01)
   in_dim[1] = 224;
   in_dim[2] = 224;
   in_dim[3] = 1;
-  ml_util_set_tensors_count (in_info, 1);
-  ml_util_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (in_info, 0, in_dim);
+  ml_tensors_info_set_count (in_info, 1);
+  ml_tensors_info_set_tensor_type (in_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (in_info, 0, in_dim);
 
   /* invalid output tensor info */
   status = ml_single_open (&single, test_model, in_info, out_info,
@@ -1514,9 +1514,9 @@ TEST (nnstreamer_capi_singleshot, failure_01)
   out_dim[1] = 1;
   out_dim[2] = 1;
   out_dim[3] = 1;
-  ml_util_set_tensors_count (out_info, 1);
-  ml_util_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
-  ml_util_set_tensor_dimension (out_info, 0, out_dim);
+  ml_tensors_info_set_count (out_info, 1);
+  ml_tensors_info_set_tensor_type (out_info, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (out_info, 0, out_dim);
 
   /* invalid file extension */
   status = ml_single_open (&single, test_model, in_info, out_info,
@@ -1536,8 +1536,8 @@ TEST (nnstreamer_capi_singleshot, failure_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   g_free (test_model);
-  ml_util_destroy_tensors_info (in_info);
-  ml_util_destroy_tensors_info (out_info);
+  ml_tensors_info_destroy (in_info);
+  ml_tensors_info_destroy (out_info);
 }
 #endif /* ENABLE_TENSORFLOW_LITE */
 


### PR DESCRIPTION
As we discussed, tensors metadata in c-api changed to the handles for meta/data.

1. alloc and destory functions are added for tensors meta/data handle.
2. refactors all functions and testcases with meta/data handle.
3. update api description.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
