### PR TITLE
[C-API] Update doxygen for Tizen API - @open sesame 7/11 15:23

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -24,32 +24,12 @@
 #define __TIZEN_MACHINELEARNING_NNSTREAMER_DOC_H__
 
 /**
- * @ingroup CAPI_ML_FRAMEWORK
- * @defgroup CAPI_ML_NNSTREAMER NNStreamer
- * @brief NNStreamer allows to construct and execute a GStreamer pipeline including neural networks.\n
- * NNStreamer is a set of GStreamer plugins that allow GStreamer developers to adopt neural network models easily and efficiently and neural network developers to manage stream pipelines and their filters easily and efficiently.\n
- * https://github.com/nnsuite/nnstreamer/\n
- * \n
- * Main objectives of NNStreamer include:\n
- * * Provide neural network framework connectivity (e.g., tensorflow, caffe) for GStreamer streams.\n
- *     * **Efficient Streaming for AI Projects**: Apply efficient and flexible stream pipeline to neural networks.\n
- *     * **Intelligent Media Filters!**: Use a neural network model as a media filter / converter.\n
- *     * **Composite Models!**: Multiple neural network models in a single stream pipeline instance.\n
- *     * **Multi Modal Intelligence!**: Multiple sources and stream paths for neural network models.\n
- * * Provide easy methods to construct media streams with neural network models using the de-facto-standard media stream framework, **GStreamer**.\n
- *     * GStreamer users: use neural network models as if they are yet another media filters.\n
- *     * Neural network developers: manage media streams easily and efficiently.\n
- * \n
- * There are following sub groups proposed:\n
- * * Pipeline: construct and control an NNStreamer pipeline.\n
- * * Single: invoke a neural network model with a single instance of input data.\n
- *
- * @defgroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE NNStreamer Pipeline
- * @ingroup  CAPI_ML_NNSTREAMER
+ * @ingroup  CAPI_ML_FRAMEWORK
+ * @defgroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE Pipeline
+ * @addtogroup CAPI_ML_NNSTREAMER_PIPELINE_MODULE
  * @brief The NNStreamer function provides interfaces to create and execute stream pipelines with neural networks and sensors.
  * @section CAPI_ML_NNSTREAMER_PIPELINE_HEADER Required Header
  *   \#include <nnstreamer/nnstreamer.h>\n
- *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_OVERVIEW Overview
  * The NNStreamer function provides interfaces to create and execute stream pipelines with neural networks and sensors.
  *
@@ -65,7 +45,7 @@
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_FEATURE Related Features
  * This function is related with the following features:\n
- *  - http://tizen.org/feature/nnstreamer.pipeline\n
+ *  - http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n
  * You can check if a device supports the related features for this function by using
@@ -80,9 +60,12 @@
  * <a href="https://developer.tizen.org/development/tizen-studio/native-tools/configuring-your-app/manifest-text-editor#feature">
  *    <b>Feature Element</b>.
  * </a>
- *
- * @defgroup CAPI_ML_NNSTREAMER_SINGLE_MODULE NNStreamer Single Shot
- * @ingroup  CAPI_ML_NNSTREAMER
+ */
+
+/**
+ * @ingroup  CAPI_ML_FRAMEWORK
+ * @defgroup CAPI_ML_NNSTREAMER_SINGLE_MODULE Single
+ * @addtogroup CAPI_ML_NNSTREAMER_SINGLE_MODULE
  * @brief The NNStreamer Single API provides interfaces to invoke a neural network model with a single instance of input data.
  * @section CAPI_ML_NNSTREAMER_SINGLE_HEADER Required Header
  *   \#include <nnstreamer/nnstreamer-single.h>\n
@@ -102,7 +85,7 @@
  *
  * @section CAPI_ML_NNSTREAMER_SINGLE_FEATURE Related Features
  * This function is related with the following features:\n
- *  - http://tizen.org/feature/nnstreamer.single\n
+ *  - http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n
  * You can check if a device supports the related features for this function by using

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -27,10 +27,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-/**
- *  Apply modify_nnstreamer_h_for_nontizen.sh if you want to use
- * in non-Tizen Linux machines
- */
+/* Apply modify_nnstreamer_h_for_nontizen.sh if you want to use in non-Tizen Linux machines */
 #include <tizen_error.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR updates the feature name of Tizen API and its related
documentation. Detailed information is as below.

* NNStreamer -> Single / Pipeline without NNStreamer
* Newly add the 2 feature keys (machine_learning & machine_learning.inference)

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

