### PR TITLE
[C-Api] Add NNFW enum for future use - @open sesame 7/12 14:04

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -110,6 +110,7 @@ typedef enum {
   ML_NNFW_TYPE_CUSTOM_FILTER, /**< Custom filter (Independent shared object). */
   ML_NNFW_TYPE_TENSORFLOW_LITE, /**< Tensorflow-lite (.tflite). */
   ML_NNFW_TYPE_TENSORFLOW, /**< Tensorflow (.pb). */
+  ML_NNFW_TYPE_NNFW, /**< Neural Network Inference framework, which is developed by SR */
 } ml_nnfw_type_e;
 
 /**

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -129,6 +129,11 @@ ml_single_open (ml_single_h * single, const char *model,
         status = ML_ERROR_INVALID_PARAMETER;
       }
       break;
+    case ML_NNFW_TYPE_NNFW:
+      /** @todo Need to check method for NNFW */
+      ml_loge ("NNFW is not supported.");
+      status = ML_ERROR_NOT_SUPPORTED;
+      break;
     default:
       break;
   }

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -761,6 +761,13 @@ ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
         goto done;
       }
       break;
+    case ML_NNFW_TYPE_NNFW:
+      {
+        /** @todo Need to check method for NNFW */
+        ml_logw ("NNFW is not supported.");
+        goto done;
+      }
+      break;
     default:
       break;
   }

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1050,6 +1050,25 @@ TEST (nnstreamer_capi_switch, failure_01)
   g_free (pipeline);
 }
 
+/**
+ * @brief Test NNStreamer Utility for checking availability of NNFW
+ */
+TEST (nnstreamer_capi_util, availability_00)
+{
+  bool result;
+  int status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+
 #ifdef ENABLE_TENSORFLOW_LITE
 /**
  * @brief Test NNStreamer single shot (tensorflow-lite)


### PR DESCRIPTION
This patch newly adds the ML_NNFW_TYPE_NNFW enumeration for future use
of NNFW.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>


#### Related Issue
* https://github.com/nnsuite/nnstreamer/issues/1519

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped