### PR TITLE
[Filter/TF] fix build conflict with TF version 1.13.1

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.cc
@@ -419,7 +419,9 @@ class TFBuffer : public TensorBuffer {
   void* data_;
   size_t len_;
 
+#if (TF_MAJOR_VERSION == 1 && TF_MINOR_VERSION < 13)
   void* data () const override { return data_; }
+#endif
   size_t size () const override { return len_; }
   TensorBuffer* root_buffer () override { return this; }
   void FillAllocationDescription (AllocationDescription* proto) const override {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.h
@@ -42,6 +42,7 @@
 #include <tensorflow/c/c_api.h>
 #include <tensorflow/c/c_api_internal.h>
 #include <tensorflow/core/public/session.h>
+#include <tensorflow/core/public/version.h>
 #pragma GCC diagnostic pop
 
 using namespace tensorflow;


### PR DESCRIPTION
override a specific method `data()` at the specific version of TF, `1.9.0` (before `1.13`)

it resolves #1518

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped