### PR TITLE
[Filter/TF] apply a new constructor for TFBuffer - @open sesame 7/22 15:49

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_core.cc
@@ -420,8 +420,14 @@ class TFBuffer : public TensorBuffer {
   size_t len_;
 
 #if (TF_MAJOR_VERSION == 1 && TF_MINOR_VERSION < 13)
+  explicit TFBuffer (void* data_ptr) : data_(data_ptr) {}
   void* data () const override { return data_; }
+#elif (TF_MAJOR_VERSION == 1 && TF_MINOR_VERSION >= 13)
+  explicit TFBuffer (void* data_ptr) : TensorBuffer (data_ptr) {}
+#else
+#error This supports Tensorflow 1.x only.
 #endif
+
   size_t size () const override { return len_; }
   TensorBuffer* root_buffer () override { return this; }
   void FillAllocationDescription (AllocationDescription* proto) const override {
@@ -470,9 +476,8 @@ TFCore::run (const GstTensorMemory * input, GstTensorMemory * output)
         }
 
         /* this input tensor should be UNREF */
-        buf = new TFBuffer;
+        buf = new TFBuffer (input[i].data);
         buf->len_ = input[i].size;
-        buf->data_ = input[i].data;
 
         in = TensorCApi::MakeTensor (
           dataType,


### PR DESCRIPTION
The different constructor is applied according to the version of TF
With this pr, GBS build works well without errors related to tensorflow 1.13.1

Signed-off-by: Hyoung Joo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
