### PR TITLE
[C-Api] fix error to run pipeline - @open sesame 7/12 19:55

### DIFF
--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -73,7 +73,7 @@ typedef void *ml_single_h;
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
- *
+ * @retval #ML_ERROR_NOT_SUPPORTED Fail. The parameter is not available.
  */
 int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw);
 

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -151,9 +151,12 @@ ml_single_open (ml_single_h * single, const char *model,
   /* 2. Determine hw */
   /** @todo Now the param hw is ignored. (Supposed CPU only) Support others later. */
   status = ml_check_nnfw_availability (nnfw, hw, &available);
-  if (status != ML_ERROR_NONE || !available) {
-    ml_loge ("The given nnfw is not available.");
+  if (status != ML_ERROR_NONE)
     return status;
+
+  if (!available) {
+    ml_loge ("The given nnfw is not available.");
+    return ML_ERROR_NOT_SUPPORTED;
   }
 
   /* 3. Construct a pipeline */


### PR DESCRIPTION
1. return valid error code when opening single-shot model.
2. When called destroy() in pipeline, remove all callbacks before changing pipeline state.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
