### PR TITLE
[Tizen/Api] add smack label for tensor filter

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -276,15 +276,18 @@ popd
 # for tensorflow
 %if 0%{?tensorflow-support}
 %files tensorflow
+%manifest capi-nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow.so
 %endif
 
 %files tensorflow-lite
+%manifest capi-nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so
 
 %files -n nnstreamer-python2
+%manifest capi-nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_python2.so
 %{_prefix}/lib/nnstreamer/filters/nnstreamer_python2.so


### PR DESCRIPTION
Tensor filters such as libnnstreamer_filter_tensorflow-lite.so does not
have a smack label, smack deny occurs when accessing it . This patch fixes
that bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Smack Error
```bash
[  127.077180] audit: type=1400 audit(1563522638.030:103): lsm=SMACK fn=smack_inode_getattr action=denied subject="User::Pkg::org.tizen.machine.nnstreamer.Test" object="User::Shell" requested=r pid=3541 comm="dotnet-launcher" path="/usr/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so" dev="vda" ino=2207
```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped