### PR TITLE
[C-API] check gstreamer initialization status in ml_single_open()

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -57,6 +57,7 @@ ml_single_open (ml_single_h * single, const char *model,
   ml_pipeline *pipe_h;
   GstElement *appsrc, *appsink, *filter;
   GstCaps *caps;
+  GError *err = NULL;
   int status = ML_ERROR_NONE;
   gchar *pipeline_desc = NULL;
   gchar *path_down;
@@ -72,6 +73,16 @@ ml_single_open (ml_single_h * single, const char *model,
 
   /* init null */
   *single = NULL;
+
+  if (FALSE == gst_init_check (NULL, NULL, &err)) {
+    if (err) {
+      ml_loge ("GStreamer has the following error: %s", err->message);
+      g_error_free (err);
+    } else {
+      ml_loge ("Cannot initialize GStreamer. Unknown reason.");
+    }
+    return ML_ERROR_STREAMS_PIPE;
+  }
 
   in_tensors_info = (ml_tensors_info_s *) input_info;
   out_tensors_info = (ml_tensors_info_s *) output_info;


### PR DESCRIPTION
Before calling gstreamer function, this patch checks its initialization
status by calling gst_init_check() in ml_single_open().

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

