### PR TITLE
[Tests/Decoder/ImageLabeling] Bugfixes in the runTest script

### DIFF
--- a/tests/nnstreamer_decoder_image_labeling/runTest.sh
+++ b/tests/nnstreamer_decoder_image_labeling/runTest.sh
@@ -36,7 +36,7 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_path})
+	path=$(grep "^filters" ${ini_file})
 	key=${path%=*}
 	value=${path##*=}
 

--- a/tests/nnstreamer_decoder_image_labeling/runTest.sh
+++ b/tests/nnstreamer_decoder_image_labeling/runTest.sh
@@ -59,10 +59,11 @@ else
 	    report
 	    exit
 	fi
-    fi
-    echo "Cannot identify nnstreamer.ini"
-    report
-    exit
+	else
+	    echo "Cannot identify nnstreamer.ini"
+	    report
+	    exit
+	fi
 fi
 
 # Decoding 'orange' tests


### PR DESCRIPTION
Related to https://github.com/nnsuite/nnstreamer/pull/1456.

There are several bugs in the runTest.sh script. 
  - The name of the 'ini_path' variable should be replaced with 'ini_file'. In the scope of the code handling /etc/nnstreamer.ini, there is no ini_path.
  - The if-logic for handling /etc/nnstreamer.ini is wrong. It is always returned at the end of that if-logic without reaching the actual test code (i.e., gstTest).

In addition, we have same issues in runTests.sh scripts for the other test cases. I will fix them.

Signed-off-by: Wook Song <wook16.song@samsung.com>