### PR TITLE
[Tests/Filter/TFLite] Bugfixes in the runTest script

### DIFF
--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -36,7 +36,7 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_path})
+	path=$(grep "^filters" ${ini_file})
 	key=${path%=*}
 	value=${path##*=}
 

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -59,10 +59,11 @@ else
 	    report
 	    exit
 	fi
-    fi
-    echo "Cannot identify nnstreamer.ini"
-    report
-    exit
+	else
+		echo "Cannot identify nnstreamer.ini"
+		report
+		exit
+	fi
 fi
 
 PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"


### PR DESCRIPTION
Related to #1456.

This PR also fixes same bugs mentioned in #1543. The only difference is that this fixes the bugs in the test script for the tensorflow-lite tensor filter.

Signed-off-by: Wook Song <wook16.song@samsung.com>