### PR TITLE
[Sink] remove unnecessary functions

### DIFF
--- a/gst/nnstreamer/tensor_sink/tensor_sink.h
+++ b/gst/nnstreamer/tensor_sink/tensor_sink.h
@@ -61,7 +61,6 @@ struct _GstTensorSink
   gboolean emit_signal; /**< true to emit signal for new data, eos */
   guint signal_rate; /**< new data signals per second */
   GstClockTime last_render_time; /**< buffer rendered time */
-  GstCaps *in_caps; /**< received caps */
 };
 
 /**


### PR DESCRIPTION
use basesink default and remove unnecessary functions.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>

