### PR TITLE
[Tests/CustomFilter] Fix a bug in code for checking existence of OpenCV

### DIFF
--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -22,7 +22,7 @@ PATH_TO_PLUGIN="../../build"
 
 # Test for opencv installed, enable OPENCV test if opencv is found
 TEST_OPENCV="NO"
-ldconfig -p | grep opencv > /dev/null 2>&1
+/sbin/ldconfig -p | grep opencv > /dev/null 2>&1
 if [[ "$?" == 0 ]]
 then
   TEST_OPENCV="YES"


### PR DESCRIPTION
This patch fixes a minor bug in the code for checking existence of OpenCV libraries.

Resolves: #1548 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>