### PR TITLE
[C-Api] Check feature before processing API

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -45,6 +45,7 @@
  *
  * @section CAPI_ML_NNSTREAMER_PIPELINE_FEATURE Related Features
  * This function is related with the following features:\n
+ *  - http://tizen.org/feature/machine_learning\n
  *  - http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n
@@ -85,6 +86,7 @@
  *
  * @section CAPI_ML_NNSTREAMER_SINGLE_FEATURE Related Features
  * This function is related with the following features:\n
+    - http://tizen.org/feature/machine_learning\n
  *  - http://tizen.org/feature/machine_learning.inference\n
  *
  * It is recommended to probe features in your application for reliability.\n

--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -33,6 +33,12 @@
 
 #define TAG_NAME "nnstreamer-capi"
 
+#define ML_INF_FEATURE_PATH "tizen.org/feature/machine_learning.inference"
+
+#define check_feature_state() \
+  if (ML_ERROR_NONE != ml_get_feature_enabled()) \
+    return ML_ERROR_NOT_SUPPORTED;
+
 #if defined(__TIZEN__)
   #include <dlog.h>
 
@@ -241,6 +247,17 @@ void ml_tensors_info_copy_from_ml (GstTensorsInfo *gst_info, const ml_tensors_in
  * @brief Gets caps from tensors info.
  */
 GstCaps * ml_tensors_info_get_caps (const ml_tensors_info_s *info);
+
+/**
+ * @brief Checks whether machine_learning.inference feature is enabled or not.
+ */
+int ml_get_feature_enabled (void);
+
+/**
+ * @brief Set the feature status of machine_learning.inference.
+ * This is only used for Unit test.
+ */
+int ml_set_feature_status (int status);
 
 #ifdef __cplusplus
 }

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -71,9 +71,9 @@ typedef void *ml_single_h;
  *               Set #ML_NNFW_HW_ANY if it does not matter.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
- * @retval #ML_ERROR_NOT_SUPPORTED Fail. The parameter is not available.
  */
 int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw);
 
@@ -83,6 +83,7 @@ int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_inf
  * @param[in] single The model handle to be closed.
  * @return @c 0 on success. otherwise a negative error value
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid (pipe is NULL?)
  */
 int ml_single_close (ml_single_h single);
@@ -97,6 +98,7 @@ int ml_single_close (ml_single_h single);
  * @param[out] output The allocated output buffer. The caller is responsible for freeing the output buffer with ml_tensors_data_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Cannot push a buffer into source element.
  * @retval #ML_ERROR_TIMED_OUT Failed to get the result from sink element.
@@ -117,6 +119,7 @@ int ml_single_invoke (ml_single_h single, const ml_tensors_data_h input, ml_tens
  * @param[out] info The handle of input tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
 int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
@@ -130,6 +133,7 @@ int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
  * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
  * @return @c 0 on success. otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
 int ml_single_get_output_info (ml_single_h single, ml_tensors_info_h *info);

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -242,6 +242,7 @@ typedef void (*ml_pipeline_state_cb) (ml_pipeline_state_e state, void *user_data
  * @param[out] pipe The NNStreamer pipeline handler from the given description.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Pipeline construction is failed because of wrong parameter or initialization failure.
  */
@@ -254,6 +255,7 @@ int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_state_c
  * @param[in] pipe The pipeline to be destroyed.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER The parameter is invalid (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Cannot access the pipeline status.
  */
@@ -267,6 +269,7 @@ int ml_pipeline_destroy (ml_pipeline_h pipe);
  * @param[out] state The pipeline state.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to get state from the pipeline.
  */
@@ -284,6 +287,7 @@ int ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e *state);
  * @param[in] pipe The pipeline handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to start the pipeline.
  */
@@ -298,6 +302,7 @@ int ml_pipeline_start (ml_pipeline_h pipe);
  * @param[in] pipe The pipeline to be stopped.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL?)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to stop the pipeline.
  */
@@ -317,6 +322,7 @@ int ml_pipeline_stop (ml_pipeline_h pipe);
  * @param[out] sink_handle The sink handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid. (pipe is NULL, sink_name is not found, or sink_name has an invalid type.)
  * @retval #ML_ERROR_STREAMS_PIPE Failed to connect a signal to sink element.
  */
@@ -328,6 +334,7 @@ int ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name, ml_pip
  * @param[in] sink_handle The sink handle to be unregistered.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_sink_unregister (ml_pipeline_sink_h sink_handle);
@@ -341,6 +348,7 @@ int ml_pipeline_sink_unregister (ml_pipeline_sink_h sink_handle);
  * @param[out] src_handle The src handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Fail to get SRC element.
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
@@ -353,6 +361,7 @@ int ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name, ml_pip
  * @param[in] src_handle The src handle to be released.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
@@ -366,6 +375,7 @@ int ml_pipeline_src_release_handle (ml_pipeline_src_h src_handle);
  * @param[in] policy The policy of buf deallocation.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
@@ -380,6 +390,7 @@ int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h 
  * @param[out] info The handle of tensors information.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE The pipeline has inconsistent padcaps. Not negotiated?
  * @retval #ML_ERROR_TRY_AGAIN The pipeline is not ready yet.
@@ -402,6 +413,7 @@ int ml_pipeline_src_get_tensors_info (ml_pipeline_src_h src_handle, ml_tensors_i
  * @param[out] switch_handle The switch handle.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, ml_pipeline_switch_e *switch_type, ml_pipeline_switch_h *switch_handle);
@@ -412,6 +424,7 @@ int ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name, 
  * @param[in] switch_handle The handle to be released.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_switch_release_handle (ml_pipeline_switch_h switch_handle);
@@ -423,6 +436,7 @@ int ml_pipeline_switch_release_handle (ml_pipeline_switch_h switch_handle);
  * @param[in] pad_name The name of the chosen pad to be activated. Use ml_pipeline_switch_get_pad_list() to list the available pad names.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_switch_select (ml_pipeline_switch_h switch_handle, const char *pad_name);
@@ -434,6 +448,7 @@ int ml_pipeline_switch_select (ml_pipeline_switch_h switch_handle, const char *p
  * @param[out] list NULL terminated array of char*. The caller must free each string (char*) in the list and free the list itself.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE The element is not both input and output switch (Internal data inconsistency).
  */
@@ -449,6 +464,7 @@ int ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h switch_handle, char **
  * @param[out] valve_handle The valve handle.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name, ml_pipeline_valve_h *valve_handle);
@@ -459,6 +475,7 @@ int ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name, ml
  * @param[in] valve_handle The handle to be released.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_valve_release_handle (ml_pipeline_valve_h valve_handle);
@@ -470,6 +487,7 @@ int ml_pipeline_valve_release_handle (ml_pipeline_valve_h valve_handle);
  * @param[in] open @c true to open(let the flow pass), @c false to close (drop & stop the flow).
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_pipeline_valve_set_open (ml_pipeline_valve_h valve_handle, bool open);
@@ -483,6 +501,7 @@ int ml_pipeline_valve_set_open (ml_pipeline_valve_h valve_handle, bool open);
  * @param[out] info The handle of tensors information.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_create (ml_tensors_info_h *info);
@@ -493,6 +512,7 @@ int ml_tensors_info_create (ml_tensors_info_h *info);
  * @param[in] info The handle of tensors information.
  * @return 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_destroy (ml_tensors_info_h info);
@@ -505,6 +525,7 @@ int ml_tensors_info_destroy (ml_tensors_info_h info);
  * @param[out] valid @c true if it's valid, @c false if if it's invalid.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_validate (const ml_tensors_info_h info, bool *valid);
@@ -516,6 +537,7 @@ int ml_tensors_info_validate (const ml_tensors_info_h info, bool *valid);
  * @param[in] src The tensors information to be copied.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_clone (ml_tensors_info_h dest, const ml_tensors_info_h src);
@@ -527,6 +549,7 @@ int ml_tensors_info_clone (ml_tensors_info_h dest, const ml_tensors_info_h src);
  * @param[in] count The number of tensors.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_set_count (ml_tensors_info_h info, unsigned int count);
@@ -538,6 +561,7 @@ int ml_tensors_info_set_count (ml_tensors_info_h info, unsigned int count);
  * @param[out] count The number of tensors.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_get_count (ml_tensors_info_h info, unsigned int *count);
@@ -550,6 +574,7 @@ int ml_tensors_info_get_count (ml_tensors_info_h info, unsigned int *count);
  * @param[in] name The tensor name to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index, const char *name);
@@ -562,6 +587,7 @@ int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index,
  * @param[out] name The tensor name.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **name);
@@ -574,6 +600,7 @@ int ml_tensors_info_get_tensor_name (ml_tensors_info_h info, unsigned int index,
  * @param[in] type The tensor type to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type);
@@ -586,6 +613,7 @@ int ml_tensors_info_set_tensor_type (ml_tensors_info_h info, unsigned int index,
  * @param[out] type The tensor type.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tensor_type_e *type);
@@ -598,6 +626,7 @@ int ml_tensors_info_get_tensor_type (ml_tensors_info_h info, unsigned int index,
  * @param[in] dimension The tensor dimension to be set.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, const ml_tensor_dimension dimension);
@@ -610,6 +639,7 @@ int ml_tensors_info_set_tensor_dimension (ml_tensors_info_h info, unsigned int i
  * @param[out] dimension The tensor dimension.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension);
@@ -629,6 +659,7 @@ size_t ml_tensors_info_get_size (const ml_tensors_info_h info);
  * @param[out] data The handle of tensors data. The caller is responsible for freeing the allocated data with ml_tensors_data_destroy().
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  * @retval #ML_ERROR_STREAMS_PIPE Failed to allocate new memory.
  */
@@ -640,6 +671,7 @@ int ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h *dat
  * @param[in] data The handle of tensors data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_data_destroy (ml_tensors_data_h data);
@@ -653,6 +685,7 @@ int ml_tensors_data_destroy (ml_tensors_data_h data);
  * @param[out] data_size Byte size of tensor data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **raw_data, size_t *data_size);
@@ -666,6 +699,7 @@ int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index,
  * @param[in] data_size Byte size of raw data.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size);
@@ -681,6 +715,7 @@ int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index,
  * @param[out] available @c true if it's available, @c false if if it's not available.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful and the environments are available.
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw, bool *available);

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -36,6 +36,7 @@ if (get_option('enable-tizen'))
   message('CAPI is in Tizen mode')
   tizen_deps = [
     dependency('capi-base-common'),
+    dependency('capi-system-info'),
     dependency('dlog')
   ]
 else

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -345,6 +345,8 @@ ml_pipeline_construct (const char *pipeline_description,
 
   ml_pipeline *pipe_h;
 
+  check_feature_state ();
+
   if (pipe == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
@@ -487,6 +489,8 @@ ml_pipeline_destroy (ml_pipeline_h pipe)
   GstStateChangeReturn scret;
   GstState state;
 
+  check_feature_state ();
+
   if (p == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
@@ -545,6 +549,8 @@ ml_pipeline_get_state (ml_pipeline_h pipe, ml_pipeline_state_e * state)
   GstState _state;
   GstStateChangeReturn scret;
 
+  check_feature_state ();
+
   if (p == NULL || state == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
@@ -573,6 +579,8 @@ ml_pipeline_start (ml_pipeline_h pipe)
   ml_pipeline *p = pipe;
   GstStateChangeReturn scret;
 
+  check_feature_state ();
+
   if (p == NULL)
     return ML_ERROR_INVALID_PARAMETER;
 
@@ -594,6 +602,8 @@ ml_pipeline_stop (ml_pipeline_h pipe)
 {
   ml_pipeline *p = pipe;
   GstStateChangeReturn scret;
+
+  check_feature_state ();
 
   if (p == NULL)
     return ML_ERROR_INVALID_PARAMETER;
@@ -622,6 +632,8 @@ ml_pipeline_sink_register (ml_pipeline_h pipe, const char *sink_name,
   ml_pipeline *p = pipe;
   ml_pipeline_sink *sink;
   int ret = ML_ERROR_NONE;
+
+  check_feature_state ();
 
   if (h == NULL) {
     ml_loge ("The argument sink handle is not valid.");
@@ -721,6 +733,8 @@ ml_pipeline_sink_unregister (ml_pipeline_sink_h h)
 {
   handle_init (sink, sink, h);
 
+  check_feature_state ();
+
   if (elem->handle_id > 0) {
     g_signal_handler_disconnect (elem->element, elem->handle_id);
     elem->handle_id = 0;
@@ -817,6 +831,8 @@ ml_pipeline_src_get_handle (ml_pipeline_h pipe, const char *src_name,
   ml_pipeline_src *src;
   int ret = ML_ERROR_NONE;
 
+  check_feature_state ();
+
   if (h == NULL) {
     ml_loge ("The argument source handle is not valid.");
     return ML_ERROR_INVALID_PARAMETER;
@@ -881,6 +897,8 @@ ml_pipeline_src_release_handle (ml_pipeline_src_h h)
 {
   handle_init (src, src, h);
 
+  check_feature_state ();
+
   elem->handles = g_list_remove (elem->handles, src);
   g_free (src);
 
@@ -902,6 +920,8 @@ ml_pipeline_src_input_data (ml_pipeline_src_h h, ml_tensors_data_h data,
   unsigned int i;
 
   handle_init (src, src, h);
+
+  check_feature_state ();
 
   _data = (ml_tensors_data_s *) data;
   if (!_data) {
@@ -992,6 +1012,8 @@ ml_pipeline_src_get_tensors_info (ml_pipeline_src_h h,
 {
   handle_init (src, src, h);
 
+  check_feature_state ();
+
   if (info == NULL) {
     ret = ML_ERROR_INVALID_PARAMETER;
     goto unlock_return;
@@ -1022,6 +1044,8 @@ ml_pipeline_switch_get_handle (ml_pipeline_h pipe, const char *switch_name,
   ml_pipeline *p = pipe;
   ml_pipeline_switch *swtc;
   int ret = ML_ERROR_NONE;
+
+  check_feature_state ();
 
   if (h == NULL) {
     ml_loge ("The argument switch handle is not valid.");
@@ -1093,6 +1117,8 @@ ml_pipeline_switch_release_handle (ml_pipeline_switch_h h)
 {
   handle_init (switch, swtc, h);
 
+  check_feature_state ();
+
   elem->handles = g_list_remove (elem->handles, swtc);
   g_free (swtc);
 
@@ -1109,6 +1135,8 @@ ml_pipeline_switch_select (ml_pipeline_switch_h h, const char *pad_name)
   gchar *active_name;
 
   handle_init (switch, swtc, h);
+
+  check_feature_state ();
 
   if (pad_name == NULL) {
     ml_loge ("The second argument, pad name, is not valid.");
@@ -1162,6 +1190,8 @@ ml_pipeline_switch_get_pad_list (ml_pipeline_switch_h h, char ***list)
   int counter = 0;
 
   handle_init (switch, swtc, h);
+
+  check_feature_state ();
 
   if (list == NULL) {
     ml_loge ("The second argument, list, is not valid.");
@@ -1250,6 +1280,8 @@ ml_pipeline_valve_get_handle (ml_pipeline_h pipe, const char *valve_name,
   ml_pipeline_valve *valve;
   int ret = ML_ERROR_NONE;
 
+  check_feature_state ();
+
   if (h == NULL) {
     ml_loge ("The argument valve handle is not valid.");
     return ML_ERROR_INVALID_PARAMETER;
@@ -1312,6 +1344,8 @@ ml_pipeline_valve_release_handle (ml_pipeline_valve_h h)
 {
   handle_init (valve, valve, h);
 
+  check_feature_state ();
+
   elem->handles = g_list_remove (elem->handles, valve);
   g_free (valve);
 
@@ -1326,6 +1360,8 @@ ml_pipeline_valve_set_open (ml_pipeline_valve_h h, bool open)
 {
   gboolean drop = FALSE;
   handle_init (valve, valve, h);
+
+  check_feature_state ();
 
   g_object_get (G_OBJECT (elem->element), "drop", &drop, NULL);
 

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -65,6 +65,8 @@ ml_single_open (ml_single_h * single, const char *model,
   bool available = false;
   bool valid = false;
 
+  check_feature_state ();
+
   /* Validate the params */
   if (!single) {
     ml_loge ("The given param, single is invalid.");
@@ -327,6 +329,8 @@ ml_single_close (ml_single_h single)
   ml_single *single_h;
   int status;
 
+  check_feature_state ();
+
   if (!single) {
     ml_loge ("The given param, single is invalid.");
     return ML_ERROR_INVALID_PARAMETER;
@@ -372,6 +376,8 @@ ml_single_invoke (ml_single_h single,
   GstMapInfo mem_info;
   GstFlowReturn ret;
   int i, status = ML_ERROR_NONE;
+
+  check_feature_state ();
 
   if (!single || !input || !output) {
     ml_loge ("The given param is invalid.");
@@ -463,6 +469,8 @@ ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
   gchar *val;
   guint rank;
 
+  check_feature_state ();
+
   if (!single || !info)
     return ML_ERROR_INVALID_PARAMETER;
 
@@ -513,6 +521,8 @@ ml_single_get_output_info (ml_single_h single, ml_tensors_info_h * info)
   GstTensorsInfo gst_info;
   gchar *val;
   guint rank;
+
+  check_feature_state ();
 
   if (!single || !info)
     return ML_ERROR_INVALID_PARAMETER;

--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_clean:
 
 override_dh_auto_configure:
 	mkdir -p build
-	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include -Dinstall-example=true -Denable-tensorflow=$(enable_tf) -Denable-capi=true build
+	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include -Dinstall-example=true -Denable-tensorflow=$(enable_tf) -Denable-capi=true -Denable-tizen=false build
 
 override_dh_auto_build:
 	ninja -C build

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -64,6 +64,7 @@ BuildRequires: lcov
 # BuildRequires:	taos-ci-unittest-coverage-assessment
 %endif
 %if %{with tizen}
+BuildRequires: pkgconfig(capi-system-info)
 BuildRequires:	pkgconfig(capi-base-common)
 BuildRequires:	pkgconfig(dlog)
 BuildRequires:	gst-plugins-bad-devel

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <glib.h>
 #include <glib/gstdio.h> /* GStatBuf */
+#include <nnstreamer-capi-private.h>
 
 /**
  * @brief Struct to check the pipeline state changes.
@@ -1616,6 +1617,8 @@ int
 main (int argc, char **argv)
 {
   testing::InitGoogleTest (&argc, argv);
+
+  ml_set_feature_status(1);
 
   return RUN_ALL_TESTS ();
 }


### PR DESCRIPTION
This patch checks the machine_learning.inference feature before
processing API by calling ml_get_feature_enabled() function.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed []Skipped
2. Run test: [* ]Passed [ ]Failed []Skipped
