### PR TITLE
[Tests/Filters] Bugfixes in the runTest script

### DIFF
--- a/tests/nnstreamer_filter_caffe2/runTest.sh
+++ b/tests/nnstreamer_filter_caffe2/runTest.sh
@@ -59,10 +59,11 @@ else
 	    report
 	    exit
 	fi
+    else
+		echo "Cannot identify nnstreamer.ini"
+		report
+		exit
     fi
-    echo "Cannot identify nnstreamer.ini"
-    report
-    exit
 fi
 
 # Test with Classifier model

--- a/tests/nnstreamer_filter_caffe2/runTest.sh
+++ b/tests/nnstreamer_filter_caffe2/runTest.sh
@@ -36,7 +36,7 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_path})
+	path=$(grep "^filters" ${ini_file})
 	key=${path%=*}
 	value=${path##*=}
 

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -38,7 +38,7 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_path})
+	path=$(grep "^filters" ${ini_file})
 	key=${path%=*}
 	value=${path##*=}
 
@@ -61,10 +61,11 @@ else
 	    report
 	    exit
 	fi
-    fi
-    echo "Cannot identify nnstreamer.ini"
-    report
-    exit
+	else
+		echo "Cannot identify nnstreamer.ini"
+		report
+		exit
+	fi
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=GRAY8,framerate=0/1 ! tensor_converter ! tensor_filter framework=pytorch model=${PATH_TO_MODEL} input=1:28:28:1 inputtype=uint8 output=10:1:1:1 outputtype=uint8 ! filesink location=tensorfilter.out.log" 1 0 0 $PERFORMANCE

--- a/tests/nnstreamer_filter_tensorflow/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow/runTest.sh
@@ -36,7 +36,7 @@ if [[ -d $PATH_TO_PLUGIN ]]; then
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_path})
+	path=$(grep "^filters" ${ini_file})
 	key=${path%=*}
 	value=${path##*=}
 
@@ -59,10 +59,11 @@ else
 	    report
 	    exit
 	fi
-    fi
-    echo "Cannot identify nnstreamer.ini"
-    report
-    exit
+	else
+		echo "Cannot identify nnstreamer.ini"
+		report
+		exit
+	fi
 fi
 
 # Test with mnist model


### PR DESCRIPTION
Related to #1456.

This PR also fixes same bugs mentioned in #1524 for the tensor filters, caffe2, tensorflow, and pytorch.

Signed-off-by: Wook Song <wook16.song@samsung.com>