### PR TITLE
[Android/Api] add script to build api library - @open sesame 8/19 16:47

### DIFF
--- a/api/android/api/build.gradle
+++ b/api/android/api/build.gradle
@@ -20,7 +20,17 @@ android {
                 if (gstRoot == null)
                     throw new GradleException('GSTREAMER_ROOT_ANDROID must be set, or "gstAndroidRoot" must be defined in your gradle.properties in the top level directory of the unpacked universal GStreamer Android binaries')
 
-                arguments "NDK_APPLICATION_MK=jni/Application.mk", "GSTREAMER_JAVA_SRC_DIR=src", "GSTREAMER_ROOT_ANDROID=$gstRoot", "GSTREAMER_ASSETS_DIR=src/assets"
+                def nnsRoot
+
+                if (project.hasProperty('nnstreamerRoot'))
+                    nnsRoot = project.nnstreamerRoot
+                else
+                    nnsRoot = System.env.NNSTREAMER_ROOT
+
+                if (nnsRoot == null)
+                    throw new GradleException('NNSTREAMER_ROOT must be set, or "nnstreamerRoot" must be defined in your gradle.properties')
+
+                arguments "NDK_APPLICATION_MK=jni/Application.mk", "GSTREAMER_JAVA_SRC_DIR=src", "GSTREAMER_ROOT_ANDROID=$gstRoot", "GSTREAMER_ASSETS_DIR=src/assets", "NNSTREAMER_ROOT=$nnsRoot"
 
                 targets "nnstreamer-native"
 

--- a/api/android/api/jni/Android.mk
+++ b/api/android/api/jni/Android.mk
@@ -19,8 +19,8 @@ endif
 #------------------------------------------------------
 # external libs
 #------------------------------------------------------
-include $(LOCAL_PATH)/Android-tensorflow-lite.mk
-#include $(LOCAL_PATH)/Android-tensorflow-lite-prebuilt.mk
+#include $(LOCAL_PATH)/Android-tensorflow-lite.mk
+include $(LOCAL_PATH)/Android-tensorflow-lite-prebuilt.mk
 
 #------------------------------------------------------
 # nnstreamer

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+##
+# @file  build-android-lib.sh
+# @brief A script to build NNStreamer API library for Android
+#
+# Before running this script, below variables must be set.
+# - ANDROID_HOME: Android SDK
+# - GSTREAMER_ROOT_ANDROID: GStreamer prebuilt libraries for Android
+# - NNSTREAMER_ROOT: NNStreamer root directory
+#
+
+# Function to check if a package is installed
+function check_package() {
+    which "$1" 2>/dev/null || {
+        echo "Need to install $1."
+        exit 1
+    }
+}
+
+# Check required packages
+check_package svn
+
+# Android SDK (Set your own path)
+[ -z "$ANDROID_HOME" ] && echo "Need to set ANDROID_HOME." && exit 1
+
+echo "Android SDK: $ANDROID_HOME"
+
+# GStreamer prebuilt libraries for Android
+# Download from https://gstreamer.freedesktop.org/data/pkg/android/
+[ -z "$GSTREAMER_ROOT_ANDROID" ] && echo "Need to set GSTREAMER_ROOT_ANDROID." && exit 1
+
+echo "GStreamer binaries: $GSTREAMER_ROOT_ANDROID"
+
+# NNStreamer root directory
+[ -z "$NNSTREAMER_ROOT" ] && echo "Need to set NNSTREAMER_ROOT." && exit 1
+
+echo "NNStreamer root directory: $NNSTREAMER_ROOT"
+
+echo "Start to build NNStreamer library for Android."
+
+# Modify header for Android
+cd $NNSTREAMER_ROOT/api/capi
+./modify_nnstreamer_h_for_nontizen.sh
+cd $NNSTREAMER_ROOT
+
+# Make directory to build NNStreamer library
+mkdir -p build_android_lib
+
+# Copy the files (native and java to build Android library) to build directory
+cp -r $NNSTREAMER_ROOT/api/android/* ./build_android_lib
+
+# Get the prebuilt libraries and build-script
+svn --force export https://github.com/nnsuite/nnstreamer-android-resource/trunk/android_api ./build_android_lib
+
+pushd ./build_android_lib
+
+tar xJf ./ext-files/ext-files.tar.xz -C ./api
+tar xJf ./ext-files/tensorflow-lite_arm64.tar.xz -C ./api/jni
+tar xJf ./ext-files/tensorflow-lite_armv7.tar.xz -C ./api/jni
+tar xJf ./ext-files/tensorflow-lite_x86.tar.xz -C ./api/jni
+tar xJf ./ext-files/tensorflow-lite_x86_64.tar.xz -C ./api/jni
+
+echo "Starting gradle build for Android library."
+./gradlew api:assembleRelease
+
+popd
+
+# Check if build procedure is done.
+nnstreamer_android_api_lib=./build_android_lib/api/build/outputs/aar/api-release.aar
+result_directory=android_lib
+
+if [[ -e $nnstreamer_android_api_lib ]]; then
+    echo "Build procedure is done, copy NNStreamer library to $result_directory directory."
+    mkdir -p $result_directory
+    cp $nnstreamer_android_api_lib ./$result_directory/nnstreamer-api-$(date '+%Y-%m-%d').aar
+else
+    echo "Failed to build NNStreamer library."
+fi
+
+# Remove build directory
+rm -rf build_android_lib
+


### PR DESCRIPTION
Add script to build android-api library.
If runs this script, ext-files are downloaded and run gradle build.

TODO add repo for ext-files (or another way to get ext-files)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
