### PR TITLE
[Tests] Apply bash script formatter to all runTest.sh files

### DIFF
--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Mar 06 2019
 ## @brief SSAT Test Cases for NNStreamer/Codegen
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -21,7 +20,7 @@ testInit $1
 PATH_TO_PLUGIN="../../build"
 pwd=$(pwd)
 rm -f nnstreamer.pc
-cat <<EOF > nnstreamer.pc
+cat <<EOF >nnstreamer.pc
 Name: nnstreamer
 Description: temporary nnstreamer pkgconfig for unittesting during build
 Version: 0.1.2
@@ -30,26 +29,25 @@ Libs: -L${pwd}/../../build/gst/nnstreamer -lnnstreamer
 Cflags: -I${pwd}/../../gst/nnstreamer
 EOF
 
-function do_test {
-rm -f tc${1}.c
-rm -f meson.build
+function do_test() {
+    rm -f tc${1}.c
+    rm -f meson.build
 
-cat <<EOF | python ../../tools/development/nnstreamerCodeGenCustomFilter.py
+    cat <<EOF | python ../../tools/development/nnstreamerCodeGenCustomFilter.py
 testcase${1}
 tc${1}
 ${2}
 ${3}
 EOF
 
-testResult $? TC${1} "CodeGen of ${2}/${3} case" 0 1
+    testResult $? TC${1} "CodeGen of ${2}/${3} case" 0 1
 
-rm -rf build${1}
-PKG_CONFIG_PATH=.:$PKG_CONFIG_PATH meson build${1} && ninja -C build${1}
-testResult $? TC${1}C "Build codegen result of TC1 (${2}/${3} case)" 0 1
+    rm -rf build${1}
+    PKG_CONFIG_PATH=.:$PKG_CONFIG_PATH meson build${1} && ninja -C build${1}
+    testResult $? TC${1}C "Build codegen result of TC1 (${2}/${3} case)" 0 1
 
-gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! tensor_filter framework=custom model=\"build${1}/libtc${1}.so\" ! fakesink" TC${1}R "Run gst-launch for TC${1}" 0 0 $PERFORMANCE
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! tensor_filter framework=custom model=\"build${1}/libtc${1}.so\" ! fakesink" TC${1}R "Run gst-launch for TC${1}" 0 0 $PERFORMANCE
 }
-
 
 do_test 01 y y
 do_test 02 y n

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -5,27 +5,25 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python generateGoldenTestResult.py
-  sopath=$1
+    echo "Test Case Generation Started"
+    python generateGoldenTestResult.py
+    sopath=$1
 fi
 convertBMP2PNG
 
@@ -47,10 +45,10 @@ callCompareTest testcase01.gray8.golden test.gray8.log 1-3 "Gray8 Golden Test" 1
 ## @param $2 Width
 ## @param $3 Height
 ## @param $4 Test Case Number
-function do_test {
-	gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase02_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! tensor_converter silent=TRUE ! filesink location=\"testcase02_${1}_${2}x${3}.log\" sync=true" ${4} 0 0 $PERFORMANCE
+function do_test() {
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase02_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! tensor_converter silent=TRUE ! filesink location=\"testcase02_${1}_${2}x${3}.log\" sync=true" ${4} 0 0 $PERFORMANCE
 
-	callCompareTest testcase02_${1}_${2}x${3}.golden testcase02_${1}_${2}x${3}.log ${4} "PNG Golden Testing ${4}" 1 0
+    callCompareTest testcase02_${1}_${2}x${3}.golden testcase02_${1}_${2}x${3}.log ${4} "PNG Golden Testing ${4}" 1 0
 }
 
 do_test BGRx 640 480 2-1

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,19 +19,18 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python generateGoldenTestResult.py
-  python ../nnstreamer_converter/generateGoldenTestResult.py 8
-  sopath=$1
+    echo "Test Case Generation Started"
+    python generateGoldenTestResult.py
+    python ../nnstreamer_converter/generateGoldenTestResult.py 8
+    sopath=$1
 fi
 convertBMP2PNG
 
-function do_test {
+function do_test() {
     param="${4}_gen_golden_data"
     gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=testcase01_${1}_${2}x${3}.png ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=${1},width=${2},height=${3},framerate=0/1 ! filesink location=\"testcase01_${1}_${2}x${3}.golden.raw\" sync=true" $param 0 0 $PERFORMANCE
 

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 

--- a/tests/nnstreamer_decoder_image_labeling/runTest.sh
+++ b/tests/nnstreamer_decoder_image_labeling/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -24,46 +23,45 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-	check=$(ls ${ini_path} | grep tensorflow-lite.so)
-	if [[ ! $check ]]; then
-	    echo "Cannot find tensorflow-lite shared lib"
-	    report
-	    exit
-	fi
+        check=$(ls ${ini_path} | grep tensorflow-lite.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find tensorflow-lite shared lib"
+            report
+            exit
+        fi
     else
-	echo "Cannot find ${ini_path}"
+        echo "Cannot find ${ini_path}"
     fi
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_file})
-	key=${path%=*}
-	value=${path##*=}
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
 
-	if [[ $key != "filters" ]]
-	then
-	    echo "String Error"
-	    report
-	    exit
-	fi
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
 
-	if [[ -d ${value} ]]; then
-	    check=$(ls ${value} | grep tensorflow-lite.so)
-	    if [[ ! $check ]]; then
-		echo "Cannot find tensorflow-lite shared lib"
-		report
-		exit
-	    fi
-	else
-	    echo "Cannot file ${value}"
-	    report
-	    exit
-	fi
-	else
-	    echo "Cannot identify nnstreamer.ini"
-	    report
-	    exit
-	fi
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep tensorflow-lite.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find tensorflow-lite shared lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot file ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
 fi
 
 # Decoding 'orange' tests
@@ -85,14 +83,13 @@ t. ! queue ! tensor_transform mode=typecast option=float32 ! tensor_decoder mode
 t. ! queue ! tensor_transform mode=typecast option=float64 ! tensor_decoder mode=image_labeling option1=\"${PATH_TO_LABEL}\" ! filesink location=\"tensordecoder.orange.double.log\"" D1 0 0 $PERFORMANCE
 let i=1
 for result in tensordecoder.orange.*.log; do
-	label=$(cat "${result}")
-	if [ "$label" == "orange" ]
-	then
-		testResult 1 D1-${i} "Decoding Orange"
-	else
-		testResult 0 D1-${i} "Decoding Orange"
-	fi
-	let i++
+    label=$(cat "${result}")
+    if [ "$label" == "orange" ]; then
+        testResult 1 D1-${i} "Decoding Orange"
+    else
+        testResult 0 D1-${i} "Decoding Orange"
+    fi
+    let i++
 done
 
 report

--- a/tests/nnstreamer_demux/runTest.sh
+++ b/tests/nnstreamer_demux/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 10
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 10
+    sopath=$1
 fi
 convertBMP2PNG
 
@@ -45,7 +43,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_mux name=mux ! tensor_demux
 callCompareTest testcase.golden demux03_0.log 3_0 "Golden Test 3-0" 1 0
 callCompareTest testcase.golden demux03_1.log 3_1 "Golden Test 3-1" 1 0
 callCompareTest testcase.golden demux03_2.log 3_2 "Golden Test 3-2" 1 0
-
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_mux name=mux ! tensor_demux name=demux multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 demux.src_0 ! queue ! filesink location=demux04.log" 4 0 0 $PERFORMANCE
 
@@ -78,7 +75,7 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_mux name=mux ! tensor_demux
 callCompareTest testcase.golden demux09_0.log 9_0 "Golden Test 9-0" 1 0
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_mux name=mux ! tensor_demux name=demux tensorpick=1 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_1 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_2 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_3 demux. ! queue ! filesink location=demux10_0.log" 10 0 0 $PERFORMANCE
-callCompareTest testcase_stream.golden demux10_0.log 10_0  "Golden Test 10-0" 1 0
+callCompareTest testcase_stream.golden demux10_0.log 10_0 "Golden Test 10-0" 1 0
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_mux name=mux ! tensor_demux name=demux tensorpick=2 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_0 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_1 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_2 multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! mux.sink_3 demux. ! queue ! filesink location=demux11_0.log" 11 0 0 $PERFORMANCE
 callCompareTest testcase_stream.golden demux11_0.log 11_0 "Golden Test 11-0" 1 0

--- a/tests/nnstreamer_filter_caffe2/runTest.sh
+++ b/tests/nnstreamer_filter_caffe2/runTest.sh
@@ -6,12 +6,12 @@
 ## @brief SSAT Test Cases for NNStreamer
 ##
 
-if [[ "$SSATAPILOADED" != "1" ]];then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -24,45 +24,44 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-	check=$(ls ${ini_path} | grep caffe2.so)
-	if [[ ! $check ]]; then
-	    echo "Cannot find caffe2 shared lib"
-	    report
-	    exit
-	fi
+        check=$(ls ${ini_path} | grep caffe2.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find caffe2 shared lib"
+            report
+            exit
+        fi
     else
-	echo "Cannot find ${ini_path}"
+        echo "Cannot find ${ini_path}"
     fi
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_file})
-	key=${path%=*}
-	value=${path##*=}
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
 
-	if [[ $key != "filters" ]]
-	then
-	    echo "String Error"
-	    report
-	    exit
-	fi
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
 
-	if [[ -d ${value} ]]; then
-	    check=$(ls ${value} | grep caffe2.so)
-	    if [[ ! $check ]]; then
-		echo "Cannot find caffe2 shared lib"
-		report
-		exit
-	    fi
-	else
-	    echo "Cannot file ${value}"
-	    report
-	    exit
-	fi
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep caffe2.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find caffe2 shared lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot file ${value}"
+            report
+            exit
+        fi
     else
-		echo "Cannot identify nnstreamer.ini"
-		report
-		exit
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
     fi
 fi
 

--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -22,28 +21,24 @@ PATH_TO_PLUGIN="../../build"
 
 # Test for opencv installed, enable OPENCV test if opencv is found
 TEST_OPENCV="NO"
-/sbin/ldconfig -p | grep opencv > /dev/null 2>&1
-if [[ "$?" == 0 ]]
-then
-  TEST_OPENCV="YES"
+/sbin/ldconfig -p | grep opencv >/dev/null 2>&1
+if [[ "$?" == 0 ]]; then
+    TEST_OPENCV="YES"
 fi
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 8
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 8
 fi
 convertBMP2PNG
 
 # Test gst availability. (0)
 gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! filesink location=\"testcase02.apitest.log\" sync=true" 0 0 0 $PERFORMANCE
 
-
 # Test constant passthrough custom filter (1, 2)
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so"
 else
     PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough.so"
@@ -57,10 +52,8 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/
 
 callCompareTest testcase02.direct.log testcase02.passthrough.log 2 "Compare 2" 0 0
 
-
 # Test variable-dim passthrough custom filter (3, 4)
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     PATH_TO_MODEL_V="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so"
 else
     PATH_TO_MODEL_V="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough_variable.so"
@@ -81,8 +74,7 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=mux ! tee name=t ! 
 callCompareTest testcase04.tensors.direct.log testcase04.tensors.passthrough.log 4-4 "Compare 4-4" 0 0
 
 # Test scaler (5, 6, 7)
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     PATH_TO_MODEL_S="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler.so"
 else
     PATH_TO_MODEL_S="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler.so"
@@ -99,8 +91,7 @@ python checkScaledTensor.py testcase07.direct.log 640 480 testcase07.scaled.log 
 testResult $? 7 "Golden test comparison" 0 1
 
 # Test average (8)
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
 else
     PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
@@ -111,14 +102,11 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/
 # Apply average to stream (9)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase09.average.log\" sync=true t. ! queue ! filesink location=\"testcase09.direct.log\" sync=true" 9 0 0 $PERFORMANCE
 
-
 # Apply scaler to stream (10)
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_S}\" custom=\"8x8\" ! filesink location=\"testcase10.average.log\" sync=true t. ! queue ! filesink location=\"testcase10.direct.log\" sync=true" 10 0 0 $PERFORMANCE
 
-
 # Test scaler + in-invoke allocator (11)
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     PATH_TO_MODEL_SI="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler_allocator.so"
 else
     PATH_TO_MODEL_SI="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler_allocator.so"
@@ -130,54 +118,48 @@ testResult $? 11 "Golden test comparison" 0 1
 
 # OpenCV Test
 # Test scaler using OpenCV (12, 13, 14)
-if [ "$TEST_OPENCV" == "YES" ]
-then
-    if [[ -z "${CUSTOMLIB_DIR// }" ]]
-    then
-	PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.so"
+if [ "$TEST_OPENCV" == "YES" ]; then
+    if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
+        PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.so"
     else
-	PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_scaler.so"
+        PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_scaler.so"
     fi
 
     # Verify that opencv tests were build before running them
-    if [ -e $PATH_TO_MODEL ]
-    then
-      echo "Running OPENCV"
-      gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"640x480\" ! filesink location=\"testcase12.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase12.direct.log\" sync=true" 12 0 0 $PERFORMANCE
-      callCompareTest testcase12.direct.log testcase12.passthrough.log 12 "Compare 12" 0 0
+    if [ -e $PATH_TO_MODEL ]; then
+        echo "Running OPENCV"
+        gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"640x480\" ! filesink location=\"testcase12.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase12.direct.log\" sync=true" 12 0 0 $PERFORMANCE
+        callCompareTest testcase12.direct.log testcase12.passthrough.log 12 "Compare 12" 0 0
 
-      gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"320x240\" ! filesink location=\"testcase13.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase13.direct.log\" sync=true" 13 0 0 $PERFORMANCE
-      python checkScaledTensor.py testcase13.direct.log 640 480 testcase13.scaled.log 320 240 3
-      testResult $? 13 "Golden test comparison" 0 1
+        gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"320x240\" ! filesink location=\"testcase13.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase13.direct.log\" sync=true" 13 0 0 $PERFORMANCE
+        python checkScaledTensor.py testcase13.direct.log 640 480 testcase13.scaled.log 320 240 3
+        testResult $? 13 "Golden test comparison" 0 1
 
-      gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"1920x1080\" ! filesink location=\"testcase14.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase14.direct.log\" sync=true" 14 0 0 $PERFORMANCE
-      python checkScaledTensor.py testcase14.direct.log 640 480 testcase14.scaled.log 1920 1080 3
-      testResult $? 14 "Golden test comparison" 0 1
+        gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" custom=\"1920x1080\" ! filesink location=\"testcase14.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase14.direct.log\" sync=true" 14 0 0 $PERFORMANCE
+        python checkScaledTensor.py testcase14.direct.log 640 480 testcase14.scaled.log 1920 1080 3
+        testResult $? 14 "Golden test comparison" 0 1
     fi
 
     # Test average using OpenCV (15)
     # custom version
-    if [[ -z "${CUSTOMLIB_DIR// }" ]]
-    then
-	PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+    if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
+        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
     else
-	PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
+        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
     fi
     gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.average.log\" sync=true" 15 0 0 $PERFORMANCE
 
     # OpenCV version
-    if [[ -z "${CUSTOMLIB_DIR// }" ]]
-    then
-	PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.so"
+    if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
+        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.so"
     else
-	PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_average.so"
+        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_average.so"
     fi
 
-    if [ -e $PATH_TO_MODEL_A ]
-    then
-      gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.opencv.average.log\" sync=true" 15 0 0 $PERFORMANCE
+    if [ -e $PATH_TO_MODEL_A ]; then
+        gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.opencv.average.log\" sync=true" 15 0 0 $PERFORMANCE
 
-      callCompareTest testcase15.opencv.average.log testcase15.average.log 15 "Compare 15" 0 0
+        callCompareTest testcase15.opencv.average.log testcase15.average.log 15 "Compare 15" 0 0
     fi
 fi
 

--- a/tests/nnstreamer_filter_python/runTest.sh
+++ b/tests/nnstreamer_filter_python/runTest.sh
@@ -6,12 +6,12 @@
 ## @brief SSAT Test Cases for NNStreamer
 ##
 
-if [[ "$SSATAPILOADED" != "1" ]];then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -21,22 +21,22 @@ testInit $1
 PATH_TO_PLUGIN="../../build"
 # Check python libraies are built
 if [[ -d $PATH_TO_PLUGIN ]]; then
-  ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
-  if [[ -d ${ini_path} ]]; then
-    check=$(ls ${ini_path} | grep python2.so)
-    if [[ ! $check ]]; then
-      echo "Cannot find python shared lib"
-      report
-      exit
+    ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
+    if [[ -d ${ini_path} ]]; then
+        check=$(ls ${ini_path} | grep python2.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find python shared lib"
+            report
+            exit
+        fi
+    else
+        echo "Cannot find ${ini_path}"
+        report exit
     fi
-  else
-    echo "Cannot find ${ini_path}"
-    report exit
-  fi
 else
-  echo "No build directory"
-  report
-  exit
+    echo "No build directory"
+    report
+    exit
 fi
 
 FRAMEWORK="python2"

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -5,13 +5,12 @@
 ## @date May 7th 2019
 ## @brief SSAT Test Cases for NNStreamer pytorch plugin
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -26,46 +25,45 @@ PATH_TO_IMAGE="img/9.png"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-	check=$(ls ${ini_path} | grep pytorch.so)
-	if [[ ! $check ]]; then
-	    echo "Cannot find pytorch shared lib"
-	    report
-	    exit
-	fi
+        check=$(ls ${ini_path} | grep pytorch.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find pytorch shared lib"
+            report
+            exit
+        fi
     else
-	echo "Cannot find ${ini_path}"
+        echo "Cannot find ${ini_path}"
     fi
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_file})
-	key=${path%=*}
-	value=${path##*=}
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
 
-	if [[ $key != "filters" ]]
-	then
-	    echo "String Error"
-	    report
-	    exit
-	fi
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
 
-	if [[ -d ${value} ]]; then
-	    check=$(ls ${value} | grep pytorch.so)
-	    if [[ ! $check ]]; then
-		echo "Cannot find pytorch shared lib"
-		report
-		exit
-	    fi
-	else
-	    echo "Cannot file ${value}"
-	    report
-	    exit
-	fi
-	else
-		echo "Cannot identify nnstreamer.ini"
-		report
-		exit
-	fi
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep pytorch.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find pytorch shared lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot file ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=GRAY8,framerate=0/1 ! tensor_converter ! tensor_filter framework=pytorch model=${PATH_TO_MODEL} input=1:28:28:1 inputtype=uint8 output=10:1:1:1 outputtype=uint8 ! filesink location=tensorfilter.out.log" 1 0 0 $PERFORMANCE

--- a/tests/nnstreamer_filter_tensorflow/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow/runTest.sh
@@ -6,12 +6,12 @@
 ## @brief SSAT Test Cases for NNStreamer
 ##
 
-if [[ "$SSATAPILOADED" != "1" ]];then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -24,46 +24,45 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-	check=$(ls ${ini_path} | grep tensorflow.so)
-	if [[ ! $check ]]; then
-	    echo "Cannot find tensorflow shared lib"
-	    report
-	    exit
-	fi
+        check=$(ls ${ini_path} | grep tensorflow.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find tensorflow shared lib"
+            report
+            exit
+        fi
     else
-	echo "Cannot find ${ini_path}"
+        echo "Cannot find ${ini_path}"
     fi
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_file})
-	key=${path%=*}
-	value=${path##*=}
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
 
-	if [[ $key != "filters" ]]
-	then
-	    echo "String Error"
-	    report
-	    exit
-	fi
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
 
-	if [[ -d ${value} ]]; then
-	    check=$(ls ${value} | grep tensorflow.so)
-	    if [[ ! $check ]]; then
-		echo "Cannot find tensorflow shared lib"
-		report
-		exit
-	    fi
-	else
-	    echo "Cannot file ${value}"
-	    report
-	    exit
-	fi
-	else
-		echo "Cannot identify nnstreamer.ini"
-		report
-		exit
-	fi
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep tensorflow.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find tensorflow shared lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot file ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
 fi
 
 # Test with mnist model

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -24,46 +23,45 @@ PATH_TO_PLUGIN="../../build"
 if [[ -d $PATH_TO_PLUGIN ]]; then
     ini_path="${PATH_TO_PLUGIN}/ext/nnstreamer/tensor_filter"
     if [[ -d ${ini_path} ]]; then
-	check=$(ls ${ini_path} | grep tensorflow-lite.so)
-	if [[ ! $check ]]; then
-	    echo "Cannot find tensorflow-lite shared lib"
-	    report
-	    exit
-	fi
+        check=$(ls ${ini_path} | grep tensorflow-lite.so)
+        if [[ ! $check ]]; then
+            echo "Cannot find tensorflow-lite shared lib"
+            report
+            exit
+        fi
     else
-	echo "Cannot find ${ini_path}"
+        echo "Cannot find ${ini_path}"
     fi
 else
     ini_file="/etc/nnstreamer.ini"
     if [[ -f ${ini_file} ]]; then
-	path=$(grep "^filters" ${ini_file})
-	key=${path%=*}
-	value=${path##*=}
+        path=$(grep "^filters" ${ini_file})
+        key=${path%=*}
+        value=${path##*=}
 
-	if [[ $key != "filters" ]]
-	then
-	    echo "String Error"
-	    report
-	    exit
-	fi
+        if [[ $key != "filters" ]]; then
+            echo "String Error"
+            report
+            exit
+        fi
 
-	if [[ -d ${value} ]]; then
-	    check=$(ls ${value} | grep tensorflow-lite.so)
-	    if [[ ! $check ]]; then
-		echo "Cannot find tensorflow-lite shared lib"
-		report
-		exit
-	    fi
-	else
-	    echo "Cannot file ${value}"
-	    report
-	    exit
-	fi
-	else
-		echo "Cannot identify nnstreamer.ini"
-		report
-		exit
-	fi
+        if [[ -d ${value} ]]; then
+            check=$(ls ${value} | grep tensorflow-lite.so)
+            if [[ ! $check ]]; then
+                echo "Cannot find tensorflow-lite shared lib"
+                report
+                exit
+            fi
+        else
+            echo "Cannot file ${value}"
+            report
+            exit
+        fi
+    else
+        echo "Cannot identify nnstreamer.ini"
+        report
+        exit
+    fi
 fi
 
 PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,15 +19,14 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 9
-  python generateTest.py
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 9
+    python generateTest.py
+    sopath=$1
 fi
 convertBMP2PNG
 
@@ -59,7 +57,6 @@ callCompareTest testcase03.golden testcase03.log 6 "Compare 6" 1 0
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_merge name=merge mode=linear option=2 ! filesink location=testcase04.log multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_0 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_1 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_2 multifilesrc location=\"testsequence04_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)30/1\" ! pngdec ! tensor_converter ! merge.sink_3" 7 0 0 $PERFORMANCE
 
 callCompareTest testcase03.golden testcase03.log 7 "Compare 7" 1 0
-
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN}  tensor_merge name=merge mode=linear option=0 ! filesink location=channel.log filesrc location=channel_00.dat blocksize=60000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=3:50:100:1 input-type=float32 ! merge.sink_0 filesrc location=channel_01.dat blocksize=40000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=2:50:100:1 input-type=float32 ! merge.sink_1 filesrc location=channel_02.dat blocksize=80000 num_buffers=1 ! application/octet-stream ! tensor_converter input-dim=4:50:100:1 input-type=float32 ! merge.sink_2" 8 0 0 $PERFORMANCE
 

--- a/tests/nnstreamer_mux/runTest.sh
+++ b/tests/nnstreamer_mux/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 9
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 9
+    sopath=$1
 fi
 convertBMP2PNG
 
@@ -178,7 +176,6 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} tensor_mux name=tensors_mux sync_mo
         tensor_converter ! tensor_mux1.sink_0 \
     multifilesrc location=\"testsequence03_%1d.png\" index=0 caps=\"image/png, framerate=(fraction)20/1\" ! pngdec ! \
         tensor_converter ! tensor_mux1.sink_1" 18 0 0 $PERFORMANCE
-
 
 callCompareTest testsynch18_0.golden testsynch18_0.log 18-1 "Compare 18-1" 1 0
 callCompareTest testsynch18_1.golden testsynch18_1.log 18-2 "Compare 18-2" 1 0

--- a/tests/nnstreamer_repo/runTest.sh
+++ b/tests/nnstreamer_repo/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 12
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 12
+    sopath=$1
 fi
 convertBMP2PNG
 

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,19 +19,17 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 12
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 12
+    sopath=$1
 fi
 convertBMP2PNG
 
-if [[ -z "${UNITTEST_DIR// }" ]]
-then
+if [[ -z "${UNITTEST_DIR// /}" ]]; then
     TESTBINDIR="../../build/tests/"
 else
     TESTBINDIR="${UNITTEST_DIR}"
@@ -50,6 +47,5 @@ callCompareTest testsequence_7.golden tensorsequence01_7.log 1-7 "Compare 1-7" 1
 callCompareTest testsequence_8.golden tensorsequence01_8.log 1-8 "Compare 1-8" 1 0
 callCompareTest testsequence_9.golden tensorsequence01_9.log 1-9 "Compare 1-9" 1 0
 callCompareTest testsequence_10.golden tensorsequence01_10.log 1-10 "Compare 1-10" 1 0
-
 
 report

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -21,22 +21,17 @@
 ##                       +-------+    +--------+    +-------+  -->out_%1d.log
 ##
 
-
-
-
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 testInit $1 # You may replace this with Test Group Name
 
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     LSTM_DIR="../../build/nnstreamer_example/custom_example_LSTM"
 else
     LSTM_DIR="${CUSTOMLIB_DIR}"

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -6,19 +6,17 @@
 ## @date Nov 01 2018
 ## @brief This is a template file for SSAT test cases. You may designate your own license.
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 testInit $1 # You may replace this with Test Group Name
 
-if [[ -z "${CUSTOMLIB_DIR// }" ]]
-then
+if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
     RNN_DIR="../../build/nnstreamer_example/custom_example_RNN"
 else
     RNN_DIR="${CUSTOMLIB_DIR}"

--- a/tests/nnstreamer_split/runTest.sh
+++ b/tests/nnstreamer_split/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 11
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 11
+    sopath=$1
 fi
 convertBMP2PNG
 

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 8
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 8
+    sopath=$1
 fi
 convertBMP2PNG
 

--- a/tests/transform_dimchg/runTest.sh
+++ b/tests/transform_dimchg/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 8
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 8
+    sopath=$1
 fi
 convertBMP2PNG
 

--- a/tests/transform_stand/runTest.sh
+++ b/tests/transform_stand/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python generateTest.py
-  sopath=$1
+    echo "Test Case Generation Started"
+    python generateTest.py
+    sopath=$1
 fi
 
 # Test gst availability. (0)

--- a/tests/transform_transpose/runTest.sh
+++ b/tests/transform_transpose/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python generateTest.py
-  sopath=$1
+    echo "Test Case Generation Started"
+    python generateTest.py
+    sopath=$1
 fi
 
 # Test gst availability. (0)

--- a/tests/transform_typecast/runTest.sh
+++ b/tests/transform_typecast/runTest.sh
@@ -5,13 +5,12 @@
 ## @date Nov 01 2018
 ## @brief SSAT Test Cases for NNStreamer
 ##
-if [[ "$SSATAPILOADED" != "1" ]]
-then
-	SILENT=0
-	INDEPENDENT=1
-	search="ssat-api.sh"
-	source $search
-	printf "${Blue}Independent Mode${NC}
+if [[ "$SSATAPILOADED" != "1" ]]; then
+    SILENT=0
+    INDEPENDENT=1
+    search="ssat-api.sh"
+    source $search
+    printf "${Blue}Independent Mode${NC}
 "
 fi
 
@@ -20,14 +19,13 @@ testInit $1
 
 PATH_TO_PLUGIN="../../build"
 
-if [ "$SKIPGEN" == "YES" ]
-then
-  echo "Test Case Generation Skipped"
-  sopath=$2
+if [ "$SKIPGEN" == "YES" ]; then
+    echo "Test Case Generation Skipped"
+    sopath=$2
 else
-  echo "Test Case Generation Started"
-  python ../nnstreamer_converter/generateGoldenTestResult.py 8
-  sopath=$1
+    echo "Test Case Generation Started"
+    python ../nnstreamer_converter/generateGoldenTestResult.py 8
+    sopath=$1
 fi
 convertBMP2PNG
 
@@ -54,24 +52,20 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 python checkResult.py typecast testcase03.direct.log testcase03.typecast.log uint8 1 B int8 1 b
 testResult $? 3 "Golden test comparison" 0 1
 
-
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=BGRx ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=typecast option=uint32 ! tensor_transform mode=typecast option=uint8 ! filesink location=\"testcase04.typecast.log\" sync=true t. ! queue ! filesink location=\"testcase04.direct.log\" sync=true" 4 0 0 $PERFORMANCE
 # uint8 -> uint32 -> uint8
 python checkResult.py typecast testcase04.direct.log testcase04.typecast.log uint8 1 B uint8 1 B
 testResult $? 4 "Golden test comparison" 0 1
-
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=BGRx ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=typecast option=float32 ! filesink location=\"testcase05.typecast.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5 0 0 $PERFORMANCE
 # uint8 -> float32
 python checkResult.py typecast testcase05.direct.log testcase05.typecast.log uint8 1 B float32 4 f
 testResult $? 5 "Golden test comparison" 0 1
 
-
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=BGRx ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=typecast option=float64 ! filesink location=\"testcase06.typecast.log\" sync=true t. ! queue ! filesink location=\"testcase06.direct.log\" sync=true" 6 0 0 $PERFORMANCE
 # uint8 -> float64
 python checkResult.py typecast testcase06.direct.log testcase06.typecast.log uint8 1 B float64 8 d
 testResult $? 6 "Golden test comparison" 0 1
-
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequence_%1d.png\" index=0 caps=\"image/png,framerate=\(fraction\)30/1\" ! pngdec ! videoconvert ! video/x-raw, format=BGRx ! tensor_converter ! tee name=t ! queue ! tensor_transform mode=typecast option=int8 ! tensor_transform mode=typecast option=float32 ! tensor_transform mode=typecast option=float64 ! tensor_transform mode=typecast option=int64 ! tensor_transform mode=typecast option=uint8 ! filesink location=\"testcase07.typecast.log\" sync=true t. ! queue ! filesink location=\"testcase07.direct.log\" sync=true" 7 0 0 $PERFORMANCE
 # uint8 -> int8 -> float32 -> float64 -> int64 -> uint8


### PR DESCRIPTION
In order to improve readability, this patch applies a bash shell script formatter named 'shfmt' [1] to all runTest.sh files in the ./tests directory. Note that 4 spaces are used for indentation instead of using
'tab'.

[1] https://github.com/mvdan/sh

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped