### PR TITLE
[Api/Pipeline] element restriction

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -236,6 +236,7 @@ if get_option('enable-test')
   nnstreamer_test_conf.set('ENABLE_ENV_VAR', true)
   nnstreamer_test_conf.set('ENABLE_SYMBOLIC_LINK', false)
   nnstreamer_test_conf.set('TORCH_USE_GPU', false)
+  nnstreamer_test_conf.set('ELEMENT_RESTRICTION_CONFIG', '')
 
   # meson 0.50 supports install argument in configure_file()
   if get_option('install-test')
@@ -257,6 +258,17 @@ nnstreamer_install_conf.merge_from(nnstreamer_conf)
 nnstreamer_install_conf.set('ENABLE_ENV_VAR', get_option('enable-env-var'))
 nnstreamer_install_conf.set('ENABLE_SYMBOLIC_LINK', get_option('enable-symbolic-link'))
 nnstreamer_install_conf.set('TORCH_USE_GPU', get_option('enable-pytorch-use-gpu'))
+
+# Element restriction
+restriction_config = ''
+
+if get_option('enable-element-restriction')
+  restriction_config = '''[element-restriction]
+enable_element_restriction=True
+restricted_elements=''' + get_option('restricted-elements')
+endif
+
+nnstreamer_install_conf.set('ELEMENT_RESTRICTION_CONFIG', restriction_config)
 
 # Install .ini
 configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer.ini',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,3 +15,5 @@ option('enable-symbolic-link', type: 'boolean', value: true)
 option('enable-capi', type: 'boolean', value: false)
 option('enable-python', type: 'boolean', value: true)
 option('enable-tizen', type: 'boolean', value: false)
+option('enable-element-restriction', type: 'boolean', value: false) # true to restrict gst-elements in api
+option('restricted-elements', type: 'string', value: '')

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -21,3 +21,5 @@ enable_nnapi=False
 # Set 1 or True if you want to use GPU with pytorch for computation.
 [pytorch]
 enable_use_gpu=@TORCH_USE_GPU@
+
+@ELEMENT_RESTRICTION_CONFIG@


### PR DESCRIPTION
Handles element restriction (whitelist for API release)

If needs restriction in pipeline elements, simply set the list in meson option.

e.g. meson -Denable-capi=true -Denable-element-restriction=true -Drestricted-elements='videotestsrc videoconvert' build
this allows videotestsrc and videoconvert with nnstreamer elements.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
