### PR TITLE
[Debian] Use Tensorflow only if it's amd64

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ export NNSTREAMER_FILTERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_filter
 export NNSTREAMER_DECODERS=${ROOT_DIR}/build/ext/nnstreamer/tensor_decoder
 export PYTHONIOENCODING=utf-8
 
-ifneq ($(filter $(DEB_HOST_ARCH),amd64 arm64),)
+ifneq ($(filter $(DEB_HOST_ARCH),amd64),)
 enable_tf=true
 else
 enable_tf=false


### PR DESCRIPTION
If it's ARM, don't use tensorflow.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

#1590 needs this as well.
