### PR TITLE
[Debian] Remove tensorflow-dev build-dep for arm64

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: gcc (>=5), ninja-build, meson (>=0.42),
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,
  python, python-numpy, python3, python3-dev, python3-numpy,
  tensorflow-lite-dev, pytorch,
- tensorflow-dev [amd64 arm64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
+ tensorflow-dev [amd64], python2.7-dev, libprotobuf-dev [amd64 arm64 armhf]
 Standards-Version: 3.9.6
 Homepage: https://github.com/nnsuite/nnstreamer
 
@@ -21,7 +21,7 @@ Description: NNStreamer plugins for Gstreamer
  Gstreamer plugins, "NNStreamer", provides access to neural network frameworks for media streams.
 
 Package: nnstreamer-tensorflow
-Architecture: amd64 arm64
+Architecture: amd64
 Multi-Arch: same
 Depends: nnstreamer, tensorflow | tensorflow-dev, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer TensorFlow Support


### PR DESCRIPTION
We are removing tensorflow-arm64 from our PPA.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


