### PR TITLE
[FILTER] add nnapi property @open sesame 8/18 21:21

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -41,10 +41,15 @@
  * @note	the model of _model_path will be loaded simultaneously
  * @return	Nothing
  */
-TFLiteCore::TFLiteCore (const char * _model_path)
+TFLiteCore::TFLiteCore (const char * _model_path, nnapi_hw hw)
 {
   model_path = _model_path;
-  use_nnapi = nnsconf_get_custom_value_bool ("tensorflowlite", "enable_nnapi", FALSE);
+  if(hw == NNAPI_UNKNOWN){
+    use_nnapi = nnsconf_get_custom_value_bool ("tensorflowlite", "enable_nnapi", FALSE);
+  } else {
+    use_nnapi = TRUE;
+    accel = hw;
+  }
 
   gst_tensors_info_init (&inputTensorMeta);
   gst_tensors_info_init (&outputTensorMeta);
@@ -381,9 +386,9 @@ TFLiteCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
  * @return	TFLiteCore class
  */
 void *
-tflite_core_new (const char * _model_path)
+tflite_core_new (const char * _model_path, nnapi_hw hw)
 {
-  return new TFLiteCore (_model_path);
+  return new TFLiteCore (_model_path, hw);
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -44,7 +44,7 @@
 class TFLiteCore
 {
 public:
-  TFLiteCore (const char * _model_path);
+  TFLiteCore (const char *_model_path, nnapi_hw hw);
   ~TFLiteCore ();
 
   int init ();
@@ -60,6 +60,7 @@ private:
 
   const char *model_path;
   bool use_nnapi;
+  nnapi_hw accel;
 
   GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
   GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
@@ -82,7 +83,7 @@ extern "C"
 {
 #endif
 
-  void *tflite_core_new (const char *_model_path);
+  void *tflite_core_new (const char *_model_path, nnapi_hw hw);
   void tflite_core_delete (void * tflite);
   int tflite_core_init (void * tflite);
   const char *tflite_core_getModelPath (void * tflite);

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -31,6 +31,18 @@ extern "C" {
 #endif
 
 /**
+ * @brief nnapi hw properties.
+ */
+typedef enum
+{
+  NNAPI_CPU = 0,
+  NNAPI_GPU = 1,
+  NNAPI_NPU = 2,
+
+  NNAPI_UNKNOWN
+} nnapi_hw;
+
+/**
  * @brief GstTensorFilter's properties for NN framework (internal data structure)
  *
  * Because custom filters of tensor_filter may need to access internal data
@@ -50,6 +62,8 @@ typedef struct _GstTensorFilterProperties
   GstTensorsInfo output_meta; /**< configured output tensor info */
 
   const char *custom_properties; /**< sub-plugin specific custom property values in string */
+  const char *nnapi;
+
 } GstTensorFilterProperties;
 
 /**

--- a/meson.build
+++ b/meson.build
@@ -211,7 +211,7 @@ if get_option('enable-tizen')
   add_project_arguments('-D__TIZEN__=1', language: ['c', 'cpp'])
 endif
 
-# nnfw
+# nnfw ( details in https://review.tizen.org/gerrit/p/platform/core/ml/nnfw )
 if get_option('enable-nnfw')
     add_project_arguments('-DENABLE_NNFW=1', language: ['c', 'cpp'])
 endif


### PR DESCRIPTION
# PR Description

Add nnapi property in the tensor_filter element.
Use nnapi=(true|false)(:(cpu|gpu|npu)) option for tensor_filter
element. For example,

gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc
location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze !
videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter
! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:gpu ! filesink location=tensorfilter.out.log

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>