### PR TITLE
[gcc9-fix] fix strncpy '__builtin_strncpy' issue @open sesame 8/14 22:00

### DIFF
--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -200,6 +200,7 @@ main (int argc, char *argv[])
   size_t size;
   char byte;
   char header[26];              /** gen24bBMP.py gives you 24B headered bmp file */
+  size_t len;
   int ret;
   char *pngfilename;
   int strn;
@@ -287,8 +288,9 @@ main (int argc, char *argv[])
   }
   fclose (bmpF);
 
-  pngfilename = calloc (strlen (argv[1]) + 1, sizeof (char));
-  strncpy (pngfilename, argv[1], strlen (argv[1]) + 1);
+  len = strlen (argv[1]) + 1;
+  pngfilename = calloc (len, sizeof (char));
+  strncpy (pngfilename, argv[1], len);
 
   /** Assume the last 4 characters are ".bmp" */
   strncpy (pngfilename + strlen (argv[1]) - 4, ".png", 5);


### PR DESCRIPTION
This fixes:

FAILED: tests/59830eb@@bmp2png@exe/bmp2png.c.o
cc -Itests/59830eb@@bmp2png@exe -Itests -I../tests -I/usr/include/libpng16 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=gnu89 '-DVERSION="0.2.1"' -Wredundant-decls -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Waggregate-return -Wold-style-definition -Wdeclaration-after-statement '-DNNSTREAMER_CONF_FILE="/etc/nnstreamer.ini"' -DHAVE_ORC=1 -DENABLE_TENSORFLOW_LITE=1 -DENABLE_PYTORCH=1 -DENABLE_CAFFE2=1 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -MD -MQ 'tests/59830eb@@bmp2png@exe/bmp2png.c.o' -MF 'tests/59830eb@@bmp2png@exe/bmp2png.c.o.d' -o 'tests/59830eb@@bmp2png@exe/bmp2png.c.o' -c ../tests/bmp2png.c
In file included from /usr/include/string.h:494,
                 from ../tests/bmp2png.c:36:
In function ‘strncpy’,
    inlined from ‘main’ at ../tests/bmp2png.c:291:3:
/usr/include/aarch64-linux-gnu/bits/string_fortified.h:106:10: error: ‘__builtin_strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../tests/bmp2png.c: In function ‘main’:
../tests/bmp2png.c:291:34: note: length computed here
  291 |   strncpy (pngfilename, argv[1], strlen (argv[1]) + 1);
      |                                  ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

This is Case 3 of #1598

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



