### PR TITLE
[CAPI/Unittest] 3s timout too short for emul @open sesame 8/14 22:00

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -427,7 +427,7 @@ ml_single_invoke (ml_single_h single,
 #if (GST_VERSION_MAJOR > 1 || (GST_VERSION_MAJOR == 1 && GST_VERSION_MINOR >= 10))
   /* gst_app_sink_try_pull_sample() is available at gstreamer-1.10 */
   sample =
-      gst_app_sink_try_pull_sample (GST_APP_SINK (single_h->sink), GST_SECOND * 3);
+      gst_app_sink_try_pull_sample (GST_APP_SINK (single_h->sink), GST_SECOND * 5);
 #else
   sample = gst_app_sink_pull_sample (GST_APP_SINK (single_h->sink));
 #endif


### PR DESCRIPTION
In launchpad emulator, 3s is not enough.

1. We may need to consider having much longer for Ubuntu...
2. In the future, let the user configure the timeout.

This is for a few cases of #1598

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

CC: @again4you @helloahn @jaeyun-jung 