### PR TITLE
[Test/bmp2png] Use g_strdup to avoid gcc9 strict checks [Need CI-Server apt update]

### DIFF
--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <glib.h>
 
 typedef enum
 {
@@ -200,7 +201,6 @@ main (int argc, char *argv[])
   size_t size;
   char byte;
   char header[26];              /** gen24bBMP.py gives you 24B headered bmp file */
-  size_t len;
   int ret;
   char *pngfilename;
   int strn;
@@ -288,9 +288,7 @@ main (int argc, char *argv[])
   }
   fclose (bmpF);
 
-  len = strlen (argv[1]) + 1;
-  pngfilename = calloc (len, sizeof (char));
-  strncpy (pngfilename, argv[1], len);
+  pngfilename = g_strdup (argv[1]);
 
   /** Assume the last 4 characters are ".bmp" */
   strncpy (pngfilename + strlen (argv[1]) - 4, ".png", 5);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,7 +18,7 @@ libpng_dep = dependency('libpng', required: false)
 if libpng_dep.found()
   b2p = executable('bmp2png',
     'bmp2png.c',
-    dependencies: [libpng_dep],
+    dependencies: [libpng_dep, glib_dep],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
   )


### PR DESCRIPTION
strncpy is required not to use strlen for the length.
Use g_strdup and let glib handle it.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


Fixes #1598 
(EOAN fix)
