### PR TITLE
Support macOS (High Sierra)

### DIFF
--- a/gst/nnstreamer/nnstreamer.c
+++ b/gst/nnstreamer/nnstreamer.c
@@ -57,7 +57,9 @@
 #include "tensor_repo/tensor_reposink.h"
 #include "tensor_repo/tensor_reposrc.h"
 #include "tensor_sink/tensor_sink.h"
+#if defined(__gnu_linux__) && !defined(__ANDROID__)
 #include "tensor_source/tensor_src_iio.h"
+#endif /* __gnu_linux__ && !__ANDROID__ */
 #include "tensor_split/gsttensorsplit.h"
 #include "tensor_transform/tensor_transform.h"
 
@@ -85,9 +87,11 @@ gst_nnstreamer_init (GstPlugin * plugin)
   NNSTREAMER_INIT (plugin, reposink, REPOSINK);
   NNSTREAMER_INIT (plugin, reposrc, REPOSRC);
   NNSTREAMER_INIT (plugin, sink, SINK);
-  NNSTREAMER_INIT (plugin, src_iio, SRC_IIO);
   NNSTREAMER_INIT (plugin, split, SPLIT);
   NNSTREAMER_INIT (plugin, transform, TRANSFORM);
+#if defined(__gnu_linux__) && !defined(__ANDROID__)
+  NNSTREAMER_INIT (plugin, src_iio, SRC_IIO);
+#endif /* __gnu_linux__ && !__ANDROID__ */
   return TRUE;
 }
 

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -125,14 +125,14 @@ _validate_file (nnsconf_type_path type, const gchar * fullpath)
 }
 
 /**
- * @brief Private function to fill in ".so list" with fullpath-filenames in a directory.
+ * @brief Private function to fill in ".so/.dylib list" with fullpath-filenames in a directory.
  * @param[in] type conf type to scan.
  * @param[in] dir Directory to be searched.
  * @param[in/out] listF The fullpath list to be updated.
  * @param[in/out] listB The basename list to be updated.
  * @param[in/out] counter increased by the number of appended elements.
  * @return True if successfully updated.
- * @todo This assumes .so for all sub plugins. Support Windows/Mac/iOS!
+ * @todo This assumes .so/.dylib for all sub plugins. Support Windows!
  */
 static gboolean
 _get_filenames (nnsconf_type_path type, const gchar * dir, GSList ** listF,
@@ -146,9 +146,9 @@ _get_filenames (nnsconf_type_path type, const gchar * dir, GSList ** listF,
     return FALSE;
 
   while (NULL != (name = g_dir_read_name (gdir))) {
-    /* check file prefix for given type, handle .so only. */
+    /* check file prefix for given type, currently handle .so and .dylib. */
     if (g_str_has_prefix (name, subplugin_prefixes[type]) &&
-        g_str_has_suffix (name, ".so")) {
+        g_str_has_suffix (name, NNSTREAMER_SO_FILE_EXTENSION)) {
       fullpath = g_build_filename (dir, name, NULL);
 
       if (_validate_file (type, fullpath)) {
@@ -381,7 +381,8 @@ nnsconf_get_fullpath (const gchar * subpluginname, nnsconf_type_path type)
 
   nnsconf_loadconf (FALSE);
 
-  filename = g_strconcat (subplugin_prefixes[type], subpluginname, ".so", NULL);
+  filename = g_strconcat (subplugin_prefixes[type], subpluginname,
+      NNSTREAMER_SO_FILE_EXTENSION, NULL);
   ret = nnsconf_get_fullpath_from_file (filename, type);
 
   g_free (filename);

--- a/gst/nnstreamer/nnstreamer_conf.h
+++ b/gst/nnstreamer/nnstreamer_conf.h
@@ -43,6 +43,16 @@ G_BEGIN_DECLS
 #define NNSTREAMER_SYS_ROOT_PATH_PREFIX "/"
 #endif /* G_OS_WIN32 */
 
+/**
+ * Hard-coded system-dependent file extension string of shared
+ * (dynamic loadable) object
+ */
+#ifdef __MACOS__
+#define NNSTREAMER_SO_FILE_EXTENSION	".dylib"
+#else
+#define NNSTREAMER_SO_FILE_EXTENSION	".so"
+#endif
+
 /* Env-var names */
 #define NNSTREAMER_ENVVAR_CONF_FILE     "NNSTREAMER_CONF"
 #define NNSTREAMER_ENVVAR_FILTERS       "NNSTREAMER_FILTERS"

--- a/gst/nnstreamer/tensor_source/meson.build
+++ b/gst/nnstreamer/tensor_source/meson.build
@@ -3,5 +3,7 @@ tensor_src_sources = [
 ]
 
 foreach s : tensor_src_sources
-  nnstreamer_sources += join_paths(meson.current_source_dir(), s)
+  if build_platform != 'macos'
+    nnstreamer_sources += join_paths(meson.current_source_dir(), s)
+  endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,21 @@ add_project_arguments('-DVERSION="' + meson.project_version() + '"', language: [
 
 cc = meson.get_compiler('c')
 cxx = meson.get_compiler('cpp')
+build_platform = ''
+
+if get_option('enable-tizen')
+  # Pass __TIZEN__ to the compiler
+  add_project_arguments('-D__TIZEN__=1', language: ['c', 'cpp'])
+  build_platform = 'tizen'
+elif not meson.is_cross_build()
+  if cc.get_id() == 'clang' and cxx.get_id() == 'clang'
+    if build_machine.system() == 'darwin'
+      # Pass __MACOS__ to the compiler
+      add_project_arguments('-D__MACOS__=1', language: ['c', 'cpp'])
+      build_platform = 'macos'
+    endif
+  endif
+endif
 
 warning_flags = [
   '-Wredundant-decls',

--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -610,12 +610,18 @@ TEST (conf_custom, env_str_01)
 
   fclose (fp);
 
-  gchar *f1 = create_null_file (dirf, "libnnstreamer_filter_fantastic.so");
-  gchar *f2 = create_null_file (dirf, "libnnstreamer_filter_neuralnetwork.so");
-  gchar *f3 = create_null_file (dird, "libnnstreamer_decoder_omg.so");
-  gchar *f4 = create_null_file (dird, "libnnstreamer_decoder_wthisgoingon.so");
-  gchar *f5 = create_null_file (dircf, "custom_mechanism.so");
-  gchar *f6 = create_null_file (dircf, "fastfaster.so");
+  gchar *f1 = create_null_file (dirf, "libnnstreamer_filter_fantastic"
+      NNSTREAMER_SO_FILE_EXTENSION);
+  gchar *f2 = create_null_file (dirf, "libnnstreamer_filter_neuralnetwork"
+      NNSTREAMER_SO_FILE_EXTENSION);
+  gchar *f3 = create_null_file (dird, "libnnstreamer_decoder_omg"
+      NNSTREAMER_SO_FILE_EXTENSION);
+  gchar *f4 = create_null_file (dird, "libnnstreamer_decoder_wthisgoingon"
+      NNSTREAMER_SO_FILE_EXTENSION);
+  gchar *f5 = create_null_file (dircf, "custom_mechanism"
+      NNSTREAMER_SO_FILE_EXTENSION);
+  gchar *f6 = create_null_file (dircf, "fastfaster"
+      NNSTREAMER_SO_FILE_EXTENSION);
 
   EXPECT_TRUE (FALSE != g_setenv ("NNSTREAMER_CONF", filename, TRUE));
   EXPECT_TRUE (nnsconf_loadconf (TRUE) == TRUE);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -84,14 +84,16 @@ if gtest_dep.found()
   test('unittest_plugins', unittest_plugins, args: ['--gst-plugin-path=..'])
 
   # Run unittest_src_iio
-  unittest_src_iio = executable('unittest_src_iio',
-    join_paths('nnstreamer_source', 'unittest_src_iio.cpp'),
-    dependencies: [nnstreamer_unittest_deps],
-    install: get_option('install-test'),
-    install_dir: unittest_install_dir
-  )
+  if build_platform != 'macos'
+    unittest_src_iio = executable('unittest_src_iio',
+      join_paths('nnstreamer_source', 'unittest_src_iio.cpp'),
+      dependencies: [nnstreamer_unittest_deps],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
 
-  test('unittest_src_iio', unittest_src_iio, timeout: 120, args: ['--gst-plugin-path=..'])
+    test('unittest_src_iio', unittest_src_iio, timeout: 120, args: ['--gst-plugin-path=..'])
+  endif
 endif
 
 # Tizen C-API

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -24,6 +24,12 @@
 #define DBG FALSE
 #endif
 
+#ifdef __MACOS__
+#define SO_EXT  "dylib"
+#else
+#define SO_EXT  "so"
+#endif /* __MACOS__ */
+
 /**
  * @brief Macro for debug message.
  */
@@ -722,26 +728,26 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink",
-	   option.num_buffers, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough");
+          "tensor_converter ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.%s ! tensor_sink name=test_sink",
+	        option.num_buffers, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough", SO_EXT);
       break;
     case TEST_TYPE_CUSTOM_TENSORS:
       /** other/tensors with tensormux, passthrough custom filter */
       str_pipeline =
           g_strdup_printf
-          ("tensor_mux name=mux ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.so ! tensor_sink name=test_sink "
+          ("tensor_mux name=mux ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.%s ! tensor_sink name=test_sink "
           "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=120,height=80,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_1 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=64,height=48,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_2",
-	   custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough" , option.num_buffers, option.num_buffers, option.num_buffers);
+	        custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough" , SO_EXT, option.num_buffers, option.num_buffers, option.num_buffers);
       break;
     case TEST_TYPE_CUSTOM_BUF_DROP:
       /* audio stream to test buffer-drop using custom filter */
       str_pipeline =
           g_strdup_printf
           ("audiotestsrc num-buffers=%d samplesperbuffer=200 ! audioconvert ! audio/x-raw,format=S16LE,rate=16000,channels=1 ! "
-          "tensor_converter frames-per-tensor=200 ! tensor_filter framework=custom model=%s/libnnscustom_drop_buffer.so ! tensor_sink name=test_sink",
-	   option.num_buffers, custom_dir? custom_dir :"./tests");
+          "tensor_converter frames-per-tensor=200 ! tensor_filter framework=custom model=%s/libnnscustom_drop_buffer.%s ! tensor_sink name=test_sink",
+	        option.num_buffers, custom_dir? custom_dir :"./tests", SO_EXT);
       break;
     case TEST_TYPE_CUSTOM_PASSTHROUGH:
       /* video 160x120 RGB, passthrough custom filter without so file */
@@ -821,65 +827,65 @@ _setup_pipeline (TestOption & option)
       /** 4x4 tensor stream, different FPS, tensor_mux them @ slowest */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_mux sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests",  SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_4:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
       /** @todo Because of the bug mentioned in #739, this is not registered as gtest case, yet */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_mux sync_mode=basepad sync_option=1:1000000000 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests",  option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_mux sync_mode=basepad sync_option=1:1000000000 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_1:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ slowest */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_0 "
-          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! mux.sink_1 "
-          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.so ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", option.num_buffers * 25, custom_dir? custom_dir : "./tests", custom_dir? custom_dir : "./tests", option.tmpfile);
+          ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
+          "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
+          "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
+	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     /** @todo Add tensor_mux policy = more policies! */
     case TEST_TYPE_DECODER_PROPERTY:
@@ -2936,6 +2942,7 @@ TEST (tensor_stream_test, filter_properties_1)
   GstElement *filter;
   gboolean silent, res_silent;
   gchar *str = NULL;
+  gchar *model = NULL;
 
   ASSERT_TRUE (_setup_pipeline (option));
 
@@ -2952,8 +2959,10 @@ TEST (tensor_stream_test, filter_properties_1)
 
   /* model */
   g_object_get (filter, "model", &str, NULL);
-  EXPECT_TRUE (g_str_has_suffix (str, "libnnstreamer_customfilter_passthrough_variable.so"));
+  model = g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s", SO_EXT);
+  EXPECT_TRUE (g_str_has_suffix (str, model));
   g_free (str);
+  g_free (model);
 
   /* input */
   g_object_get (filter, "input", &str, NULL);
@@ -3031,6 +3040,7 @@ TEST (tensor_stream_test, filter_properties_2)
   GstElement *filter;
   gboolean silent, res_silent;
   gchar *str = NULL;
+  gchar *model = NULL;
 
   ASSERT_TRUE (_setup_pipeline (option));
 
@@ -3047,8 +3057,10 @@ TEST (tensor_stream_test, filter_properties_2)
 
   /* model */
   g_object_get (filter, "model", &str, NULL);
-  EXPECT_TRUE (g_str_has_suffix (str, "libnnstreamer_customfilter_passthrough_variable.so"));
+  model = g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s", SO_EXT);
+  EXPECT_TRUE (g_str_has_suffix (str, model));
   g_free (str);
+  g_free (model);
 
   /* input */
   g_object_get (filter, "input", &str, NULL);


### PR DESCRIPTION
https://github.com/myungjoo/SSAT/pull/12 is required.

This PR concerns macOS (High Sierra) support.

- Update the meson build script to make NNStreamer be built on macOS
- Support .dylib as a file extension of shared object in the macOS envirionment
- Let unit test cases for common and tensor_sink work on macOS 

### How to test this PR

1. Development environment
```bash
$ uname -a
Darwin MacbookAirAtHome 17.7.0 Darwin Kernel Version 17.7.0: Sun Jun  2 20:31:42 PDT 2019; root:xnu-4570.71.46~1/RELEASE_X86_64 x86_64

$ clang --version
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

2. How to build
- [brew](https://brew.sh) is required. 
```bash
$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
```
- Install packages for build dependency
```bash
$ brew install cask
$ brew update
$ brew install meson pkg-config cmake libffi glib gstreamer gst-plugins-base gst-plugins-good
```
- Build
```bash
$ meson build -Denable-tensorflow=false -Denable-tensorflow-lite=false -Denable-pytorch=false -Denable-caffe2=false
$ ninja -C build
```

3. How to test
- Install googletest
```bash
$ git clone https://github.com/google/googletest
$ cd googletest
$ mkdir build
$ cd build
$ cmake ..
$ make
$ make install
```
- Build nnstreamer again
```bash
$ cd $NNS_DIR
$ rm -rf build
$ meson build -Denable-tensorflow=false -Denable-tensorflow-lite=false -Denable-pytorch=false -Denable-caffe2=false
$ ninja -C build
```

- Set environment variables for test
```bash
$ cd $NNS_DIR
$ pushd build
$ export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
$ export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
$ export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
$ export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
$ popd
```

- Run googletest-based test cases
```bash
$ ./tests/unittest_common 
...omission...
[==========] 32 tests from 6 test suites ran. (9 ms total)
[  PASSED  ] 32 tests.
```
```bash
$ ./tests/unittest_sink
...omission...
[==========] 69 tests from 2 test suites ran. (34234 ms total)
[  PASSED  ] 69 tests.
```
```bash
$ ./tests/unittest_plugin
...omission...
[==========] 58 tests from 2 test suites ran. (94 ms total)
[  PASSED  ] 58 tests.
```
Signed-off-by: Wook Song <wook16.song@samsung.com>