### PR TITLE
[Build] update build script

### DIFF
--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -36,7 +36,6 @@ NNSTREAMER_PLUGINS_SRCS := \
     $(NNSTREAMER_GST_HOME)/tensor_repo/tensor_reposink.c \
     $(NNSTREAMER_GST_HOME)/tensor_repo/tensor_reposrc.c \
     $(NNSTREAMER_GST_HOME)/tensor_sink/tensor_sink.c \
-    $(NNSTREAMER_GST_HOME)/tensor_source/tensor_src_iio.c \
     $(NNSTREAMER_GST_HOME)/tensor_split/gsttensorsplit.c \
     $(NNSTREAMER_GST_HOME)/tensor_transform/tensor_transform.c
 

--- a/meson.build
+++ b/meson.build
@@ -222,15 +222,10 @@ if get_option('enable-python')
   endif
 endif
 
-if get_option('enable-tizen')
-  add_project_arguments('-D__TIZEN__=1', language: ['c', 'cpp'])
-endif
-
 # nnfw ( details in https://review.tizen.org/gerrit/p/platform/core/ml/nnfw )
 if get_option('enable-nnfw')
-    add_project_arguments('-DENABLE_NNFW=1', language: ['c', 'cpp'])
+  add_project_arguments('-DENABLE_NNFW=1', language: ['c', 'cpp'])
 endif
-
 
 # Build nnstreamer (common, plugins)
 subdir('gst')

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -64,7 +64,7 @@ BuildRequires: lcov
 # BuildRequires:	taos-ci-unittest-coverage-assessment
 %endif
 %if %{with tizen}
-BuildRequires: pkgconfig(capi-system-info)
+BuildRequires:	pkgconfig(capi-system-info)
 BuildRequires:	pkgconfig(capi-base-common)
 BuildRequires:	pkgconfig(dlog)
 BuildRequires:	gst-plugins-bad-devel
@@ -181,7 +181,7 @@ mkdir -p build
 %define enable_tf false
 %endif
 
-meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} --bindir=%{nnstexampledir} --includedir=%{_includedir} -Dinstall-example=true -Denable-tensorflow=%{enable_tf} -Denable-pytorch=false -Denable-caffe2=false %{api} -Denable-env-var=false -Denable-symbolic-link=false -Denable-tizen=true build -Denable-nnfw=false
+meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} --bindir=%{nnstexampledir} --includedir=%{_includedir} -Dinstall-example=true -Denable-tensorflow=%{enable_tf} -Denable-pytorch=false -Denable-caffe2=false %{api} -Denable-env-var=false -Denable-symbolic-link=false -Denable-tizen=true build
 
 ninja -C build %{?_smp_mflags}
 


### PR DESCRIPTION
Fix duplicated and unnecessary code with the updation of nnstreamer features.
1. remove src-iio in android-jni (currently excluded to register the element, so unnecessary.)
2. remove option enable-nnfw in .spec (default false)
3. duplicated feature definition for tizen

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
