### PR TITLE
[Filter/Decoder] sub-plugins extension

### DIFF
--- a/gst/nnstreamer/tensor_decoder/tensordec.c
+++ b/gst/nnstreamer/tensor_decoder/tensordec.c
@@ -559,16 +559,17 @@ gst_tensordec_get_property (GObject * object, guint prop_id,
       if (total > 0) {
         GString *subplugins;
         const gchar *prefix_str;
-        gsize prefix, len;
+        gsize prefix, extension, len;
 
         subplugins = g_string_new (NULL);
 
         prefix_str = nnsconf_get_subplugin_name_prefix (NNSCONF_PATH_DECODERS);
         prefix = strlen (prefix_str);
+        extension = strlen (NNSTREAMER_SO_FILE_EXTENSION);
 
         for (i = 0; i < total; ++i) {
-          /* supposed .so files only */
-          len = strlen (sinfo.names[i]) - prefix - 3;
+          /* remove file extension */
+          len = strlen (sinfo.names[i]) - prefix - extension;
           g_string_append_len (subplugins, sinfo.names[i] + prefix, len);
 
           if (i < total - 1) {

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -887,16 +887,17 @@ gst_tensor_filter_get_property (GObject * object, guint prop_id,
 
       if (total > 0) {
         const gchar *prefix_str;
-        gsize prefix, len;
+        gsize prefix, extension, len;
 
         prefix_str = nnsconf_get_subplugin_name_prefix (NNSCONF_PATH_FILTERS);
         prefix = strlen (prefix_str);
+        extension = strlen (NNSTREAMER_SO_FILE_EXTENSION);
 
         for (i = 0; i < total; ++i) {
           g_string_append (subplugins, ",");
 
-          /* supposed .so files only */
-          len = strlen (sinfo.names[i]) - prefix - 3;
+          /* remove file extension */
+          len = strlen (sinfo.names[i]) - prefix - extension;
           g_string_append_len (subplugins, sinfo.names[i] + prefix, len);
         }
       }


### PR DESCRIPTION
Check sub-plugins file extension after supporting mac.

Wook defined the file extension for build target. With this, set sub-plugins name in filter/decoder.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
