### PR TITLE
[Filter] Fix svace issue

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -48,8 +48,8 @@ TFLiteCore::TFLiteCore (const char * _model_path, nnapi_hw hw)
     use_nnapi = nnsconf_get_custom_value_bool ("tensorflowlite", "enable_nnapi", FALSE);
   } else {
     use_nnapi = TRUE;
-    accel = hw;
   }
+  accel = hw;
 
   gst_tensors_info_init (&inputTensorMeta);
   gst_tensors_info_init (&outputTensorMeta);


### PR DESCRIPTION
If the parameter hw of constructor is NNAPI_UNKNOWN, the member variable
accel is not initialized. This patch fixes that bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped

