### PR TITLE
[single-shot] Completion for new single-shot API

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -273,6 +273,14 @@ int ml_set_feature_status (int status);
  */
 int ml_check_plugin_availability (const char *plugin_name, const char *element_name);
 
+/**
+ * @brief Creates a tensor data frame wihout buffer with the given tensors information.
+ * @param[in] info The handle of tensors information for the allocation.
+ * @param[out] data The handle of tensors data.
+ * @return @c 0 on success. Otherwise a negative error value.
+ */
+int ml_tensors_data_create_no_alloc (const ml_tensors_info_h info, ml_tensors_data_h *data);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -74,8 +74,8 @@ nnstreamer_capi_dep = declare_dependency(link_with: nnstreamer_capi_lib,
 )
 
 # New single-shot c-api
-
 capi_single_new_main = []
+capi_single_new_main += join_paths(meson.current_source_dir(), 'src', 'nnstreamer-capi-pipeline.c')
 capi_single_new_main += join_paths(meson.current_source_dir(), 'src', 'nnstreamer-capi-util.c')
 capi_single_new_main += join_paths(meson.current_source_dir(), 'src', 'nnstreamer-capi-single-new.c')
 capi_single_new_main += join_paths(meson.current_source_dir(), 'src', 'tensor_filter_single.c')

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -503,9 +503,10 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
 
 /**
  * @brief Allocates a tensor data frame with the given tensors info. (more info in nnstreamer.h)
+ * @note Memory for data buffer is not allocated.
  */
 int
-ml_tensors_data_create (const ml_tensors_info_h info,
+ml_tensors_data_create_no_alloc (const ml_tensors_info_h info,
     ml_tensors_data_h * data)
 {
   ml_tensors_data_s *_data;
@@ -529,6 +530,30 @@ ml_tensors_data_create (const ml_tensors_info_h info,
   _data->num_tensors = tensors_info->num_tensors;
   for (i = 0; i < _data->num_tensors; i++) {
     _data->tensors[i].size = ml_tensor_info_get_size (&tensors_info->info[i]);
+    _data->tensors[i].tensor = NULL;
+  }
+
+  *data = _data;
+  return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Allocates a tensor data frame with the given tensors info. (more info in nnstreamer.h)
+ */
+int
+ml_tensors_data_create (const ml_tensors_info_h info,
+    ml_tensors_data_h * data)
+{
+  gint status;
+  ml_tensors_data_s *_data = NULL;
+  gint i;
+
+  status = ml_tensors_data_create_no_alloc (info, (ml_tensors_data_h *) &_data);
+
+  if (status != ML_ERROR_NONE)
+    return status;
+
+  for (i = 0; i < _data->num_tensors; i++) {
     _data->tensors[i].tensor = g_malloc0 (_data->tensors[i].size);
     if (_data->tensors[i].tensor == NULL)
       goto failed;

--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -181,7 +181,206 @@ static void
 g_tensor_filter_single_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  /** TODO: share this with tensor_filter*/
+  GTensorFilterSingle *self;
+  GstTensorFilterProperties *prop;
+
+  self = G_TENSOR_FILTER_SINGLE (object);
+  prop = &self->prop;
+
+  g_debug ("Setting property for prop %d.\n", prop_id);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      self->silent = g_value_get_boolean (value);
+      g_debug ("Debug mode = %d", self->silent);
+      break;
+    case PROP_FRAMEWORK:
+    {
+      const gchar *fw_name = g_value_get_string (value);
+      const GstTensorFilterFramework *fw;
+
+      if (self->fw != NULL) {
+        /* close old framework */
+        g_tensor_filter_single_stop (self);
+      }
+
+      g_debug ("Framework = %s\n", fw_name);
+
+      fw = nnstreamer_filter_find (fw_name);
+
+      /* See if mandatory methods are filled in */
+      if (nnstreamer_filter_validate (fw)) {
+        self->fw = fw;
+        prop->fwname = g_strdup (fw_name);
+      } else {
+        g_warning ("Cannot identify the given neural network framework, %s\n",
+            fw_name);
+      }
+      break;
+    }
+    case PROP_MODEL:
+    {
+      const gchar *model_files = g_value_get_string (value);
+      guint model_num;
+
+      if (prop->model_file) {
+        g_tensor_filter_single_stop (self);
+        g_free_const (prop->model_file);
+        prop->model_file = NULL;
+      }
+
+      if (prop->model_file_sub) {
+        g_tensor_filter_single_stop (self);
+        g_free_const (prop->model_file_sub);
+        prop->model_file_sub = NULL;
+      }
+
+      /* Once configures, it cannot be changed in runtime */
+      g_assert (model_files);
+      model_num = gst_tensor_filter_parse_modelpaths_string (prop, model_files);
+      if (model_num == 1) {
+        g_debug ("Model = %s\n", prop->model_file);
+        if (!g_file_test (prop->model_file, G_FILE_TEST_IS_REGULAR))
+          g_critical ("Cannot find the model file: %s\n", prop->model_file);
+      } else if (model_num == 2) {
+        g_debug ("Init Model = %s\n", prop->model_file_sub);
+        g_debug ("Pred Model = %s\n", prop->model_file);
+        if (!g_file_test (prop->model_file_sub, G_FILE_TEST_IS_REGULAR))
+          g_critical ("Cannot find the init model file: %s\n",
+              prop->model_file_sub);
+        if (!g_file_test (prop->model_file, G_FILE_TEST_IS_REGULAR))
+          g_critical ("Cannot find the pred model file: %s\n",
+              prop->model_file);
+      } else if (model_num > 2) {
+        /** @todo if the new NN framework requires more than 2 model files, this area will be implemented */
+        g_critical
+            ("There is no NN framework that requires model files more than 2. Current Input model files are :%d\n",
+            model_num);
+      } else {
+        g_critical ("Set model file path first\n");
+      }
+      break;
+    }
+    case PROP_INPUT:
+      g_assert (!prop->input_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_dims;
+
+        num_dims = gst_tensors_info_parse_dimensions_string (&prop->input_meta,
+            g_value_get_string (value));
+
+        if (prop->input_meta.num_tensors > 0 &&
+            prop->input_meta.num_tensors != num_dims) {
+          g_warning
+              ("Invalid input-dim, given param does not match with old value.");
+        }
+
+        prop->input_meta.num_tensors = num_dims;
+      }
+      break;
+    case PROP_OUTPUT:
+      g_assert (!prop->output_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_dims;
+
+        num_dims = gst_tensors_info_parse_dimensions_string (&prop->output_meta,
+            g_value_get_string (value));
+
+        if (prop->output_meta.num_tensors > 0 &&
+            prop->output_meta.num_tensors != num_dims) {
+          g_warning
+              ("Invalid output-dim, given param does not match with old value.");
+        }
+
+        prop->output_meta.num_tensors = num_dims;
+      }
+      break;
+    case PROP_INPUTTYPE:
+      g_assert (!prop->input_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_types;
+
+        num_types = gst_tensors_info_parse_types_string (&prop->input_meta,
+            g_value_get_string (value));
+
+        if (prop->input_meta.num_tensors > 0 &&
+            prop->input_meta.num_tensors != num_types) {
+          g_warning
+              ("Invalid input-type, given param does not match with old value.");
+        }
+
+        prop->input_meta.num_tensors = num_types;
+      }
+      break;
+    case PROP_OUTPUTTYPE:
+      g_assert (!prop->output_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_types;
+
+        num_types = gst_tensors_info_parse_types_string (&prop->output_meta,
+            g_value_get_string (value));
+
+        if (prop->output_meta.num_tensors > 0 &&
+            prop->output_meta.num_tensors != num_types) {
+          g_warning
+              ("Invalid output-type, given param does not match with old value.");
+        }
+
+        prop->output_meta.num_tensors = num_types;
+      }
+      break;
+    case PROP_INPUTNAME:
+      /* INPUTNAME is required by tensorflow to designate the order of tensors */
+      g_assert (!prop->input_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_names;
+
+        num_names = gst_tensors_info_parse_names_string (&prop->input_meta,
+            g_value_get_string (value));
+
+        if (prop->input_meta.num_tensors > 0 &&
+            prop->input_meta.num_tensors != num_names) {
+          g_warning
+              ("Invalid input-name, given param does not match with old value.");
+        }
+
+        prop->input_meta.num_tensors = num_names;
+      }
+      break;
+    case PROP_OUTPUTNAME:
+      /* OUTPUTNAME is required by tensorflow to designate the order of tensors */
+      g_assert (!prop->output_configured && value);
+      /* Once configures, it cannot be changed in runtime */
+      {
+        guint num_names;
+
+        num_names = gst_tensors_info_parse_names_string (&prop->output_meta,
+            g_value_get_string (value));
+
+        if (prop->output_meta.num_tensors > 0 &&
+            prop->output_meta.num_tensors != num_names) {
+          g_warning
+              ("Invalid output-name, given param does not match with old value.");
+        }
+
+        prop->output_meta.num_tensors = num_names;
+      }
+      break;
+    case PROP_CUSTOM:
+      /* In case updated custom properties in runtime! */
+      g_free_const (prop->custom_properties);
+      prop->custom_properties = g_value_dup_string (value);
+      g_debug ("Custom Option = %s\n", prop->custom_properties);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
 }
 
 /**
@@ -374,12 +573,40 @@ static gboolean
 g_tensor_filter_single_invoke (GTensorFilterSingle * self,
     GstTensorMemory * input, GstTensorMemory * output)
 {
-  gboolean status = TRUE;
-  /** TODO: fill this */
+  gboolean status;
+  int i;
+
+  if (G_UNLIKELY (!self->fw) || G_UNLIKELY (!self->fw->invoke_NN))
+    return FALSE;
+  if (G_UNLIKELY (!self->fw->run_without_model) &&
+      G_UNLIKELY (!self->prop.model_file))
+    return FALSE;
 
   /** start if not already started */
-  if (self->started == FALSE)
+  if (self->started == FALSE) {
     status = g_tensor_filter_single_start (self);
+    if (status == FALSE) {
+      return status;
+    }
+    self->started = TRUE;
+  }
 
-  return status;
+  /** Setup output buffer */
+  for (i = 0; i < self->prop.output_meta.num_tensors; i++) {
+    /* allocate memory if allocate_in_invoke is FALSE */
+    if (self->fw->allocate_in_invoke == FALSE) {
+      output[i].data = g_malloc (output[i].size);
+      if (!output[i].data)
+        goto error;
+    }
+  }
+
+  if (self->fw->invoke_NN (&self->prop, &self->privateData, input, output) == 0)
+    return TRUE;
+
+error:
+  if (self->fw->allocate_in_invoke == FALSE)
+    for (i = 0; i < self->prop.output_meta.num_tensors; i++)
+      g_free (output[i].data);
+  return FALSE;
 }

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -212,6 +212,7 @@ ninja -C build %{?_smp_mflags}
     ./tests/unittest_plugins --gst-plugin-path=. --gtest_output="xml:unittest_plugins.xml"
     ./tests/unittest_src_iio --gst-plugin-path=. --gtest_output="xml:unittest_src_iio.xml"
     ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=. --gtest_output="xml:unittest_tizen_capi.xml"
+    ./tests/tizen_capi/unittest_tizen_capi_single_new --gst-plugin-path="xml:unittest_tizen_capi_single_new.xml"
     popd
     pushd tests
     ssat -n

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -10,3 +10,16 @@ unittest_tizen_capi = executable('unittest_tizen_capi',
   install: false
 )
 test('unittest_tizen_capi', unittest_tizen_capi, args: ['--gst-plugin-path=../..'])
+
+tizen_apptest_deps = [
+  nnstreamer_capi_single_new_dep,
+  gtest_dep,
+  glib_dep
+]
+
+unittest_tizen_capi_single_new = executable('unittest_tizen_capi_single_new',
+  'unittest_tizen_capi.cpp',
+  dependencies: [tizen_apptest_deps],
+  install: false
+)
+test('unittest_tizen_capi_single_new', unittest_tizen_capi_single_new, args: ['--gst-plugin-path=../..'])


### PR DESCRIPTION
Completed the implementation for single-shot API without GStreamer
Added a separate binary for this API
Added remaining functions in `tensor_filter_single.c`
Added another test run in meson and `nnstreamer.spec` for testing of this new implementation

Note: single-shot new API is not part of the original `capi-nnstreamer-0.2.1-0.*.rpm` package
It is contained in `capi-nnstreamer-single-new-0.2.1-0.*.rpm` along with its devel version

Working on #1547

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com