### PR TITLE
[Api/Single] clear old buffer

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1928,6 +1928,11 @@ TEST (nnstreamer_capi_singleshot, invoke_timeout)
     EXPECT_EQ (status, ML_ERROR_TIMED_OUT);
     EXPECT_TRUE (output == NULL);
 
+    /* check the old buffer is dropped */
+    status = ml_single_invoke (single, input, &output);
+    EXPECT_EQ (status, ML_ERROR_TIMED_OUT);
+    EXPECT_TRUE (output == NULL);
+
     ml_tensors_data_destroy (output);
     ml_tensors_data_destroy (input);
     ml_tensors_info_destroy (in_info);


### PR DESCRIPTION
1. Add mutex-lock for internal process.
2. Clear old buffer of appsink before pushing new buffer to appsrc.

When old buffer received in appsink after timeout, next output of invoke() may be the previous result.
To prevent this, clear old sample in appsink.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
