### PR TITLE
[build] Cleanup after build - @open sesame 09/18 16:38

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -72,7 +72,9 @@ echo "Start to build NNStreamer library for Android."
 
 # Modify header for Android
 cd $NNSTREAMER_ROOT/api/capi
-./modify_nnstreamer_h_for_nontizen.sh
+if ! patch -R --dry-run -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch; then
+  patch -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch
+fi
 cd $NNSTREAMER_ROOT
 
 # Make directory to build NNStreamer library
@@ -136,4 +138,3 @@ popd
 
 # Remove build directory
 rm -rf build_android_lib
-

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -48,9 +48,12 @@ if (get_option('enable-tizen'))
     dependency('dlog')
   ]
 else
-  r = run_command('./modify_nnstreamer_h_for_nontizen.sh')
+  r = run_command('patch', '-R', '--dry-run', '-sfp1', '-i', patch_file)
   if (r.returncode() != 0)
-    message('Non-Tizen mode support failed')
+    r = run_command('patch', '-p1', '-i', patch_file)
+    if (r.returncode() != 0)
+      message('Non-Tizen mode support failed')
+    endif
   endif
   message('CAPI is in non-Tizen mode')
 endif

--- a/meson.build
+++ b/meson.build
@@ -228,6 +228,9 @@ if get_option('enable-nnfw')
   add_project_arguments('-DENABLE_NNFW=1', language: ['c', 'cpp'])
 endif
 
+# Patch for non-tizen build
+patch_file = join_paths(meson.current_source_dir(), 'packaging', 'non_tizen_build.patch')
+
 # Build nnstreamer (common, plugins)
 subdir('gst')
 

--- a/packaging/non_tizen_build.patch
+++ b/packaging/non_tizen_build.patch
@@ -1,0 +1,21 @@
+diff --git a/include/nnstreamer.h b/include/nnstreamer.h
+index a18a066..ab1808c 100644
+--- a/include/nnstreamer.h
++++ b/include/nnstreamer.h
+@@ -28,7 +28,15 @@
+ #include <stdbool.h>
+
+ /* Apply modify_nnstreamer_h_for_nontizen.sh if you want to use in non-Tizen Linux machines */
+-#include <tizen_error.h>
++#include <errno.h>
++#define TIZEN_ERROR_NONE (0)
++#define TIZEN_ERROR_INVALID_PARAMETER (-EINVAL)
++#define TIZEN_ERROR_STREAMS_PIPE (-ESTRPIPE)
++#define TIZEN_ERROR_TRY_AGAIN (-EAGAIN)
++#define TIZEN_ERROR_UNKNOWN (-1073741824LL)
++#define TIZEN_ERROR_TIMED_OUT (TIZEN_ERROR_UNKNOWN + 1)
++#define TIZEN_ERROR_NOT_SUPPORTED (TIZEN_ERROR_UNKNOWN + 2)
++#define TIZEN_ERROR_PERMISSION_DENIED (-EACCES)
+
+ #ifdef __cplusplus
+ extern "C" {


### PR DESCRIPTION
When enable-capi is set and enable-tizen is not set,
meson modifies nnstreamer.h to build capi without tizen
However, that modification is not reverted
This PR reverts the modification at the end of install

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>