### PR TITLE
[API] Fix the errors in package config file @open sesame 09/03 17:30

### DIFF
--- a/api/capi/capi-nnstreamer.pc.in
+++ b/api/capi/capi-nnstreamer.pc.in
@@ -10,5 +10,5 @@ Name: tizen-api-nnstreamer
 Description: NNStreamer API for Tizen
 Version: @VERSION@
 Requires:
-Libs: -L${libdir}
-Cflags: -I${includedir}
+Libs: -L${libdir} -lcapi-nnstreamer
+Cflags: -I${includedir}/nnstreamer


### PR DESCRIPTION
There are wrong include path, link option and omitted requires in CAPI
PC file. This patch fixes that bug.

* Contained files of capi-nnstreamer-devel package
```bash
$ rpm -qlp capi-nnstreamer-devel-0.2.1-0.x86_64.rpm
/usr/include/nnstreamer/nnstreamer-single.h
/usr/include/nnstreamer/nnstreamer.h
/usr/lib64/libcapi-nnstreamer.a
/usr/lib64/libcapi-nnstreamer.so
/usr/lib64/pkgconfig/capi-nnstreamer.pc
```

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [* ]Passed [ ]Failed [ ]Skipped
2. Run test: [* ]Passed [ ]Failed [ ]Skipped


@kparichay and @jaeyun-jung 
Please go over this PR. Thanks in advance.
