### PR TITLE
[Android] unnecessary log while running android-lib

### DIFF
--- a/api/android/api/res/values/strings.xml
+++ b/api/android/api/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="lib_name">NNStreamer API</string>
-</resources>

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -115,7 +115,7 @@ static gboolean
 _validate_file (nnsconf_type_path type, const gchar * fullpath)
 {
   /* ignore directory */
-  if (!g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
+  if (!fullpath || !g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
     return FALSE;
   /* ignore symbol link file */
   if (!conf.enable_symlink && g_file_test (fullpath, G_FILE_TEST_IS_SYMLINK))

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -534,7 +534,9 @@ gst_tensors_info_get_names_string (const GstTensorsInfo * info)
     GString *names = g_string_new (NULL);
 
     for (i = 0; i < info->num_tensors; i++) {
-      g_string_append (names, info->info[i].name);
+      if (info->info[i].name) {
+        g_string_append (names, info->info[i].name);
+      }
 
       if (i < info->num_tensors - 1) {
         g_string_append (names, ",");


### PR DESCRIPTION
1. add condition to check file path or tensor name
2. remove unnecessary res file in android

This will remove unnecessary log-print while running java custom-filter and tf-lite model.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
