### PR TITLE
[Tests] Use SO_EXT instead of hard-coded 'so'

### DIFF
--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -18,6 +18,11 @@ if [ -z ${SO_EXT} ]; then
     SO_EXT="so"
 fi
 
+# For macOS support
+if [[ ${SO_EXT} == 'dylib' ]]; then
+    EXTRA_PKG_CONFIG=/usr/local/opt/libffi/lib/pkgconfig
+fi
+
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
@@ -47,7 +52,7 @@ EOF
     testResult $? TC${1} "CodeGen of ${2}/${3} case" 0 1
 
     rm -rf build${1}
-    PKG_CONFIG_PATH=.:$PKG_CONFIG_PATH meson build${1} && ninja -C build${1}
+    PKG_CONFIG_PATH=.:$EXTRA_PKG_CONFIG:$PKG_CONFIG_PATH meson build${1} && ninja -C build${1}
     testResult $? TC${1}C "Build codegen result of TC1 (${2}/${3} case)" 0 1
 
     gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! tensor_filter framework=custom model=\"build${1}/libtc${1}.${SO_EXT}\" ! fakesink" TC${1}R "Run gst-launch for TC${1}" 0 0 $PERFORMANCE

--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -14,6 +14,10 @@ if [[ "$SSATAPILOADED" != "1" ]]; then
 "
 fi
 
+if [ -z ${SO_EXT} ]; then
+    SO_EXT="so"
+fi
+
 # This is compatible with SSAT (https://github.com/myungjoo/SSAT)
 testInit $1
 
@@ -46,7 +50,7 @@ EOF
     PKG_CONFIG_PATH=.:$PKG_CONFIG_PATH meson build${1} && ninja -C build${1}
     testResult $? TC${1}C "Build codegen result of TC1 (${2}/${3} case)" 0 1
 
-    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! tensor_filter framework=custom model=\"build${1}/libtc${1}.so\" ! fakesink" TC${1}R "Run gst-launch for TC${1}" 0 0 $PERFORMANCE
+    gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num_buffers=10 ! videoconvert ! videoscale ! video/x-raw,width=224,height=224,format=RGB ! tensor_converter ! tensor_filter framework=custom model=\"build${1}/libtc${1}.${SO_EXT}\" ! fakesink" TC${1}R "Run gst-launch for TC${1}" 0 0 $PERFORMANCE
 }
 
 do_test 01 y y

--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -21,9 +21,15 @@ PATH_TO_PLUGIN="../../build"
 
 # Test for opencv installed, enable OPENCV test if opencv is found
 TEST_OPENCV="NO"
-/sbin/ldconfig -p | grep opencv >/dev/null 2>&1
-if [[ "$?" == 0 ]]; then
-    TEST_OPENCV="YES"
+if [[ "${KernelName}" != "Darwin" ]]; then
+    /sbin/ldconfig -p | grep opencv >/dev/null 2>&1
+    if [[ "$?" == 0 ]]; then
+        TEST_OPENCV="YES"
+    fi
+fi
+
+if [ -z ${SO_EXT} ]; then
+    SO_EXT="so"
 fi
 
 if [ "$SKIPGEN" == "YES" ]; then
@@ -39,9 +45,9 @@ gstTest "videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40
 
 # Test constant passthrough custom filter (1, 2)
 if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-    PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so"
+    PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.${SO_EXT}"
 else
-    PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough.so"
+    PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough.${SO_EXT}"
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL}\" input=\"3:280:40\" inputtype=\"uint8\" output=\"3:280:40\" outputtype=\"uint8\" ! filesink location=\"testcase01.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase01.direct.log\" sync=true" 1 0 0 $PERFORMANCE
@@ -54,9 +60,9 @@ callCompareTest testcase02.direct.log testcase02.passthrough.log 2 "Compare 2" 0
 
 # Test variable-dim passthrough custom filter (3, 4)
 if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-    PATH_TO_MODEL_V="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.so"
+    PATH_TO_MODEL_V="../../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough_variable.${SO_EXT}"
 else
-    PATH_TO_MODEL_V="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough_variable.so"
+    PATH_TO_MODEL_V="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_passthrough_variable.${SO_EXT}"
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_V}\" input=\"3:640:480\" inputtype=\"uint8\" output=\"3:640:480\" outputtype=\"uint8\" ! filesink location=\"testcase03.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase03.direct.log\" sync=true" 3 0 0 $PERFORMANCE
@@ -75,9 +81,9 @@ callCompareTest testcase04.tensors.direct.log testcase04.tensors.passthrough.log
 
 # Test scaler (5, 6, 7)
 if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-    PATH_TO_MODEL_S="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler.so"
+    PATH_TO_MODEL_S="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler.${SO_EXT}"
 else
-    PATH_TO_MODEL_S="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler.so"
+    PATH_TO_MODEL_S="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler.${SO_EXT}"
 fi
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_S}\" ! filesink location=\"testcase05.passthrough.log\" sync=true t. ! queue ! filesink location=\"testcase05.direct.log\" sync=true" 5 0 0 $PERFORMANCE
 callCompareTest testcase05.direct.log testcase05.passthrough.log 5 "Compare 5" 0 0
@@ -92,9 +98,9 @@ testResult $? 7 "Golden test comparison" 0 1
 
 # Test average (8)
 if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-    PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+    PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.${SO_EXT}"
 else
-    PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
+    PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.${SO_EXT}"
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase08.average.log\" sync=true t. ! queue ! filesink location=\"testcase08.direct.log\" sync=true" 8 0 0 $PERFORMANCE
@@ -107,9 +113,9 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} multifilesrc location=\"testsequenc
 
 # Test scaler + in-invoke allocator (11)
 if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-    PATH_TO_MODEL_SI="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler_allocator.so"
+    PATH_TO_MODEL_SI="../../build/nnstreamer_example/custom_example_scaler/libnnstreamer_customfilter_scaler_allocator.${SO_EXT}"
 else
-    PATH_TO_MODEL_SI="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler_allocator.so"
+    PATH_TO_MODEL_SI="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_scaler_allocator.${SO_EXT}"
 fi
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tee name=t ! queue ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_SI}\" custom=\"320x240\" ! filesink location=\"testcase11.scaled.log\" sync=true t. ! queue ! filesink location=\"testcase11.direct.log\" sync=true" 11 0 0 $PERFORMANCE
@@ -120,9 +126,9 @@ testResult $? 11 "Golden test comparison" 0 1
 # Test scaler using OpenCV (12, 13, 14)
 if [ "$TEST_OPENCV" == "YES" ]; then
     if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-        PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.so"
+        PATH_TO_MODEL="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_scaler.${SO_EXT}"
     else
-        PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_scaler.so"
+        PATH_TO_MODEL="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_scaler.${SO_EXT}"
     fi
 
     # Verify that opencv tests were build before running them
@@ -143,17 +149,17 @@ if [ "$TEST_OPENCV" == "YES" ]; then
     # Test average using OpenCV (15)
     # custom version
     if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.so"
+        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_average/libnnstreamer_customfilter_average.${SO_EXT}"
     else
-        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.so"
+        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_average.${SO_EXT}"
     fi
     gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=640,height=480,framerate=0/1 ! videoconvert ! video/x-raw, format=RGB ! tensor_converter ! tensor_filter framework=\"custom\" model=\"${PATH_TO_MODEL_A}\" ! filesink location=\"testcase15.average.log\" sync=true" 15 0 0 $PERFORMANCE
 
     # OpenCV version
     if [[ -z "${CUSTOMLIB_DIR// /}" ]]; then
-        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.so"
+        PATH_TO_MODEL_A="../../build/nnstreamer_example/custom_example_opencv/libnnstreamer_customfilter_opencv_average.${SO_EXT}"
     else
-        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_average.so"
+        PATH_TO_MODEL_A="${CUSTOMLIB_DIR}/libnnstreamer_customfilter_opencv_average.${SO_EXT}"
     fi
 
     if [ -e $PATH_TO_MODEL_A ]; then

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -37,10 +37,14 @@ else
     LSTM_DIR="${CUSTOMLIB_DIR}"
 fi
 
+if [ -z ${SO_EXT} ]; then
+    SO_EXT="so"
+fi
+
 # Generate video_4x4xBGRx.xraw & golden
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${LSTM_DIR}/libdummyLSTM.so ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${LSTM_DIR}/libdummyLSTM.${SO_EXT} ! tensor_demux name=demux ! queue ! tensor_reposink slot-index=0 silent=false demux.src_1 ! queue ! tee name=t ! queue ! tensor_reposink slot-index=1 silent=false tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_0 tensor_reposrc slot-index=1 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)float32,framerate=(fraction)0/1\" ! mux.sink_1 filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=float32 ! mux.sink_2 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest lstm.golden out_9.log 1-1 "Compare 1-1" 1 0
 

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -22,10 +22,14 @@ else
     RNN_DIR="${CUSTOMLIB_DIR}"
 fi
 
+if [ -z ${SO_EXT} ]; then
+    SO_EXT="so"
+fi
+
 # Generate video_4x4xBGRx.xraw
 python generateTestCase.py
 
-gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${RNN_DIR}/libdummyRNN.so ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
+gstTest "--gst-plugin-path=../../build tensor_mux name=mux ! tensor_filter framework=custom model=${RNN_DIR}/libdummyRNN.${SO_EXT} ! tee name=t ! queue ! tensor_reposink slot-index=0 silent=false filesrc location=\"video_4x4xBGRx.xraw\" ! application/octet-stream ! tensor_converter input-dim=4:4:4:1 input-type=uint8 ! mux.sink_0 tensor_reposrc slot-index=0 silent=false caps=\"other/tensor,dimension=(string)4:4:4:1,type=(string)uint8,framerate=(fraction)0/1\" ! mux.sink_1 t. ! queue ! multifilesink location=\"out_%1d.log\"" 1 0 0 $PERFORMANCE
 
 callCompareTest rnn.golden out_9.log 1-1 "Compare 1-1" 1 0
 


### PR DESCRIPTION
This patch replaces the hard-coded filename extension, 'so', in the custom filter, repo_lstm, and repo_rnn test scripts with SO_EXT defined at ssat-api.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Partially resolves a sub-item of #1608 

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [X]Passed [ ]Failed [ ]Skipped