### PR TITLE
[HOTFIX] [Fix/Test] nnapi test cases breaks non-Tizen-arm builds

### DIFF
--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -67,6 +67,7 @@ fi
 PATH_TO_MODEL="../test_models/models/mobilenet_v1_1.0_224_quant.tflite"
 PATH_TO_LABEL="../test_models/labels/labels.txt"
 PATH_TO_IMAGE="../test_models/data/orange.png"
+SYSTEM=`uname -m`
 
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} ! filesink location=tensorfilter.out.log" 1 0 0 $PERFORMANCE
 python checkLabel.py tensorfilter.out.log ${PATH_TO_LABEL} orange
@@ -80,17 +81,27 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} !
 
 # Property reading test for nnapi
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:cpu ! filesink location=tensorfilter.out.log" 2-1 1 0 $PERFORMANCE 2> info
-cat info | grep "true : cpu"
-testResult $? 2-1 "Golden test comparison" 0 1
+# This test is not critical because NNAPI is not available in some systems (it's available with Tizen-ARM only!)
+if [ "$SYSTEM" == "armv7l" ] || [ "$SYSTEM" == "aarch64" ]; then
+	cat info | grep "true : cpu"
+	testResult $? 2-1a "NNAPI activaion test" 1 1
+fi
 
 # Property reading test for nnapi
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true ! filesink location=tensorfilter.out.log" 2-2 1 0 $PERFORMANCE 2> info
-cat info | grep "true : cpu"
-testResult $? 2-2 "Golden test comparison" 0 1
+# This test is not critical because NNAPI is not available in some systems (it's available with Tizen-ARM only!)
+if [ "$SYSTEM" == "armv7l" ] || [ "$SYSTEM" == "aarch64" ]; then
+	cat info | grep "true : cpu"
+	testResult $? 2-2a "NNAPI activation test" 1 1
+fi
 
 # Property reading test for nnapi
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:gpu ! filesink location=tensorfilter.out.log" 2-3 1 0 $PERFORMANCE 2> info
-cat info | grep "true : gpu"
-testResult $? 2-3 "Golden test comparison" 0 1
+# This test is not critical because NNAPI is not available in some systems (it's available with Tizen-ARM only!)
+if [ "$SYSTEM" == "armv7l" ] || [ "$SYSTEM" == "aarch64" ]; then
+	cat info | grep "true : gpu"
+	testResult $? 2-3a "NNAPI activation test" 1 1
+	# This test is not critical because NNAPI is not available in some systems (it's available with Tizen-ARM only!)
+fi
 
 report


### PR DESCRIPTION
With SSAT updates, this bug has been exposed:
- New test cases of nnapi-tensorflow-lite require nnapi. However,
there are systems that do not support nnapi.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

ps. @jijoongmoon Please update nnapi test cases so that it is applied to Tizen-ARM/ARM64 systems only (then, update the 4th argument of ```testResult``` call from 1 to 0)