### PR TITLE
[Android/Api] add timeout in single-shot

### DIFF
--- a/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
+++ b/api/android/api/src/main/java/org/nnsuite/nnstreamer/SingleShot.java
@@ -39,6 +39,7 @@ public final class SingleShot implements AutoCloseable {
     private native TensorsData nativeInvoke(long handle, TensorsData in);
     private native TensorsInfo nativeGetInputInfo(long handle);
     private native TensorsInfo nativeGetOutputInfo(long handle);
+    private native boolean nativeSetTimeout(long handle, int timeout);
 
     /**
      * Creates a new <code>SingleShot</code> instance with the given model.
@@ -84,6 +85,10 @@ public final class SingleShot implements AutoCloseable {
      * Invokes the model with the given input data.
      * Even if the model has flexible input data dimensions,
      * input data frames of an instance of a model should share the same dimension.
+     *
+     * Note that this has a default timeout of 3 seconds.
+     * If an application wants to change the time to wait for an output,
+     * set the timeout using {@link #setTimeout(int)}.
      *
      * @param in The input data to be inferred (a single frame, tensor/tensors)
      *
@@ -141,6 +146,26 @@ public final class SingleShot implements AutoCloseable {
         }
 
         return info;
+    }
+
+    /**
+     * Sets the maximum amount of time to wait for an output, in milliseconds.
+     *
+     * @param timeout The time to wait for an output
+     *
+     * @throws IllegalArgumentException if given param is invalid
+     * @throws IllegalStateException if failed to set the timeout
+     */
+    public void setTimeout(int timeout) {
+        checkPipelineHandle();
+
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("The param timeout is invalid");
+        }
+
+        if (!nativeSetTimeout(mHandle, timeout)) {
+            throw new IllegalStateException("Failed to set the timeout");
+        }
     }
 
     /**

--- a/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-singleshot.c
@@ -188,3 +188,27 @@ done:
   ml_tensors_info_destroy (info);
   return result;
 }
+
+/**
+ * @brief Native method for single-shot API.
+ */
+jboolean
+Java_org_nnsuite_nnstreamer_SingleShot_nativeSetTimeout (JNIEnv * env, jobject thiz,
+    jlong handle, jint timeout)
+{
+  pipeline_info_s *pipe_info;
+  ml_single_h single;
+  int status;
+
+  pipe_info = CAST_TO_TYPE (handle, pipeline_info_s*);
+  single = pipe_info->pipeline_handle;
+
+  status = ml_single_set_timeout (single, (unsigned int) timeout);
+  if (status != ML_ERROR_NONE) {
+    nns_loge ("Failed to set the timeout.");
+    return JNI_FALSE;
+  }
+
+  nns_logi ("Successfully set the timeout, %d milliseconds.", timeout);
+  return JNI_TRUE;
+}

--- a/api/android/sample/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
+++ b/api/android/sample/src/main/java/org/nnsuite/nnstreamer/sample/MainActivity.java
@@ -262,6 +262,9 @@ public class MainActivity extends Activity {
             TensorsInfo outInfo = single.getOutputInfo();
             printTensorsInfo(outInfo);
 
+            /* set timeout (1 second) */
+            single.setTimeout(1000);
+
             /* single-shot invoke */
             for (int i = 0; i < 15; i++) {
                 /* dummy input */


### PR DESCRIPTION
Add method to set the timeout in single-shot API.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
