### PR TITLE
[Config] remove unnecessary lines

### DIFF
--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -11,9 +11,6 @@ customfilters=@SUBPLUGIN_INSTALL_PREFIX@/customfilters/
 [decoder]
 decoders=@SUBPLUGIN_INSTALL_PREFIX@/decoders/
 
-# Set 1 or True if you want to eliminate memcpy of tensorflow input frames for faster executions.
-# It may break in some special cases (running tensorflow & nnstreamer in a chroot of a AWS VM); in such a case, keep it 0 or FALSE.
-
 # Set 1 or True if you want to use NNAPI with tensorflow-lite, which enables to use NNAPI backend, which may use GPU or NPU/TPU.
 [tensorflowlite]
 enable_nnapi=False


### PR DESCRIPTION
Remove unnecessary lines about tensorflow optimization.
The key of mem-optimize was removed and these lines are now unnecessary.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
