### PR TITLE
[Tests/Plugins] Avoid warnings caused by a GCC bug related to gtest - @open sesame 09/19 18:24

### DIFF
--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -141,7 +141,8 @@ TEST (test_tensor_transform, properties)
 
   g_object_set (transform, "silent", !default_silent, NULL);
   g_object_get (transform, "silent", &res_silent, NULL);
-  EXPECT_EQ (!default_silent, res_silent);
+  /** expect FALSE, which is !default_silent */
+  EXPECT_FALSE (res_silent);
 
   /**
    * If HAVE_ORC is set, default acceleration is TRUE.
@@ -153,7 +154,8 @@ TEST (test_tensor_transform, properties)
 #ifdef HAVE_ORC
   g_object_set (transform, "acceleration", !default_accl, NULL);
   g_object_get (transform, "acceleration", &accl, NULL);
-  EXPECT_EQ (!default_accl, accl);
+  /** expect FALSE, which is !default_accl */
+  EXPECT_FALSE (accl);
 #endif
 
   /** We do not need to test setting properties for 'mode' and 'option' */


### PR DESCRIPTION
This PR is related to a sub-item of https://github.com/nnsuite/nnstreamer/issues/1608.

A GCC bug [1] might cause warnings related to 'conversion-null' when using googletest macros with !FALSE as arguments. Therefore, in the case that Werror is true, the build would be broken by this bug. To avoid such situation, this patch replaces EXPECT_EQs in the plugin unit tests with EXPECT_TRUE or EXPECT_FALSE.

[1] https://github.com/google/googletest/issues/322

Signed-off-by: Wook Song <wook16.song@samsung.com>


Detail build logs are as follows:
```bash
HOMEBREW_VERSION: 2.1.11
ORIGIN: https://github.com/Homebrew/brew
HEAD: 37714b5ce1e4909d4d61de2af98343c7012f7cd9
Last commit: 4 weeks ago
Core tap ORIGIN: https://github.com/Homebrew/linuxbrew-core
Core tap HEAD: 102f2c1f8abdf6f3ea4ffe0d65f854e7c8c83d22
Core tap last commit: 13 hours ago
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CACHE: /home/wook/.cache/Homebrew
HOMEBREW_LOGS: /home/wook/.cache/Homebrew/Logs
CPU: octa-core 64-bit skylake
Homebrew Ruby: 2.3.7 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby
Clang: 3.8 build 380
Git: 2.7.4 => /usr/bin/git
Curl: 7.47.0 => /usr/bin/curl
Java: 1.8.0_201
Kernel: Linux 4.15.0-62-generic x86_64 GNU/Linux
OS: Ubuntu 16.04.6 LTS (xenial)
Host glibc: 2.23
/usr/bin/gcc: 5.5.0
glibc: N/A
gcc: 5.5.0_4
xorg: 20170115_1

...omission...

[95/99] Compiling C++ object 'tests/59830eb@@unittest_plugins@exe/nnstreamer_plugins_unittest_plugins.cpp.o'.
FAILED: tests/59830eb@@unittest_plugins@exe/nnstreamer_plugins_unittest_plugins.cpp.o 
g++-5 -Itests/59830eb@@unittest_plugins@exe -Itests -I../tests -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/tensor_transform -I/home/linuxbrew/.linuxbrew/Cellar/pcre/8.43/include -I/home/linuxbrew/.linuxbrew/Cellar/glib/2.62.0/include/glib-2.0 -I/home/linuxbrew/.linuxbrew/Cellar/glib/2.62.0/lib/glib-2.0/include -I/home/linuxbrew/.linuxbrew/opt/gettext/include -I/home/linuxbrew/.linuxbrew/Cellar/libffi/3.2.1/lib/libffi-3.2.1/include -I/home/linuxbrew/.linuxbrew/Cellar/glib/2.62.0/include -I/home/linuxbrew/.linuxbrew/Cellar/gstreamer/1.16.0_1/include/gstreamer-1.0 -I/home/linuxbrew/.linuxbrew/Cellar/orc/0.4.29/include/orc-0.4 -I/home/linuxbrew/.linuxbrew/Cellar/gst-plugins-base/1.16.0_1/include/gstreamer-1.0 -I/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -Werror -std=c++11 -g '-DVERSION="0.3.0"' -Wredundant-decls -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -DHAVE_ORC=1 -DGTEST_HAS_PTHREAD=1 -pthread -MD -MQ 'tests/59830eb@@unittest_plugins@exe/nnstreamer_plugins_unittest_plugins.cpp.o' -MF 'tests/59830eb@@unittest_plugins@exe/nnstreamer_plugins_unittest_plugins.cpp.o.d' -o 'tests/59830eb@@unittest_plugins@exe/nnstreamer_plugins_unittest_plugins.cpp.o' -c ../tests/nnstreamer_plugins/unittest_plugins.cpp
In file included from /home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest.h:382:0,
                 from ../tests/nnstreamer_plugins/unittest_plugins.cpp:11:
../tests/nnstreamer_plugins/unittest_plugins.cpp: In member function 'virtual void test_tensor_transform_properties_Test::TestBody()':
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/internal/gtest-internal.h:135:55: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
     (sizeof(::testing::internal::IsNullLiteralHelper(x)) == 1)
                                                       ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest_pred_impl.h:76:52: note: in definition of macro 'GTEST_ASSERT_'
   if (const ::testing::AssertionResult gtest_ar = (expression)) \
                                                    ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest_pred_impl.h:161:3: note: in expansion of macro 'GTEST_PRED_FORMAT2_'
   GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_NONFATAL_FAILURE_)
   ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest.h:1967:3: note: in expansion of macro 'EXPECT_PRED_FORMAT2'
   EXPECT_PRED_FORMAT2(::testing::internal:: \
   ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest.h:1968:32: note: in expansion of macro 'GTEST_IS_NULL_LITERAL_'
                       EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
                                ^
../tests/nnstreamer_plugins/unittest_plugins.cpp:144:3: note: in expansion of macro 'EXPECT_EQ'
   EXPECT_EQ (!default_silent, res_silent);
   ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/internal/gtest-internal.h:135:55: error: converting 'false' to pointer type for argument 1 of 'char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)' [-Werror=conversion-null]
     (sizeof(::testing::internal::IsNullLiteralHelper(x)) == 1)
                                                       ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest_pred_impl.h:76:52: note: in definition of macro 'GTEST_ASSERT_'
   if (const ::testing::AssertionResult gtest_ar = (expression)) \
                                                    ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest_pred_impl.h:161:3: note: in expansion of macro 'GTEST_PRED_FORMAT2_'
   GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_NONFATAL_FAILURE_)
   ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest.h:1967:3: note: in expansion of macro 'EXPECT_PRED_FORMAT2'
   EXPECT_PRED_FORMAT2(::testing::internal:: \
   ^
/home/linuxbrew/.linuxbrew/Cellar/googletest/1.8.1/include/gtest/gtest.h:1968:32: note: in expansion of macro 'GTEST_IS_NULL_LITERAL_'
                       EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
                                ^
../tests/nnstreamer_plugins/unittest_plugins.cpp:156:3: note: in expansion of macro 'EXPECT_EQ'
   EXPECT_EQ (!default_accl, accl);
   ^
cc1plus: all warnings being treated as errors
[96/99] Compiling C++ object 'tests/59830eb@@unittest_sink@exe/nnstreamer_sink_unittest_sink.cpp.o'.
ninja: build stopped: subcommand failed.
```


