### PR TITLE
[Build] remove warning message

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1890,7 +1890,8 @@ typedef struct {
 /**
  * @brief Open and run on single shot API with provided data
  */
-void * single_shot_loop_test (void * arg)
+static void *
+single_shot_loop_test (void *arg)
 {
   guint i;
   int status = ML_ERROR_NONE;


### PR DESCRIPTION
function declaration to avoid build warning (missing-declaration)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
