### PR TITLE
[ReadMe] Correct typo in bullet items under Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ In [Component Description](Documentation/component-description.md) page, we desc
 
 ## Getting Started
 For more details, please access the following manuals.
-* For Linux-like systems such as Tizen, Debian, and Ubuntu, press [Here](Documentation/getting-started.md)
-* For macOS systems, press [Here](Documentation/getting-started-macos.md)
+* For Linux-like systems such as Tizen, Debian, and Ubuntu, press [here](Documentation/getting-started.md)
+* For macOS systems, press [here](Documentation/getting-started-macos.md)
 
 ## Usage Examples
 - [Example apps](https://github.com/nnsuite/nnstreamer-example) (stable)


### PR DESCRIPTION
This patch corrects typo in bullet items under the Getting Started section.

Signed-off-by: Wook Song <wook16.song@samsung.com>