### PR TITLE
[Tests/RepoDynamicity] Support running tests on Yocto @open sesame 09/25 19:05

### DIFF
--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -29,10 +29,12 @@ else
 fi
 convertBMP2PNG
 
-if [[ -z "${UNITTEST_DIR// /}" ]]; then
-    TESTBINDIR="../../build/tests/"
-else
+if [[ ! -z "${UNITTEST_DIR}" ]]; then
     TESTBINDIR="${UNITTEST_DIR}"
+elif [ ! -d "${PATH_TO_PLUGIN}" ] && [ ! -d "${UNITTEST_DIR}" ]; then
+    TESTBINDIR="/usr/lib/nnstreamer/unittest"
+else
+    TESTBINDIR="../../build/tests"
 fi
 
 ${TESTBINDIR}/unittest_repo --gst-plugin-path=../../build


### PR DESCRIPTION
As a workaround for running tests on Yocto, this patch uses the default installation directory excepting that the tests are running at the build time or the directory where the test binary is located is provided.

Signed-off-by: Wook Song <wook16.song@samsung.com>