### PR TITLE
[Tests/TFLite] Run NNAPI tests only on Tizen

### DIFF
--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -78,22 +78,24 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} !
 # Fail test for invalid output properties
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} output=1:7 outputtype=int8 ! filesink location=tensorfilter.out.log" 3F_n 0 1 $PERFORMANCE
 
-# Property reading test for nnapi
-gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:cpu ! filesink location=tensorfilter.out.log 2> info
+if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; then
+    # Property reading test for nnapi
+    gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:cpu ! filesink location=tensorfilter.out.log 2> info
 
-cat info | grep "true : cpu"
-testResult $? 2-1 "NNAPI activaion test" 1 1
+    cat info | grep "true : cpu"
+    testResult $? 2-1 "NNAPI activaion test" 1 1
 
-# Property reading test for nnapi
-gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true ! filesink location=tensorfilter.out.log 2> info
+    # Property reading test for nnapi
+    gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true ! filesink location=tensorfilter.out.log 2> info
 
-cat info | grep "true : cpu"
-testResult $? 2-2 "NNAPI activation test" 1 1
+    cat info | grep "true : cpu"
+    testResult $? 2-2 "NNAPI activation test" 1 1
 
-# Property reading test for nnapi
-gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:gpu ! filesink location=tensorfilter.out.log 2> info
+    # Property reading test for nnapi
+    gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} nnapi=true:gpu ! filesink location=tensorfilter.out.log 2> info
 
-cat info | grep "true : gpu"
-testResult $? 2-3 "NNAPI activation test" 1 1
+    cat info | grep "true : gpu"
+    testResult $? 2-3 "NNAPI activation test" 1 1
+fi
 
 report


### PR DESCRIPTION
NNAPI tests are only needded in the case of Tizen. Although these tests are not harmful on the other platform, this patch makes those NNAPI tests run only on Tizen.

Signed-off-by: Wook Song <wook16.song@samsung.com>