### PR TITLE
Release of nnstreamer 1.0.0 (1.0 RC2) @open sesame 9/30 13:28

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+0.3.0 -> 1.0.0:
+	- Tizen Public C-API (Single & Pipeline) Reviewed and Confirmed!
+	- Tizen Public C#-API (Single) Reviewed and Confirmed!
+	- Tested with Tizen Studio.
+	- Official API test suites released via Tizen.
+	- Android Java-API released via JCenter for Android Studio users.
+	- Passed Quality Assurance. (code quality, stability, security, compliance, and so on)
+		- Fixed a lot of minor bugs in the course.
+	- Support macOS
+	- Fixed regressions related with ROS and Yocto support.
+
 0.2.0 -> 0.3.0:
 	- Tizen Public C-API Single/Pipeline RC1 Fixed for 5.5 M2
 	- Tizen Public C-API RC2 features included (pipeline whitelist, aliasing)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (1.0.0.0) unstable xenial bionic; urgency=medium
+
+  * 1.0.0 Release (1.0 RC2). NNStreamer becomes 1.0 with Tizen 5.5 M2 official release.
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Thu, 26 Sep 2019 15:39:00 +0900
+
 nnstreamer (0.3.0.0) unstable xenial bionic; urgency=medium
 
   * 0.3.0 Release. 0.2.1 becomes 0.3.0 as a lot of features are included for commercialization.

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -5,7 +5,7 @@ $(warning NNSTREAMER_ROOT is not defined! Using $(LOCAL_PATH)/.. )
 NNSTREAMER_ROOT := $(LOCAL_PATH)/..
 endif
 
-NNSTREAMER_VERSION  := 0.3.0
+NNSTREAMER_VERSION  := 1.0.0
 
 NNSTREAMER_GST_HOME := $(NNSTREAMER_ROOT)/gst/nnstreamer
 NNSTREAMER_EXT_HOME := $(NNSTREAMER_ROOT)/ext/nnstreamer

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
 
 project('nnstreamer', 'c', 'cpp',
-  version: '0.3.0',
+  version: '1.0.0',
   license: ['LGPL'],
   meson_version: '>=0.42.0',
   default_options: [

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -14,7 +14,7 @@ Summary:	gstremaer plugins for neural networks
 # 2. Tizen  : ./packaging/nnstreamer.spec
 # 3. Android: ./jni/nnstreamer.mk
 # 4. Meson  : ./meson.build
-Version:	0.3.0
+Version:	1.0.0
 Release:	0
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -377,8 +377,11 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %endif
 
 %changelog
+* Thu Sep 26 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 1.0.0 (1.0 RC2)
+
 * Wed Aug 14 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
-- Release of 0.3.0
+- Release of 0.3.0 (1.0 RC1)
 
 * Mon May 27 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.2.0


### PR DESCRIPTION
This is 1.0 RC2.
With Tizen Official Release, 1.0 stable will be released.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>



I'll merge this commit with next SR in Tizen.org. Don't merge it before that.