### PR TITLE
[Tests] Make tool scripts written in python be compatible with python3 @open sesame 9/27 15:09

### DIFF
--- a/tests/gen24bBMP.py
+++ b/tests/gen24bBMP.py
@@ -14,6 +14,24 @@ from struct import pack
 import random
 import sys
 
+##
+# @brief Convert given data to bytes
+# @param[in] data The data to be converted to bytes array
+# @return bytes converted from the data
+
+def convert_to_bytes(data):
+    """
+    Convert given data to bytes
+
+    @param  data: The data to be converted to bytes
+    @rtype      : bytes
+    @return     : bytes converted from the data
+    """
+
+    if isinstance(data, bytes):
+        return data
+    else:
+        return pack("<B", data)
 
 ##
 # @brief Save bitmap "data" to "filename"
@@ -34,9 +52,9 @@ def saveBMP(filename, data, colorspace, width, height):
         for h in range(height-1, -1, -1):
             for w in range(0, width):
                 pos = 3 * (w + width * h)
-                graphics += data[pos+2]
-                graphics += data[pos+1]
-                graphics += data[pos]
+                graphics += convert_to_bytes(data[pos + 2])
+                graphics += convert_to_bytes(data[pos + 1])
+                graphics += convert_to_bytes(data[pos])
             for x in range(0, (width * 3) % 4):
                 graphics += pack('<B', 0)
     elif colorspace == 'BGRx':
@@ -46,9 +64,9 @@ def saveBMP(filename, data, colorspace, width, height):
         for h in range(height-1, -1, -1):
             for w in range(0, width):
                 pos = bytes_per_px * (w + width * h)
-                graphics += data[pos]
-                graphics += data[pos+1]
-                graphics += data[pos+2]
+                graphics += convert_to_bytes(data[pos])
+                graphics += convert_to_bytes(data[pos + 1])
+                graphics += convert_to_bytes(data[pos + 2])
             for x in range(0, (width * 3) % 4):
                 graphics += pack('<B', 0)
     elif colorspace == 'GRAY8':
@@ -58,7 +76,7 @@ def saveBMP(filename, data, colorspace, width, height):
         for h in range(height-1, -1, -1):
             for w in range(0, width):
                 pos = bytes_per_px * (w + width * h)
-                graphics += data[pos]
+                graphics += convert_to_bytes(data[pos])
             for x in range(0, (width * 3) % 4):
                 graphics += pack('<B', 0)
     else:

--- a/tests/nnstreamer_converter/generateGoldenTestResult.py
+++ b/tests/nnstreamer_converter/generateGoldenTestResult.py
@@ -51,7 +51,7 @@ if target == -1 or target == 9:
             file.write(s[i])
 
     for i in range(0,10):
-        sink_1 = i/3;
+        sink_1 = i // 3;
         with open("testsynch03_"+str(i)+".golden",'wb') as file:
             file.write(s[i])
             file.write(s[sink_1])
@@ -81,7 +81,7 @@ if target == -1 or target == 9:
     id=[0,1,1,2,3,3,4,5,5,6]
     for i in range(0,10):
         sink_0 = id[i]
-        sink_1 = i/3
+        sink_1 = i // 3
         with open("testsynch05_"+str(i)+".golden",'wb') as file:
             file.write(s[i])
             file.write(s[sink_0])
@@ -143,21 +143,21 @@ if target == -1 or target == 11:
     s=b''
     for y in range(0,100):
         for x in range(0,100):
-            s+=buf[y*100+x];
+            s += bmp.convert_to_bytes(buf[y * 100 + x])
     bmp.write('testcase_1_0.golden', s);
 
     s = b''
     for i in range(1, 3):
         for y in range(0,100):
             for x in range(0,100):
-                s+=buf[y*100+x + i*100*100];
+                s += bmp.convert_to_bytes(buf[y*100+x + i*100*100]);
     bmp.write('testcase_1_1.golden', s);
 
     for i in range(0,3):
         s = b''
         for y in range(0,100):
             for x in range(0,100):
-                s += buf[y*100+x + i*100*100]
+                s += bmp.convert_to_bytes(buf[y*100+x + i*100*100])
         bmp.write('testcase_2_'+str(i)+'.golden', s)
 
     string = bmp.gen_BMP_stream('testsequence', 'testcase_stream.golden', 1)
@@ -166,7 +166,7 @@ if target == -1 or target == 11:
     for i in range (0,10):
         for y in range(0,16):
             for x in range(0,16):
-                s += string[i][y*16+x]
+                s += bmp.convert_to_bytes(string[i][y*16+x])
     bmp.write('testcase_stream_1_0.golden',s)
 
     s=b''
@@ -174,7 +174,7 @@ if target == -1 or target == 11:
         for j in range (1,3):
             for y in range(0,16):
                 for x in range(0,16):
-                    s += string[i][j*16*16+ y*16+x]
+                    s += bmp.convert_to_bytes(string[i][j*16*16+ y*16+x])
     bmp.write('testcase_stream_1_1.golden',s)
 
     for j in range (0,3):
@@ -182,7 +182,7 @@ if target == -1 or target == 11:
         for i in range (0,10):
             for y in range(0,16):
                 for x in range(0,16):
-                    s += string[i][j*16*16+ y*16+x]
+                    s += bmp.convert_to_bytes(string[i][j*16*16+ y*16+x])
         bmp.write('testcase_stream_2_'+str(j)+'.golden',s)
 
 if target == -1 or target == 12:

--- a/tests/nnstreamer_filter_caffe2/checkLabel.py
+++ b/tests/nnstreamer_filter_caffe2/checkLabel.py
@@ -9,22 +9,33 @@
 # @author HyoungJoo Ahn <hello.ahn@samsung.com>
 
 import sys
+import os
 import struct
 import string
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from gen24bBMP  import convert_to_bytes
+
+if sys.version_info < (3,):
+    range = xrange
 
 def readbyte (filename):
-  F = open(filename, 'r')
-  readbyte = F.read()
-  F.close()
-  return readbyte
+    F = open(filename, 'rb')
+    readbyte = F.read()
+    F.close()
+    return readbyte
+
 
 bytearr = readbyte(sys.argv[1])
 softmax = []
-for i in xrange(10):
-  byte = bytearr[i * 4] + bytearr[i * 4 + 1] + bytearr[i * 4 + 2] + bytearr[i * 4 + 3]
-  softmax.append(struct.unpack('f', byte))
+for i in range(10):
+    byte = b''
+    byte += convert_to_bytes(bytearr[i * 4])
+    byte += convert_to_bytes(bytearr[i * 4 + 1])
+    byte += convert_to_bytes(bytearr[i * 4 + 2])
+    byte += convert_to_bytes(bytearr[i * 4 + 3])
+    softmax.append(struct.unpack('f', byte))
 
 pred = softmax.index(max(softmax))
-answer = string.atoi(sys.argv[2].strip())
+answer = int(sys.argv[2].strip())
 
 exit(pred != answer)

--- a/tests/nnstreamer_filter_custom/checkScaledTensor.py
+++ b/tests/nnstreamer_filter_custom/checkScaledTensor.py
@@ -30,8 +30,8 @@ def compare (data1, width1, height1, data2, width2, height2, innerdim):
     for y in range(0, height2):
       for x in range(0, width2):
         for c in range(0, innerdim):
-          ix = x * width1 / width2
-          iy = y * height1 / height2
+          ix = x * width1 // width2
+          iy = y * height1 // height2
           if data1[count + c + ix * innerdim + iy * width1 * innerdim] != data2[count2 + c + x * innerdim + y * width2 * innerdim]:
             print("At "+str(x)+","+str(y))
             return 5
@@ -45,7 +45,7 @@ def compare (data1, width1, height1, data2, width2, height2, innerdim):
   return 0
 
 def readfile (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readfile = F.read()
   F.close()
   return readfile

--- a/tests/nnstreamer_filter_python/checkScaledTensor.py
+++ b/tests/nnstreamer_filter_python/checkScaledTensor.py
@@ -31,8 +31,8 @@ def compare (data1, width1, height1, data2, width2, height2, innerdim):
     for y in range(0, height2):
       for x in range(0, width2):
         for c in range(0, innerdim):
-          ix = x * width1 / width2
-          iy = y * height1 / height2
+          ix = x * width1 // width2
+          iy = y * height1 // height2
           if data1[count + c + ix * innerdim + iy * width1 * innerdim] != data2[count2 + c + x * innerdim + y * width2 * innerdim]:
             print("At "+str(x)+","+str(y))
             return 5
@@ -47,7 +47,7 @@ def compare (data1, width1, height1, data2, width2, height2, innerdim):
 
 ## @brief Read file and return its content
 def readfile (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readfile = F.read()
   F.close()
   return readfile

--- a/tests/nnstreamer_filter_pytorch/checkLabel.py
+++ b/tests/nnstreamer_filter_pytorch/checkLabel.py
@@ -9,16 +9,21 @@
 # @author Parichay Kapoor <pk.kapoor@samsung.com>
 
 import sys
+import os
+import struct
+import string
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from gen24bBMP import convert_to_bytes
 
 # Read the bytes from the file
 def readbyte (filename):
-  with open(filename, 'r') as f:
-    readbyte = f.read()
-  return readbyte
+    with open(filename, 'rb') as f:
+      readbyte = f.read()
+    return readbyte
 
 # Verify that the output of test case verifies the filename of the input
 onehot = readbyte(sys.argv[1])
-onehot = [str(ord(x)) for x in onehot]
+onehot = [convert_to_bytes(x) for x in onehot]
 idx = onehot.index(max(onehot))
 
 label = str(idx)

--- a/tests/nnstreamer_filter_tensorflow/checkLabel.py
+++ b/tests/nnstreamer_filter_tensorflow/checkLabel.py
@@ -9,28 +9,38 @@
 # @author HyoungJoo Ahn <hello.ahn@samsung.com>
 
 import sys
+import os
 import struct
 import string
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from gen24bBMP  import convert_to_bytes
+
+if sys.version_info < (3,):
+    range = xrange
 
 def readbyte (filename):
-  F = open(filename, 'r')
-  readbyte = F.read()
-  F.close()
-  return readbyte
+    F = open(filename, 'rb')
+    readbyte = F.read()
+    F.close()
+    return readbyte
 
 
 def readlabel (filename):
-  F = open(filename, 'r')
-  line = F.readlines()
-  F.close()
-  return line
+    F = open(filename, 'r')
+    line = F.readlines()
+    F.close()
+    return line
 
 bytearr = readbyte(sys.argv[1])
 softmax = []
-for i in xrange(10):
-  byte = bytearr[i * 4] + bytearr[i * 4 + 1] + bytearr[i * 4 + 2] + bytearr[i * 4 + 3]
-  softmax.append(struct.unpack('f', byte))
+for i in range(10):
+    byte = b''
+    byte += convert_to_bytes(bytearr[i * 4])
+    byte += convert_to_bytes(bytearr[i * 4 + 1])
+    byte += convert_to_bytes(bytearr[i * 4 + 2])
+    byte += convert_to_bytes(bytearr[i * 4 + 3])
+    softmax.append(struct.unpack('f', byte))
 
 pred = softmax.index(max(softmax))
-answer = string.atoi(sys.argv[2].strip())
+answer = int(sys.argv[2].strip())
 exit(pred != answer)

--- a/tests/nnstreamer_filter_tensorflow_lite/checkLabel.py
+++ b/tests/nnstreamer_filter_tensorflow_lite/checkLabel.py
@@ -9,10 +9,15 @@
 # @author HyoungJoo Ahn <hello.ahn@samsung.com>
 
 import sys
+import os
+import struct
+import string
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from gen24bBMP import convert_to_bytes
 
 
 def readbyte (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readbyte = F.read()
   F.close()
   return readbyte
@@ -25,7 +30,7 @@ def readlabel (filename):
   return line
 
 onehot = readbyte(sys.argv[1])
-onehot = [str(ord(x)) for x in onehot]
+onehot = [convert_to_bytes(x) for x in onehot]
 idx = onehot.index(max(onehot))
 
 label_list = readlabel(sys.argv[2])

--- a/tests/nnstreamer_repo_rnn/generateTestCase.py
+++ b/tests/nnstreamer_repo_rnn/generateTestCase.py
@@ -17,6 +17,10 @@ from __future__ import print_function
 import sys
 import os
 import array as arr
+import struct
+import string
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from gen24bBMP import convert_to_bytes
 
 def location(c, w, h):
     return c+4*(w+4*h)
@@ -46,31 +50,32 @@ def genFrame(seq, out):
     for h in range(0,4):
         w=0
         for i in range(0,4):
-            out[location(i,w,h)]=frame[location(i,w,h)]
+            out[location(i,w,h)] = frame[location(i,w,h)]
         for w in range(1,3):
             for c in range(0,4):
                 sum = frame[location(0,w,h)]
                 sum += out[location(0,w,h)]
-                out[location(0,w,h)] = sum/2
+                out[location(0,w,h)] = sum // 2
         w=3
         for i in range(0,4):
             out[location(i,w,h)] = out[location(i,w,h)]
 
-    return frame.tostring(), out
+    return frame, out
 
 filename = "video_4x4xBGRx.xraw"
-f = open(filename, "w")
+f = open(filename, "wb")
 
 out = arr.array('B',[0]*64)
 
 for seq in range(0, 10):
     outfilename = "rnn.golden"
-    string, out=genFrame(seq,out)
+    frame, out = genFrame(seq,out)
+
     if(seq == 9):
         with open(outfilename,'wb') as file:
             file.write(out.tostring())
 
-    f.write(string)
+    f.write(frame)
 
 f.close()
 

--- a/tests/transform_dimchg/checkResult.py
+++ b/tests/transform_dimchg/checkResult.py
@@ -18,10 +18,10 @@ import sys
 def testDimchgFirstDimGoHigher(dataA, dataB, dim1, repeatblocksize, elementsize):
   if (len(dataA) != len(dataB)):
     return 1
-  loop = len(dataA) / repeatblocksize
+  loop = len(dataA) // repeatblocksize
   if ((loop * repeatblocksize) != len(dataA)):
     return 2
-  ncpy = repeatblocksize / dim1 / elementsize
+  ncpy = repeatblocksize // dim1 // elementsize
   if ((ncpy * dim1 * elementsize) != repeatblocksize):
     return 3
   for x in range(0, loop):
@@ -33,7 +33,7 @@ def testDimchgFirstDimGoHigher(dataA, dataB, dim1, repeatblocksize, elementsize)
           return 4
 
 def readfile (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readfile = F.read()
   F.close
   return readfile

--- a/tests/transform_stand/checkResult.py
+++ b/tests/transform_stand/checkResult.py
@@ -22,8 +22,8 @@ def testStandardization (fna, fnb, typeasize, typebsize,typeapack, typebpack):
 
   if (0 < (lena % typeasize)) or (0 < (lenb % typebsize)):
     return 10
-  num = lena / typeasize
-  if num != (lenb / typebsize):
+  num = lena // typeasize
+  if num != (lenb // typebsize):
     return 11
   limitb = 2 ** (8 * typebsize)
   maskb = limitb - 1
@@ -36,7 +36,7 @@ def testStandardization (fna, fnb, typeasize, typebsize,typeapack, typebpack):
   return 0
 
 def readfile (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readfile = F.read()
   F.close
   return readfile

--- a/tests/transform_typecast/checkResult.py
+++ b/tests/transform_typecast/checkResult.py
@@ -22,8 +22,8 @@ def testTypeCast (fna, fnb, typea, typeasize, typeapack, typeb, typebsize, typeb
 
   if (0 < (lena % typeasize)) or (0 < (lenb % typebsize)):
     return 10
-  num = lena / typeasize
-  if num != (lenb / typebsize):
+  num = lena // typeasize
+  if num != (lenb // typebsize):
     return 11
   limitb = 2 ** (8 * typebsize)
   maskb = limitb - 1
@@ -50,7 +50,7 @@ def testTypeCast (fna, fnb, typea, typeasize, typeapack, typeb, typebsize, typeb
   return 0
 
 def readfile (filename):
-  F = open(filename, 'r')
+  F = open(filename, 'rb')
   readfile = F.read()
   F.close
   return readfile


### PR DESCRIPTION
There are several platforms which do not support python2.7 by default anymore. To prepare this issue, this patch revises all python scripts in tests to be also compatible with python3.

Signed-off-by: Wook Song <wook16.song@samsung.com>