### PR TITLE
[Android/Test] tc fail case

### DIFF
--- a/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
+++ b/api/android/api/src/androidTest/java/org/nnsuite/nnstreamer/APITestPipeline.java
@@ -86,6 +86,7 @@ public class APITestPipeline {
         try (Pipeline pipe = new Pipeline(desc, null)) {
             Thread.sleep(100);
             assertEquals(NNStreamer.PIPELINE_STATE_PAUSED, pipe.getState());
+            Thread.sleep(100);
         } catch (Exception e) {
             fail();
         }
@@ -119,6 +120,7 @@ public class APITestPipeline {
             Thread.sleep(300);
 
             assertEquals(NNStreamer.PIPELINE_STATE_PAUSED, mPipelineState);
+            Thread.sleep(100);
         } catch (Exception e) {
             fail();
         }
@@ -141,6 +143,7 @@ public class APITestPipeline {
             Thread.sleep(300);
 
             assertEquals(NNStreamer.PIPELINE_STATE_PAUSED, pipe.getState());
+            Thread.sleep(100);
         } catch (Exception e) {
             fail();
         }


### PR DESCRIPTION
Sometimes testcase failed with pipeline state NULL when stopping the pipeline.
Add sleep time before closing the pipeline.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
