### PR TITLE
[Api/Tizen] handle dpm restriction case

### DIFF
--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -48,6 +48,7 @@ if (get_option('enable-tizen'))
   message('CAPI is in Tizen mode')
 
   tizen_deps = [
+    dependency('dpm'),
     dependency('mm-resource-manager'),
     dependency('mm-camcorder'),
     dependency('capi-privacy-privilege-manager'),

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -634,6 +634,7 @@ ml_pipeline_destroy (ml_pipeline_h pipe)
     }
 
     gst_object_unref (p->element);
+    p->element = NULL;
   }
 
   /* Destroy registered callback handles and resources */

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -68,6 +68,7 @@ BuildRequires: lcov
 %define		enable_nnfw_runtime	-Denable-nnfw-runtime=false
 %define		enable_nnfw_r	0
 %if %{with tizen}
+BuildRequires:	pkgconfig(dpm)
 BuildRequires:	pkgconfig(mm-resource-manager)
 BuildRequires:	pkgconfig(mm-camcorder)
 BuildRequires:	pkgconfig(capi-privacy-privilege-manager)


### PR DESCRIPTION
Check the pipeline with device policy restricted case.
Create dpm handle and when trying to start the pipeline, check device policy and handle error case.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
