### PR TITLE
[API/Tizen] Fix the rootstrap buildbreak issue

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -281,7 +281,7 @@ popd
 
 # Hotfix: Support backward compatibility
 pushd %{buildroot}%{_libdir}
-ln -sf %{_libdir}/libcapi-nnstreamer.so libcapi-nnstreamer.so.0
+ln -sf ./libcapi-nnstreamer.so libcapi-nnstreamer.so.0
 popd
 
 %if 0%{?testcoverage}


### PR DESCRIPTION
This patch fixes the rootstrap buildbreak issue by using relative path
instead of absolute one.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
