### PR TITLE
[test]Change num_buffers type from guint to gint @open sesame 10/14 18:52

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.c
@@ -379,7 +379,7 @@ bb_setOption (void **pdata, int opNum, const char *param)
     bounding_box_modes previous = bdata->mode;
     bdata->mode = find_key_strv (bb_modes, param);
 
-    if (NULL == param || *param == '\0' || bdata->mode < 0) {
+    if (NULL == param || *param == '\0') {
       GST_ERROR ("Please set the valid mode at option1");
       return FALSE;
     }

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -128,7 +128,7 @@ typedef enum
  */
 typedef struct
 {
-  guint num_buffers; /**< count of buffers */
+  gint num_buffers; /**< count of buffers */
   TestType test_type; /**< test pipeline */
   tensor_type t_type; /**< tensor type */
   char *tmpfile; /**< tmpfile to write */
@@ -156,7 +156,7 @@ typedef struct
   GstTensorConfig tensor_config; /**< tensor config from negotiated caps */
   GstTensorsConfig tensors_config; /**< tensors config from negotiated caps */
   TestOption option; /**< test option */
-  guint buffer_index; /**< index of buffers sent by appsrc */
+  gint buffer_index; /**< index of buffers sent by appsrc */
 } TestData;
 
 /**


### PR DESCRIPTION
It is dangerous to cast from gint to guint and vice versa.
According to Gstreamer GstBaseSrc menual, num-buffer's type is  'gint' not 'guint'.
num-buffers means 'Number of buffers to output before sending EOS (-1 = unlimited).
And because of comparison with buffer_index, buffer_index also must be also gint type.

<https://gstreamer.freedesktop.org/documentation/base/gstbasesrc.html?gi-language=c#GstBaseSrc:num-buffers>

Signed-off-by: Niklas Jang <niklasjang@gmail.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped