### PR TITLE
[Typecast] Use explicit type casting with g_ascii_strto(u)ll function

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -981,7 +981,7 @@ gst_tensor_get_type (const gchar * typestr)
 
   if (g_regex_match_simple ("^uint(8|16|32|64)$",
           type_string, G_REGEX_CASELESS, 0)) {
-    size = g_ascii_strtoull (&type_string[4], NULL, 10);
+    size = (gsize) g_ascii_strtoull (&type_string[4], NULL, 10);
 
     switch (size) {
       case 8:
@@ -998,7 +998,7 @@ gst_tensor_get_type (const gchar * typestr)
     }
   } else if (g_regex_match_simple ("^int(8|16|32|64)$",
           type_string, G_REGEX_CASELESS, 0)) {
-    size = g_ascii_strtoull (&type_string[3], NULL, 10);
+    size = (gsize) g_ascii_strtoull (&type_string[3], NULL, 10);
 
     switch (size) {
       case 8:
@@ -1015,7 +1015,7 @@ gst_tensor_get_type (const gchar * typestr)
     }
   } else if (g_regex_match_simple ("^float(32|64)$",
           type_string, G_REGEX_CASELESS, 0)) {
-    size = g_ascii_strtoull (&type_string[5], NULL, 10);
+    size = (gsize) g_ascii_strtoull (&type_string[5], NULL, 10);
 
     switch (size) {
       case 32:
@@ -1195,12 +1195,12 @@ gst_tensor_time_sync_set_option_data (tensor_time_sync_data * sync)
 
       strv = g_strsplit (sync->option, ":", 2);
       if (strv[0] != NULL)
-        sink_id = g_ascii_strtoull (strv[0], NULL, 10);
+        sink_id = (guint) g_ascii_strtoull (strv[0], NULL, 10);
       else
         sink_id = 0;
 
       if (strv[1] != NULL)
-        duration = g_ascii_strtoull (strv[1], NULL, 10);
+        duration = (guint) g_ascii_strtoull (strv[1], NULL, 10);
       else
         duration = G_MAXINT;
 

--- a/gst/nnstreamer/tensor_source/tensor_src_iio.c
+++ b/gst/nnstreamer/tensor_source/tensor_src_iio.c
@@ -602,7 +602,8 @@ gst_tensor_src_iio_get_id_by_name (const gchar * dir_name, const gchar * name,
     if (g_str_has_prefix (dir_entry->d_name, prefix) &&
         g_ascii_isdigit (dir_entry->d_name[strlen (prefix)])) {
 
-      id = g_ascii_strtoll (dir_entry->d_name + strlen (prefix), NULL, 10);
+      id = (gint) g_ascii_strtoll (dir_entry->d_name + strlen (prefix), NULL,
+          10);
       filename =
           g_build_filename (dir_name, dir_entry->d_name, NAME_FILE, NULL);
 
@@ -914,7 +915,7 @@ gst_tensor_src_iio_get_all_channel_info (GstTensorSrcIIO * self,
       }
       g_free (filename);
 
-      value = g_ascii_strtoull (file_contents, NULL, 10);
+      value = (guint) g_ascii_strtoull (file_contents, NULL, 10);
       g_free (file_contents);
       if (value == 1) {
         channel_prop->enabled = TRUE;
@@ -941,7 +942,7 @@ gst_tensor_src_iio_get_all_channel_info (GstTensorSrcIIO * self,
       }
       g_free (filename);
 
-      value = g_ascii_strtoull (file_contents, NULL, 10);
+      value = (guint) g_ascii_strtoull (file_contents, NULL, 10);
       g_free (file_contents);
       channel_prop->index = value;
 
@@ -1068,7 +1069,7 @@ gst_tensor_src_iio_get_available_frequency (const gchar * base_dir,
    * else verify the frequency received from user is supported by the device
    */
   if (frequency == 0) {
-    ret = g_ascii_strtoull (freq_list[0], NULL, 10);
+    ret = g_ascii_strtoll (freq_list[0], NULL, 10);
   } else {
     for (i = 0; i < num; i++) {
       val = g_ascii_strtoull (freq_list[i], NULL, 10);
@@ -1178,7 +1179,7 @@ gst_tensor_src_iio_set_property (GObject * object, guint prop_id,
         strv = g_strsplit_set (param, ",;", -1);
         num = g_strv_length (strv);
         for (i = 0; i < num; i++) {
-          val = g_ascii_strtoull (strv[i], &endptr, 10);
+          val = g_ascii_strtoll (strv[i], &endptr, 10);
           if (errno == ERANGE || errno == EINVAL || (endptr == strv[i]
                   && val == 0)) {
             GST_ERROR_OBJECT (self, "Cannot parse received custom channels %s",
@@ -1865,7 +1866,8 @@ gst_tensor_src_iio_setup_device_buffer (GstTensorSrcIIO * self)
   if (!g_file_get_contents (filename, &file_contents, &length, NULL)) {
     GST_WARNING_OBJECT (self, "Unable to read default buffer capacity.");
   } else if (file_contents != NULL && length > 0) {
-    self->default_buffer_capacity = g_ascii_strtoull (file_contents, NULL, 10);
+    self->default_buffer_capacity =
+        (guint) g_ascii_strtoull (file_contents, NULL, 10);
   }
   g_free (file_contents);
   g_free (filename);

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -747,8 +747,8 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
 
       strv = g_strsplit (filter->option, ":", 2);
 
-      filter->data_dimchg.from = g_ascii_strtoull (strv[0], NULL, 10);
-      filter->data_dimchg.to = g_ascii_strtoull (strv[1], NULL, 10);
+      filter->data_dimchg.from = (int) g_ascii_strtoll (strv[0], NULL, 10);
+      filter->data_dimchg.to = (int) g_ascii_strtoll (strv[1], NULL, 10);
       filter->loaded = TRUE;
       g_strfreev (strv);
       break;
@@ -900,7 +900,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       strv = g_strsplit (filter->option, ":", NNS_TENSOR_RANK_LIMIT);
       for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
         filter->data_transpose.trans_order[i] =
-            g_ascii_strtoull (strv[i], NULL, 10);
+            (uint8_t) g_ascii_strtoull (strv[i], NULL, 10);
       }
 
       filter->loaded = TRUE;

--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -1076,7 +1076,7 @@ TEST (test_tensor_src_iio, \
   dev0 = make_full_device (data_value, data_bits, FALSE, SKIP); \
   ASSERT_NE (dev0, nullptr); \
   /** setup */ \
-  samp_freq = g_ascii_strtoll (samp_freq_avail[0], NULL, 10); \
+  samp_freq = (gint) g_ascii_strtoll (samp_freq_avail[0], NULL, 10); \
   dev0->log_file = g_build_filename (dev0->base_dir, "temp.log", NULL); \
   parse_launch =  g_strdup_printf ( \
       "%s device=%s silent=FALSE ! multifilesink location=%s", \
@@ -1196,7 +1196,7 @@ TEST (test_tensor_src_iio, data_verify_trigger)
   ASSERT_NE (dev0, nullptr);
   /** setup */
   num_scan_elements = dev0->num_scan_elements;
-  samp_freq = g_ascii_strtoll (samp_freq_avail[0], NULL, 10);
+  samp_freq = (gint) g_ascii_strtoll (samp_freq_avail[0], NULL, 10);
   dev0->log_file = g_build_filename (dev0->base_dir, "temp.log", NULL);
   parse_launch =
       g_strdup_printf
@@ -1322,7 +1322,7 @@ TEST (test_tensor_src_iio, data_verify_custom_channels)
   dev0 = make_full_device (data_value, data_bits);
   ASSERT_NE (dev0, nullptr);
   /** setup */
-  samp_freq = g_ascii_strtoll (samp_freq_avail[0], NULL, 10);
+  samp_freq = (gint) g_ascii_strtoll (samp_freq_avail[0], NULL, 10);
   dev0->log_file = g_build_filename (dev0->base_dir, "temp.log", NULL);
   parse_launch =
       g_strdup_printf
@@ -1428,7 +1428,7 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
   ASSERT_NE (dev0, nullptr);
   /** setup */
   num_scan_elements = dev0->num_scan_elements;
-  samp_freq = g_ascii_strtoll (samp_freq_avail[samp_freq_idx], NULL, 10);
+  samp_freq = (gint) g_ascii_strtoll (samp_freq_avail[samp_freq_idx], NULL, 10);
   dev0->log_file = g_build_filename (dev0->base_dir, "temp.log", NULL);
   parse_launch =
       g_strdup_printf


### PR DESCRIPTION
This patch use explicit type casting between variables and return values of
`g_ascii_strtoll()` or `g_ascii_strtoull()` functions.

This resolves issue #1762, which is about potential warnings
from compilers with strict option.

Original codes invoke warnings from gcc with `-Wconversion` option.

Signed-off-by: Injae Kang <abcinje@gmail.com>