### PR TITLE
[Filter] Enable C++ subplugin build @open sesame 10/18 16:07

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -55,6 +55,20 @@ Depends: nnstreamer, python3, python3-numpy, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Python Custom Filter Support (3.x)
  This Package allows nnstreamer to support python custom filters
 
+Package: nnstreamer-cpp
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer CPP Filter Subplugin Support
+ This package allows nnstreamer to support custom filters of C++ classes
+
+Package: nnsreamer-cpp-dev
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer-cpp, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer CPP Filter Subplugin Development Support
+ This package allows developers to write custom filters of C++ classes
+
 Package: nnstreamer-dev
 Architecture: any
 Multi-Arch: same

--- a/debian/nnstreamer-cpp-dev.install
+++ b/debian/nnstreamer-cpp-dev.install
@@ -1,0 +1,1 @@
+/usr/include/nnstreamer/tensor_filter_cpp.h

--- a/debian/nnstreamer-cpp.install
+++ b/debian/nnstreamer-cpp.install
@@ -1,0 +1,1 @@
+/usr/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so

--- a/debian/nnstreamer-dev.install
+++ b/debian/nnstreamer-dev.install
@@ -1,3 +1,7 @@
-/usr/include/nnstreamer/*.h
+/usr/include/nnstreamer/nnstreamer_plugin_api.h
+/usr/include/nnstreamer/nnstreamer_plugin_api_decoder.h
+/usr/include/nnstreamer/nnstreamer_plugin_api_filter.h
+/usr/include/nnstreamer/tensor_filter_custom.h
+/usr/include/nnstreamer/tensor_typedef.h
 /usr/lib/*/pkgconfig/*.pc
 /usr/lib/*/*.a

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -268,3 +268,15 @@ if get_option('enable-movidius-ncsdk2')
     )
   endif
 endif
+
+if get_option('enable-cppfilter')
+  shared_library('nnstreamer_filter_cpp',
+    ['tensor_filter_cpp.cc'],
+    dependencies: [glib_dep, gst_dep, nnstreamer_dep],
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
+  install_headers(['tensor_filter_cpp.h'],
+    subdir: 'nnstreamer'
+  )
+endif

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.h
@@ -49,20 +49,31 @@ class tensor_filter_cpp {
 
   public:
     tensor_filter_cpp(const char *modelName); /**< modelName is the model property of tensor_filter, which could be the path to the model file (requires proper extension name) or the registered model name at runtime. */
-    ~tensor_filter_cpp();
+    virtual ~tensor_filter_cpp();
 
     /** C++ plugin writers need to fill {getInput/Output} inclusive-or {setInput} */
     virtual int getInputDim(GstTensorsInfo *info) = 0;
     virtual int getOutputDim(GstTensorsInfo *info) = 0;
 
-    virtual int setIutputDim(const GstTensorsInfo *in, GstTensorsInfo *out) = 0;
+    virtual int setInputDim(const GstTensorsInfo *in, GstTensorsInfo *out) = 0;
 
-    bool allocate_before_invoke; /**< TRUE, if you want nnstreamer to preallocate output buffers before calling invoke */
     virtual int invoke(const GstTensorMemory *in, GstTensorMemory *out) = 0;
 
-    /** API */
-    static int tensor_filter_cpp_register (class tensor_filter_cpp *filter) final; /**< Register a C++ custom filter with this API if you want to register it at runtime. (or at the constructor of a shared object if you want to load it dynamically.) This should be invoked before initialized (constructed) by tensor_filter at run-time. */
+    virtual bool isAllocatedBeforeInvoke() = 0;
+      /**< return true if you want nnstreamer to preallocate output buffers
+           before calling invoke. This value should be configured at the
+           constructor and cannot be changed afterwards.
+           This should not change its return values. */
 
+    /** API. Do not override. */
+    static int tensor_filter_cpp_register(class tensor_filter_cpp *filter);
+      /**< Register a C++ custom filter with this API if you want to register
+           it at runtime or at the constructor of a shared object if you want
+           to load it dynamically. This should be invoked before initialized
+           (constructed) by tensor_filter at run-time. */
+
+    /** Internal Functions. Do not override. */
+    bool isValid();
 };
 
 #endif /* __cplusplus */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,3 +19,4 @@ option('enable-element-restriction', type: 'boolean', value: false) # true to re
 option('restricted-elements', type: 'string', value: '')
 option('enable-nnfw', type: 'boolean', value: false)
 option('enable-nnfw-runtime', type: 'boolean', value: false)
+option('enable-cppfilter', type: 'boolean', value: true)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -205,6 +205,19 @@ Requires:	capi-nnstreamer-devel = %{version}-%{release}
 Tizen internal API to construct the pipeline without the permissions.
 %endif
 
+%package cpp
+Summary:	NNStreamer Custom Plugin Support for C++ Classes
+Requires:	nnstreamer = %{version}-%{release}
+%description cpp
+With this package, you may use C++ classes as yet another tensor-filter subplugins of nnstreamer pipelines.
+
+%package cpp-devel
+Summary:	NNStreamer Custom Plugin Development Support for C++ Classes
+Requires:	nnstreamer-cpp = %{version}-%{release}
+%description cpp-devel
+With this package, you may write C++ classes as yet another tensor-filter subplugins of nnstreamer pipelines.
+Note that there is no .pc file for this package because nnstreamer.pc file may be used for developing this.
+
 # Define build options
 %if %{with tizen}
 %define enable_tizen -Denable-tizen=true
@@ -233,6 +246,7 @@ cp %{SOURCE1001} .
 %if %{with tizen}
 cp %{SOURCE1002} .
 %endif
+cp %{SOURCE1001} ./nnstreamer-cpp.manifest
 
 %build
 %if 0%{?testcoverage}
@@ -420,6 +434,14 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %files -n nnstreamer-tizen-internal-capi-devel
 %{_includedir}/nnstreamer/nnstreamer-tizen-internal.h
 %endif
+
+%files cpp
+%manifest nnstreamer-cpp.manifest
+%license LICENSE
+%{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_cpp.so
+
+%files cpp-devel
+%{_includedir}/nnstreamer/tensor_filter_cpp.h
 
 %changelog
 * Thu Sep 26 2019 MyungJoo Ham <myungjoo.ham@samsung.com>


### PR DESCRIPTION
Before adding test cases for C++ filter subplugins,
enable build for Tizen/Ubuntu.

Add enable-cppfilter=true for meson build if you
want to use this feature.

Fixes #1692 

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

