### PR TITLE
[tests] Install models/data with tests @open sesame 10/16 19:28

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -96,43 +96,58 @@ if gtest_dep.found()
   endif
 endif
 
+# Install data required for unittest
+unittest_tests_install_dir = join_paths(unittest_install_dir,'tests')
+tensor_filter_ext_enabled = get_option('enable-tensorflow-lite') or
+    get_option('enable-python') or  get_option('enable-tensorflow') or
+    get_option('enable-pytorch') or get_option('enable-caffe2')
+if get_option('install-test') and (get_option('enable-capi') or tensor_filter_ext_enabled)
+  install_subdir('test_models', install_dir: unittest_tests_install_dir)
+endif
+
 # Tizen C-API
 if get_option('enable-capi')
   subdir('tizen_capi')
 endif
 
+# Tizen NNFW runtime
 if get_option('enable-nnfw-runtime')
   subdir('tizen_nnfw_runtime')
 endif
 
 # Install Unittest
 if get_option('install-test')
-  install_data('gen24bBMP.py', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_converter', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_merge', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_decoder', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_demux', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_filter_custom', install_dir: join_paths(unittest_install_dir,'tests'))
+  install_data('gen24bBMP.py', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_converter', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_merge', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_decoder', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_demux', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_filter_custom', install_dir: unittest_tests_install_dir)
   if get_option('enable-tensorflow-lite')
-    install_subdir('test_models', install_dir: join_paths(unittest_install_dir,'tests'))
-    install_subdir('nnstreamer_filter_tensorflow_lite', install_dir: join_paths(unittest_install_dir,'tests'))
-    install_subdir('nnstreamer_decoder_image_labeling', install_dir: join_paths(unittest_install_dir,'tests'))
+    install_subdir('nnstreamer_filter_tensorflow_lite', install_dir: unittest_tests_install_dir)
+    install_subdir('nnstreamer_decoder_image_labeling', install_dir: unittest_tests_install_dir)
+  endif
+  if get_option('enable-python')
+    install_subdir('nnstreamer_filter_python', install_dir: unittest_tests_install_dir)
   endif
   if get_option('enable-tensorflow')
-    install_subdir('nnstreamer_filter_tensorflow', install_dir: join_paths(unittest_install_dir,'tests'))
+    install_subdir('nnstreamer_filter_tensorflow', install_dir: unittest_tests_install_dir)
   endif
   if get_option('enable-pytorch')
-    install_subdir('nnstreamer_filter_pytorch', install_dir: join_paths(unittest_install_dir,'tests'))
+    install_subdir('nnstreamer_filter_pytorch', install_dir: unittest_tests_install_dir)
   endif
-  install_subdir('nnstreamer_mux', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_repo', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_repo_dynamicity', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_repo_lstm', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_repo_rnn', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('nnstreamer_split', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('transform_arithmetic', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('transform_dimchg', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('transform_stand', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('transform_transpose', install_dir: join_paths(unittest_install_dir,'tests'))
-  install_subdir('transform_typecast', install_dir: join_paths(unittest_install_dir,'tests'))
+  if get_option('enable-caffe2')
+    install_subdir('nnstreamer_filter_caffe2', install_dir: unittest_tests_install_dir)
+  endif
+  install_subdir('nnstreamer_mux', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_repo', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_repo_dynamicity', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_repo_lstm', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_repo_rnn', install_dir: unittest_tests_install_dir)
+  install_subdir('nnstreamer_split', install_dir: unittest_tests_install_dir)
+  install_subdir('transform_arithmetic', install_dir: unittest_tests_install_dir)
+  install_subdir('transform_dimchg', install_dir: unittest_tests_install_dir)
+  install_subdir('transform_stand', install_dir: unittest_tests_install_dir)
+  install_subdir('transform_transpose', install_dir: unittest_tests_install_dir)
+  install_subdir('transform_typecast', install_dir: unittest_tests_install_dir)
 endif

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -7,7 +7,8 @@ tizen_apptest_deps = [
 unittest_tizen_capi = executable('unittest_tizen_capi',
   'unittest_tizen_capi.cpp',
   dependencies: [tizen_apptest_deps],
-  install: false
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
 )
 test('unittest_tizen_capi', unittest_tizen_capi, args: ['--gst-plugin-path=../..'])
 
@@ -20,6 +21,7 @@ tizen_apptest_deps = [
 unittest_tizen_capi_single_new = executable('unittest_tizen_capi_single_new',
   'unittest_tizen_capi.cpp',
   dependencies: [tizen_apptest_deps],
-  install: false
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
 )
 test('unittest_tizen_capi_single_new', unittest_tizen_capi_single_new, args: ['--gst-plugin-path=../..'])


### PR DESCRIPTION
Install models/data with tests correctly when needed
Install tizen-capi-unittest with install-test option
Install python and caffe2 unittests

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>