### PR TITLE
[Security] [Converter] handle text format in chain function @open sesame 10/17 15:17

### DIFF
--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -660,6 +660,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
 
       if (buf_size != frame_size) {
         GstMapInfo src_info, dest_info;
+        gsize block_size = MIN (buf_size, frame_size);
 
         inbuf = gst_buffer_new_and_alloc (frame_size);
         gst_buffer_memset (inbuf, 0, 0, frame_size);
@@ -667,7 +668,7 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
         g_assert (gst_buffer_map (buf, &src_info, GST_MAP_READ));
         g_assert (gst_buffer_map (inbuf, &dest_info, GST_MAP_WRITE));
 
-        strncpy ((char *) dest_info.data, (char *) src_info.data, frame_size);
+        memcpy (dest_info.data, src_info.data, block_size);
 
         gst_buffer_unmap (buf, &src_info);
         gst_buffer_unmap (inbuf, &dest_info);


### PR DESCRIPTION
get min block size and use memcpy when input mime-type is text.

This PR is related with ssms-1016-0005.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
