### PR TITLE
[single] Added API and skeleton for flexible input dimension

### DIFF
--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -139,6 +139,19 @@ int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info);
 int ml_single_get_output_info (ml_single_h single, ml_tensors_info_h *info);
 
 /**
+ * @brief Sets the information (tensor dimension, type, name and so on) of required input data for the given model.
+ * @details Note that a model/framework may not support setting such information.
+ * @param[in] single The model handle.
+ * @param[in] info The handle of input tensors information.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED This implies that the given framework does not support dynamic dimensions.
+ *         Use ml_single_set_input_info/ml_single_get_output_info APIs instead for this framework.
+ * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
+ */
+int ml_single_set_input_info (ml_single_h single, const ml_tensors_info_h info);
+
+/**
  * @brief Sets the maximum amount of time to wait for an output, in milliseconds.
  * @since_tizen 5.5
  * @param[in] single The model handle.

--- a/api/capi/src/nnstreamer-capi-single-new.c
+++ b/api/capi/src/nnstreamer-capi-single-new.c
@@ -680,8 +680,8 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 }
 
 /**
- * @brief Gets the type of required input data for the given handle.
- * @note type = (tensor dimension, type, name and so on)
+ * @brief Gets the information of required input data for the given handle.
+ * @note information = (tensor dimension, type, name and so on)
  */
 int
 ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
@@ -690,8 +690,8 @@ ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
 }
 
 /**
- * @brief Gets the type of required output data for the given handle.
- * @note type = (tensor dimension, type, name and so on)
+ * @brief Gets the information of output data for the given handle.
+ * @note information = (tensor dimension, type, name and so on)
  */
 int
 ml_single_get_output_info (ml_single_h single, ml_tensors_info_h * info)
@@ -718,4 +718,13 @@ ml_single_set_timeout (ml_single_h single, unsigned int timeout)
 
   ML_SINGLE_HANDLE_UNLOCK (single_h);
   return ML_ERROR_NONE;
+}
+
+/**
+ * @brief Sets the information (tensor dimension, type, name and so on) of required input data for the given model.
+ */
+int ml_single_set_input_info (ml_single_h single, const ml_tensors_info_h info)
+{
+  /** TODO: Fill me */
+  return ML_ERROR_NOT_SUPPORTED;
 }

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -615,7 +615,7 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 }
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of required input data for the given handle.
+ * @brief Gets the information (tensor dimension, type, name and so on) of required input data for the given handle.
  */
 int
 ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
@@ -624,7 +624,7 @@ ml_single_get_input_info (ml_single_h single, ml_tensors_info_h * info)
 }
 
 /**
- * @brief Gets the type (tensor dimension, type, name and so on) of output data for the given handle.
+ * @brief Gets the information (tensor dimension, type, name and so on) of output data for the given handle.
  */
 int
 ml_single_get_output_info (ml_single_h single, ml_tensors_info_h * info)
@@ -656,4 +656,12 @@ ml_single_set_timeout (ml_single_h single, unsigned int timeout)
 #else
   return ML_ERROR_NOT_SUPPORTED;
 #endif
+}
+
+/**
+ * @brief Sets the information (tensor dimension, type, name and so on) of required input data for the given model.
+ */
+int ml_single_set_input_info (ml_single_h single, const ml_tensors_info_h info)
+{
+  return ML_ERROR_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Adding support for flexible input dimension
Added API and skeleton for setting input dimension via single API

Check #1651 for more information

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>