### PR TITLE
[TF-Lite] Added setInputDimension

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -210,6 +210,23 @@ tflite_getOutputDim (const GstTensorFilterProperties * prop,
   return tflite_core_getOutputDim (tf->tflite_private_data, info);
 }
 
+/**
+ * @brief The optional callback for GstTensorFilterFramework
+ * @param prop property of tensor_filter instance
+ * @param private_data : tensorflow lite plugin's private data
+ * @param in_info The dimesions and types of input tensors
+ * @param[out] out_info The dimesions and types of output tensors
+ */
+static int
+tflite_setInputDim (const GstTensorFilterProperties * prop, void **private_data,
+    const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
+{
+  tflite_data *tf;
+  tf = *private_data;
+  g_assert (*private_data);
+  return tflite_core_setInputDim (tf->tflite_private_data, in_info, out_info);
+}
+
 static gchar filter_subplugin_tensorflow_lite[] = "tensorflow-lite";
 
 static GstTensorFilterFramework NNS_support_tensorflow_lite = {
@@ -219,6 +236,7 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .invoke_NN = tflite_invoke,
   .getInputDimension = tflite_getInputDim,
   .getOutputDimension = tflite_getOutputDim,
+  .setInputDimension = tflite_setInputDim,
   .open = tflite_open,
   .close = tflite_close,
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -53,6 +53,7 @@ public:
   int setOutputTensorProp ();
   int getInputTensorDim (GstTensorsInfo * info);
   int getOutputTensorDim (GstTensorsInfo * info);
+  int setInputTensorDim (const GstTensorsInfo * info);
   int invoke (const GstTensorMemory * input, GstTensorMemory * output);
 
 private:
@@ -73,6 +74,9 @@ private:
 
   tensor_type getTensorType (TfLiteType tfType);
   int getTensorDim (int tensor_idx, tensor_dim dim);
+
+  int setTensorProp (const std::vector<int> &tensor_idx_list,
+      GstTensorsInfo * tensorMeta);
 };
 
 /**
@@ -88,6 +92,8 @@ extern "C"
   const char *tflite_core_getModelPath (void * tflite);
   int tflite_core_getInputDim (void * tflite, GstTensorsInfo * info);
   int tflite_core_getOutputDim (void * tflite, GstTensorsInfo * info);
+  int tflite_core_setInputDim (void * tflite, const GstTensorsInfo * in_info,
+      GstTensorsInfo * out_info);
   int tflite_core_invoke (void * tflite, const GstTensorMemory * input,
       GstTensorMemory * output);
 

--- a/gst/nnstreamer/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api.h
@@ -85,6 +85,13 @@ extern void
 gst_tensor_info_copy (GstTensorInfo * dest, const GstTensorInfo * src);
 
 /**
+ * @brief Get tensor rank
+ * @note Minimum rank is 1
+ */
+extern int
+gst_tensor_info_get_rank (const GstTensorInfo * info);
+
+/**
  * @brief Initialize the tensors info structure
  * @param info tensors info structure to be initialized
  */

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -223,6 +223,24 @@ gst_tensor_info_copy (GstTensorInfo * dest, const GstTensorInfo * src)
 }
 
 /**
+ * @brief Get tensor rank
+ * @note Minimum rank is 1
+ */
+int
+gst_tensor_info_get_rank (const GstTensorInfo * info)
+{
+  int idx;
+
+  /** rank is at least 1 */
+  for (idx = NNS_TENSOR_RANK_LIMIT - 1; idx > 0; idx--) {
+    if (info->dimension[idx] != 1)
+      break;
+  }
+
+  return idx + 1;
+}
+
+/**
  * @brief Initialize the tensors info structure
  * @param info tensors info structure to be initialized
  */


### PR DESCRIPTION
Added implementation for setInputDimension
This can allow support for flexible input dimensions
The support is limited to only changing dimensions
Data type for the input or the number of inputs cannot be changed with current TF-Lite API
The rank for the input is allowed to be changed if the model allows
The input dimension can return error if the model does not allow dimension to be changed

Check #1651 for more information

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>