### PR TITLE
Added the coverity badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # NNStreamer
 
-[![Gitter][gitter-image]][gitter-url] [![Code Coverage](http://nnsuite.mooo.com/nnstreamer/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer/ci/gcov_html/index.html)
+[![Gitter][gitter-image]][gitter-url] [![Code Coverage](http://nnsuite.mooo.com/nnstreamer/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer/ci/gcov_html/index.html) <a href="https://scan.coverity.com/projects/nnsuite-nnstreamer">
+  <img alt="Coverity Scan Build Status"
+       src="https://scan.coverity.com/projects/19225/badge.svg"/>
+</a>
 
 Neural Network Support as Gstreamer Plugins.
 


### PR DESCRIPTION
This commit is to append the badge of the Coverity (static analysis tool).
TODO: the Coverity module of TAOS-CI will be soon enabled in the nnstreamer GitHub repository.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---