### PR TITLE
[Android/Api] Add execution bit of gradlew

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -122,6 +122,7 @@ fi
 
 echo "Starting gradle build for Android library."
 
+chmod +x gradlew
 # Build Android library.
 ./gradlew api:build
 


### PR DESCRIPTION
Added excution bit of gradlew to prevent permission denied error.

The "api/android/build-android-lib.sh" file has changed

related issue: #1793 
Signed-off-by: 이원준 <dldnjs1013@nate.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped

