### PR TITLE
[CAPI] Add Error-header file for use without patch file

### DIFF
--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -58,7 +58,6 @@ function check_package() {
 # Check required packages
 check_package svn
 check_package sed
-check_package patch
 check_package zip
 
 # Android SDK (Set your own path)
@@ -80,10 +79,6 @@ echo "NNStreamer root directory: $NNSTREAMER_ROOT"
 echo "Start to build NNStreamer library for Android."
 pushd $NNSTREAMER_ROOT
 
-# Modify header for Android
-if ! patch -R --dry-run -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch; then
-    patch -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch
-fi
 
 # Make directory to build NNStreamer library
 mkdir -p build_android_lib
@@ -161,9 +156,6 @@ popd
 
 # Remove build directory
 rm -rf build_android_lib
-
-# Clean the applied patches
-patch -R -sfp1 -i $NNSTREAMER_ROOT/packaging/non_tizen_build.patch
 
 popd
 

--- a/api/capi/include/nnstreamer-error.h
+++ b/api/capi/include/nnstreamer-error.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ */
+/**
+ * @file nnstreamer-error.h
+ * @date 02 October 2019
+ * @brief error header in TIZEN and Non Tizen without a patch.
+ * @see	https://github.com/nnsuite/nnstreamer
+ * @author WonJun Lee <dldnjs1013@nate.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __NNSTREAMER_ERROR_H__
+#define __NNSTREAMER_ERROR_H__
+
+#ifdef __TIZEN__
+#include <tizen_error.h>
+#else
+#include <errno.h>
+#define TIZEN_ERROR_NONE (0)
+#define TIZEN_ERROR_INVALID_PARAMETER (-EINVAL)
+#define TIZEN_ERROR_STREAMS_PIPE (-ESTRPIPE)
+#define TIZEN_ERROR_TRY_AGAIN (-EAGAIN)
+#define TIZEN_ERROR_UNKNOWN (-1073741824LL)
+#define TIZEN_ERROR_TIMED_OUT (TIZEN_ERROR_UNKNOWN + 1)
+#define TIZEN_ERROR_NOT_SUPPORTED (TIZEN_ERROR_UNKNOWN + 2)
+#define TIZEN_ERROR_PERMISSION_DENIED (-EACCES)
+#endif /* __TIZEN__ */
+
+#endif /* __NNSTREAMER_ERROR_H__ */

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -27,8 +27,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-/* Apply modify_nnstreamer_h_for_nontizen.sh if you want to use in non-Tizen Linux machines */
-#include <tizen_error.h>
+#include "nnstreamer-error.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/debian/rules
+++ b/debian/rules
@@ -58,5 +58,4 @@ override_dh_auto_install:
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
-	patch -R -p1 -i ./packaging/non_tizen_build.patch
 # Add --fail-missing option after adding *.install files for all subpackages.


### PR DESCRIPTION
Create header file to use same error header without patch
regardless of Tizen and Non-Tizen.
And change bash-script because bash-script used patch-file.

related issue: #1796 
Signed-off-by: WonJun Lee <dldnjs1013@nate.com>

Self evaluation:

    Build test: [*]Passed [ ]Failed [ ]Skipped
