### PR TITLE
[single] simplify get_tensors_info in single API @open sesame 10/22 11:55

### DIFF
--- a/api/capi/src/nnstreamer-capi-single-new.c
+++ b/api/capi/src/nnstreamer-capi-single-new.c
@@ -672,6 +672,7 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 {
   ml_single *single_h;
   int status = ML_ERROR_NONE;
+  ml_tensors_info_s *input_info;
 
   check_feature_state ();
 
@@ -680,8 +681,22 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 
   ML_SINGLE_GET_VALID_HANDLE_LOCKED (single_h, single, 0);
 
-  ml_single_get_tensors_info_from_filter (single_h->filter, is_input, info);
+  /* allocate handle for tensors info */
+  status = ml_tensors_info_create (info);
+  if (status != ML_ERROR_NONE)
+    goto exit;
 
+  input_info = (ml_tensors_info_s *) (*info);
+
+  if (is_input)
+    status = ml_tensors_info_clone (input_info, &single_h->in_info);
+  else
+    status = ml_tensors_info_clone (input_info, &single_h->out_info);
+
+  if (status != ML_ERROR_NONE)
+    ml_tensors_info_destroy (input_info);
+
+exit:
   ML_SINGLE_HANDLE_UNLOCK (single_h);
   return status;
 }

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -604,6 +604,7 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 {
   ml_single *single_h;
   int status = ML_ERROR_NONE;
+  ml_tensors_info_s *input_info;
 
   check_feature_state ();
 
@@ -612,8 +613,19 @@ ml_single_get_tensors_info (ml_single_h single, gboolean is_input,
 
   ML_SINGLE_GET_VALID_HANDLE_LOCKED (single_h, single, 0);
 
-  ml_single_get_tensors_info_from_filter (single_h->filter, is_input, info);
+  /* allocate handle for tensors info */
+  status = ml_tensors_info_create (info);
+  if (status != ML_ERROR_NONE)
+    goto exit;
 
+  input_info = (ml_tensors_info_s *) (*info);
+
+  if (is_input)
+    ml_tensors_info_clone (input_info, &single_h->in_info);
+  else
+    ml_tensors_info_clone (input_info, &single_h->out_info);
+
+exit:
   ML_SINGLE_HANDLE_UNLOCK (single_h);
   return status;
 }


### PR DESCRIPTION
Added simplification for get_tensors_info in single API implementation
input and output tensors info is stored in single API
This patch updates to use that information than extracting the info again from element

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>