### PR TITLE
[Tests/Sink] Fix test failure on macOS/Travis CI @open sesame 10/22 20:30

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -98,9 +98,11 @@ endif
 
 # Install data required for unittest
 unittest_tests_install_dir = join_paths(unittest_install_dir,'tests')
-tensor_filter_ext_enabled = get_option('enable-tensorflow-lite') or
-    get_option('enable-python') or  get_option('enable-tensorflow') or
+
+tensor_filter_ext_enabled = get_option('enable-tensorflow-lite') or \
+    get_option('enable-python') or  get_option('enable-tensorflow') or \
     get_option('enable-pytorch') or get_option('enable-caffe2')
+
 if get_option('install-test') and (get_option('enable-capi') or tensor_filter_ext_enabled)
   install_subdir('test_models', install_dir: unittest_tests_install_dir)
 endif

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -452,28 +452,32 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_BGR:
       /** video 160x120 BGR */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGR,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_RGB_PADDING:
       /** video 162x120 RGB, remove padding */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_BGR_PADDING:
       /** video 162x120 BGR, remove padding */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGR,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_RGB_3F:
       /** video 160x120 RGB, 3 frames */
@@ -488,56 +492,64 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBA,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_BGRA:
       /** video 162x120 BGRA */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRA,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_ARGB:
       /** video 162x120 ARGB */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ARGB,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_ABGR:
       /** video 162x120 ABGR */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ABGR,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_RGBx:
       /** video 162x120 RGBx */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBx,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_xRGB:
       /** video 162x120 xRGB */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xRGB,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_xBGR:
       /** video 162x120 xBGR */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xBGR,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_BGRx:
       /** video 162x120 BGRx */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRx,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_BGRx_2F:
       /** video 160x120 BGRx, 2 frames */
@@ -552,14 +564,16 @@ _setup_pipeline (TestOption & option)
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=GRAY8,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_GRAY8_PADDING:
       /** video 162x120 GRAY8, remove padding */
       str_pipeline =
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)%lu/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers,
+          fps);
       break;
     case TEST_TYPE_VIDEO_GRAY8_3F_PADDING:
       /** video 162x120 GRAY8, 3 frames, remove padding */
@@ -734,7 +748,9 @@ _setup_pipeline (TestOption & option)
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.%s ! tensor_sink name=test_sink",
-	        option.num_buffers, fps, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough", SO_EXT);
+          option.num_buffers, fps,
+          custom_dir ? custom_dir :
+          "./nnstreamer_example/custom_example_passthrough", SO_EXT);
       break;
     case TEST_TYPE_CUSTOM_TENSORS:
       /** other/tensors with tensormux, passthrough custom filter */
@@ -744,7 +760,9 @@ _setup_pipeline (TestOption & option)
           "videotestsrc num-buffers=%d ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_0 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=120,height=80,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_1 "
           "videotestsrc num-buffers=%d ! video/x-raw,width=64,height=48,format=RGB,framerate=(fraction)30/1 ! tensor_converter ! mux.sink_2",
-	        custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough" , SO_EXT, option.num_buffers, option.num_buffers, option.num_buffers);
+          custom_dir ? custom_dir :
+          "./nnstreamer_example/custom_example_passthrough", SO_EXT,
+          option.num_buffers, option.num_buffers, option.num_buffers);
       break;
     case TEST_TYPE_CUSTOM_BUF_DROP:
       /* audio stream to test buffer-drop using custom filter */
@@ -752,7 +770,7 @@ _setup_pipeline (TestOption & option)
           g_strdup_printf
           ("audiotestsrc num-buffers=%d samplesperbuffer=200 ! audioconvert ! audio/x-raw,format=S16LE,rate=16000,channels=1 ! "
           "tensor_converter frames-per-tensor=200 ! tensor_filter framework=custom model=%s/libnnscustom_drop_buffer.%s ! tensor_sink name=test_sink",
-	        option.num_buffers, custom_dir? custom_dir :"./tests", SO_EXT);
+          option.num_buffers, custom_dir ? custom_dir : "./tests", SO_EXT);
       break;
     case TEST_TYPE_CUSTOM_PASSTHROUGH:
       /* video 160x120 RGB, passthrough custom filter without so file */
@@ -760,7 +778,7 @@ _setup_pipeline (TestOption & option)
           g_strdup_printf
           ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_filter framework=custom-passthrough ! tensor_sink name=test_sink",
-	   option.num_buffers, fps);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_NEGO_FAILED:
       /** caps negotiation failed */
@@ -835,7 +853,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_mux sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
@@ -844,7 +864,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_mux sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
@@ -853,7 +875,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_mux sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests",  SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MUX_PARALLEL_4:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ basepad*/
@@ -863,7 +887,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_mux sync_mode=basepad sync_option=1:1000000000 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_1:
       /** 4x4 tensor stream, different FPS, tensor_mux them @ slowest */
@@ -872,7 +898,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_merge mode=linear option=3 sync_mode=slowest name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	        option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_2:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
@@ -881,7 +909,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=0:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     case TEST_TYPE_ISSUE739_MERGE_PARALLEL_3:
       /** 4x4 tensor stream, different FPS, tensor_merge them @ basepad*/
@@ -890,7 +920,9 @@ _setup_pipeline (TestOption & option)
           ("videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=10/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_0 "
           "videotestsrc pattern=snow num-buffers=%d ! video/x-raw,format=BGRx,height=4,width=4,framerate=25/1 ! tensor_converter ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! mux.sink_1 "
           "tensor_merge mode=linear option=3 sync_mode=basepad sync_option=1:0 name=mux ! tensor_filter framework=custom model=%s/libnnscustom_framecounter.%s ! tee name=t ! queue ! tensor_sink sync=true name=test_sink t. ! queue ! filesink location=%s",
-	   option.num_buffers * 10, custom_dir? custom_dir : "./tests", SO_EXT, option.num_buffers * 25, custom_dir? custom_dir : "./tests", SO_EXT, custom_dir? custom_dir : "./tests", SO_EXT, option.tmpfile);
+          option.num_buffers * 10, custom_dir ? custom_dir : "./tests", SO_EXT,
+          option.num_buffers * 25, custom_dir ? custom_dir : "./tests", SO_EXT,
+          custom_dir ? custom_dir : "./tests", SO_EXT, option.tmpfile);
       break;
     /** @todo Add tensor_mux policy = more policies! */
     case TEST_TYPE_DECODER_PROPERTY:
@@ -2993,7 +3025,9 @@ TEST (tensor_stream_test, filter_properties_1)
 
   /* model */
   g_object_get (filter, "model", &str, NULL);
-  model = g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s", SO_EXT);
+  model =
+      g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s",
+      SO_EXT);
   EXPECT_TRUE (g_str_has_suffix (str, model));
   g_free (str);
   g_free (model);
@@ -3091,7 +3125,9 @@ TEST (tensor_stream_test, filter_properties_2)
 
   /* model */
   g_object_get (filter, "model", &str, NULL);
-  model = g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s", SO_EXT);
+  model =
+      g_strdup_printf ("libnnstreamer_customfilter_passthrough_variable.%s",
+      SO_EXT);
   EXPECT_TRUE (g_str_has_suffix (str, model));
   g_free (str);
   g_free (model);
@@ -4182,7 +4218,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_1)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4246,7 +4282,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_2)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4311,7 +4347,7 @@ TEST (tensor_stream_test, issue739_mux_parallel_3)
   EXPECT_GE (g_test_data.received, num_buffers * 25 - 1);
   EXPECT_LE (g_test_data.received, num_buffers * 25);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4393,7 +4429,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_1)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4457,7 +4493,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_2)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, num_buffers * 10);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4522,7 +4558,7 @@ TEST (tensor_stream_test, issue739_merge_parallel_3)
   EXPECT_GE (g_test_data.received, num_buffers * 25 - 1);
   EXPECT_LE (g_test_data.received, num_buffers * 25);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 4U);     /* uint32_t, 1:1:1:1 */
+  EXPECT_EQ (g_test_data.received_size, 4U);    /* uint32_t, 1:1:1:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));
@@ -4636,7 +4672,7 @@ TEST (tensor_stream_test, tensor_decoder_property)
   /** check received buffers */
   EXPECT_EQ (g_test_data.received, 5U);
   EXPECT_EQ (g_test_data.mem_blocks, 1U);
-  EXPECT_EQ (g_test_data.received_size, 64U);     /* uint8_t, 4:4:4:1 */
+  EXPECT_EQ (g_test_data.received_size, 64U);   /* uint8_t, 4:4:4:1 */
 
   /** check caps name */
   EXPECT_TRUE (g_str_equal (g_test_data.caps_name, "other/tensor"));

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -46,8 +46,10 @@
 
 const gulong MSEC_PER_USEC = 1000;
 const gulong DEFAULT_JITTER = 0UL;
+const gulong DEFAULT_FPS = 30UL;
 gchar *custom_dir = NULL;
 gulong jitter = DEFAULT_JITTER;
+gulong fps = DEFAULT_FPS;
 
 /**
  * @brief Current status.
@@ -449,123 +451,123 @@ _setup_pipeline (TestOption & option)
       /** video 160x120 RGB */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_BGR:
       /** video 160x120 BGR */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGR,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGR,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_PADDING:
       /** video 162x120 RGB, remove padding */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_BGR_PADDING:
       /** video 162x120 BGR, remove padding */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGR,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGR,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_3F:
       /** video 160x120 RGB, 3 frames */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGBA:
       /** video 162x120 RGBA */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBA,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBA,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_BGRA:
       /** video 162x120 BGRA */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRA,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRA,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_ARGB:
       /** video 162x120 ARGB */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ARGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ARGB,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_ABGR:
       /** video 162x120 ABGR */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ABGR,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=ABGR,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGBx:
       /** video 162x120 RGBx */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBx,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=RGBx,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_xRGB:
       /** video 162x120 xRGB */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xRGB,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xRGB,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_xBGR:
       /** video 162x120 xBGR */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xBGR,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=xBGR,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_BGRx:
       /** video 162x120 BGRx */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRx,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=BGRx,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_BGRx_2F:
       /** video 160x120 BGRx, 2 frames */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGRx,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=BGRx,framerate=(fraction)%lu/1 ! "
           "tensor_converter frames-per-tensor=2 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_GRAY8:
       /** video 160x120 GRAY8 */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=GRAY8,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_GRAY8_PADDING:
       /** video 162x120 GRAY8, remove padding */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
-          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)%lu/1 ! "
+          "tensor_converter ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_GRAY8_3F_PADDING:
       /** video 162x120 GRAY8, 3 frames, remove padding */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=162,height=120,format=GRAY8,framerate=(fraction)%lu/1 ! "
           "tensor_converter frames-per-tensor=3 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_AUDIO_S8:
       /** audio sample rate 16000 (8 bits, signed, little endian) */
@@ -730,9 +732,9 @@ _setup_pipeline (TestOption & option)
       /** video 160x120 RGB, passthrough custom filter */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_filter name=test_filter framework=custom model=%s/libnnstreamer_customfilter_passthrough_variable.%s ! tensor_sink name=test_sink",
-	        option.num_buffers, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough", SO_EXT);
+	        option.num_buffers, fps, custom_dir? custom_dir : "./nnstreamer_example/custom_example_passthrough", SO_EXT);
       break;
     case TEST_TYPE_CUSTOM_TENSORS:
       /** other/tensors with tensormux, passthrough custom filter */
@@ -756,51 +758,51 @@ _setup_pipeline (TestOption & option)
       /* video 160x120 RGB, passthrough custom filter without so file */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_filter framework=custom-passthrough ! tensor_sink name=test_sink",
-	   option.num_buffers);
+	   option.num_buffers, fps);
       break;
     case TEST_TYPE_NEGO_FAILED:
       /** caps negotiation failed */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
-          "videoconvert ! tensor_sink name=test_sink", option.num_buffers);
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
+          "videoconvert ! tensor_sink name=test_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_SPLIT:
       /** video stream with tensor_split */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_split silent=TRUE name=split tensorseg=1:160:120,1:160:120,1:160:120 tensorpick=0,1,2 "
           "split.src_0 ! queue ! tensor_sink "
           "split.src_1 ! queue ! tensor_sink name=test_sink "
-          "split.src_2 ! queue ! tensor_sink", option.num_buffers);
+          "split.src_2 ! queue ! tensor_sink", option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_AGGR_1:
       /** video stream with tensor_aggregator */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_aggregator frames-out=10 frames-flush=5 frames-dim=3 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_AGGR_2:
       /** video stream with tensor_aggregator */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=160,height=120,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_aggregator frames-out=10 frames-flush=5 frames-dim=1 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_VIDEO_RGB_AGGR_3:
       /** video stream with tensor_aggregator */
       str_pipeline =
           g_strdup_printf
-          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=64,height=48,format=RGB,framerate=(fraction)30/1 ! "
+          ("videotestsrc num-buffers=%d ! videoconvert ! video/x-raw,width=64,height=48,format=RGB,framerate=(fraction)%lu/1 ! "
           "tensor_converter ! tensor_aggregator frames-out=10 frames-dim=1 concat=false ! "
           "tensor_aggregator frames-in=10 frames-out=8 frames-flush=10 frames-dim=1 ! tensor_sink name=test_sink",
-          option.num_buffers);
+          option.num_buffers, fps);
       break;
     case TEST_TYPE_AUDIO_S16_AGGR:
       /** audio stream with tensor_aggregator, 4 buffers with 2000 frames */
@@ -1154,7 +1156,7 @@ TEST (tensor_sink_test, signal_rate)
   ASSERT_TRUE (_setup_pipeline (option));
 
   /** set signal-rate */
-  g_object_set (g_test_data.sink, "signal-rate", (guint) 15, NULL);
+  g_object_set (g_test_data.sink, "signal-rate", (guint) (fps / 2), NULL);
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
@@ -1340,7 +1342,7 @@ TEST (tensor_stream_test, video_rgb)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1383,7 +1385,7 @@ TEST (tensor_stream_test, video_bgr)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1426,7 +1428,7 @@ TEST (tensor_stream_test, video_rgb_padding)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1469,7 +1471,7 @@ TEST (tensor_stream_test, video_bgr_padding)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1512,7 +1514,7 @@ TEST (tensor_stream_test, video_rgb_3f)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1555,7 +1557,7 @@ TEST (tensor_stream_test, video_rgba)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1598,7 +1600,7 @@ TEST (tensor_stream_test, video_bgra)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1641,7 +1643,7 @@ TEST (tensor_stream_test, video_argb)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1684,7 +1686,7 @@ TEST (tensor_stream_test, video_abgr)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1727,7 +1729,7 @@ TEST (tensor_stream_test, video_rgbx)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1770,7 +1772,7 @@ TEST (tensor_stream_test, video_xrgb)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1813,7 +1815,7 @@ TEST (tensor_stream_test, video_xbgr)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1856,7 +1858,7 @@ TEST (tensor_stream_test, video_bgrx)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1899,7 +1901,7 @@ TEST (tensor_stream_test, video_bgrx_2f)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 2U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1942,7 +1944,7 @@ TEST (tensor_stream_test, video_gray8)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -1985,7 +1987,7 @@ TEST (tensor_stream_test, video_gray8_padding)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -2028,7 +2030,7 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 162U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 3U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -2865,7 +2867,7 @@ TEST (tensor_stream_test, custom_filter_tensor)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   /** check caps and config for tensor */
@@ -3278,7 +3280,7 @@ TEST (tensor_stream_test, custom_filter_passthrough)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -3940,7 +3942,7 @@ TEST (tensor_stream_test, video_split)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -3982,7 +3984,7 @@ TEST (tensor_stream_test, video_aggregate_1)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 160U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 10U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -4024,7 +4026,7 @@ TEST (tensor_stream_test, video_aggregate_2)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 1600U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 120U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -4066,7 +4068,7 @@ TEST (tensor_stream_test, video_aggregate_3)
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[1], 64U * 8);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[2], 48U);
   EXPECT_EQ (g_test_data.tensor_config.info.dimension[3], 1U);
-  EXPECT_EQ (g_test_data.tensor_config.rate_n, 30);
+  EXPECT_EQ (g_test_data.tensor_config.rate_n, (int) fps);
   EXPECT_EQ (g_test_data.tensor_config.rate_d, 1);
 
   EXPECT_FALSE (g_test_data.test_failed);
@@ -4653,6 +4655,7 @@ int
 main (int argc, char **argv)
 {
   gchar *jitter_cmd_arg = NULL;
+  gchar *fps_cmd_arg = NULL;
   const GOptionEntry main_entries[] = {
     {"customdir", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &custom_dir,
           "A directory containing custom sub-plugins to use this test",
@@ -4660,6 +4663,9 @@ main (int argc, char **argv)
     {"jitter", 'j', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &jitter_cmd_arg,
           "Jitter in ms between starting and stopping test pipelines",
         "0 (default)"},
+    {"fps", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &fps_cmd_arg,
+          "Frames per second to run tests made of videotestsrc-based single pipeline",
+        "30 (default)"},
     {NULL}
   };
   GError *error = NULL;
@@ -4676,6 +4682,13 @@ main (int argc, char **argv)
   if (jitter_cmd_arg != NULL) {
     jitter = (gulong) g_ascii_strtoull (jitter_cmd_arg, NULL, 10) *
         MSEC_PER_USEC;
+  }
+
+  if (fps_cmd_arg != NULL) {
+    fps = (gulong) g_ascii_strtoull (fps_cmd_arg, NULL, 10);
+    if (fps == 0) {
+      fps = DEFAULT_FPS;
+    }
   }
 
   gst_init (&argc, &argv);

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -44,7 +44,10 @@
     goto error; \
   }
 
-gchar *custom_dir;
+const gulong MSEC_PER_USEC = 1000;
+const gulong DEFAULT_JITTER = 0UL;
+gchar *custom_dir = NULL;
+gulong jitter = DEFAULT_JITTER;
 
 /**
  * @brief Current status.
@@ -1017,7 +1020,6 @@ TEST (tensor_sink_test, properties)
   /** GstBaseSink:max-lateness -1 (unlimited time) */
   g_object_get (g_test_data.sink, "max-lateness", &lateness, NULL);
   EXPECT_EQ (lateness, -1);
-
   lateness = 30 * GST_MSECOND;
   g_object_set (g_test_data.sink, "max-lateness", lateness, NULL);
   g_object_get (g_test_data.sink, "max-lateness", &res_lateness, NULL);
@@ -1057,6 +1059,7 @@ TEST (tensor_sink_test, signals)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1119,6 +1122,7 @@ TEST (tensor_sink_test, emit_signal)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1154,6 +1158,7 @@ TEST (tensor_sink_test, signal_rate)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1202,6 +1207,7 @@ TEST (tensor_sink_test, caps_error_n)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check error message */
@@ -1245,6 +1251,7 @@ TEST (tensor_sink_test, caps_tensors)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1309,6 +1316,7 @@ TEST (tensor_stream_test, video_rgb)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1351,6 +1359,7 @@ TEST (tensor_stream_test, video_bgr)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1393,6 +1402,7 @@ TEST (tensor_stream_test, video_rgb_padding)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1435,6 +1445,7 @@ TEST (tensor_stream_test, video_bgr_padding)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1477,6 +1488,7 @@ TEST (tensor_stream_test, video_rgb_3f)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1519,6 +1531,7 @@ TEST (tensor_stream_test, video_rgba)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1561,6 +1574,7 @@ TEST (tensor_stream_test, video_bgra)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1603,6 +1617,7 @@ TEST (tensor_stream_test, video_argb)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1645,6 +1660,7 @@ TEST (tensor_stream_test, video_abgr)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1687,6 +1703,7 @@ TEST (tensor_stream_test, video_rgbx)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1729,6 +1746,7 @@ TEST (tensor_stream_test, video_xrgb)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1771,6 +1789,7 @@ TEST (tensor_stream_test, video_xbgr)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1813,6 +1832,7 @@ TEST (tensor_stream_test, video_bgrx)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1855,6 +1875,7 @@ TEST (tensor_stream_test, video_bgrx_2f)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1897,6 +1918,7 @@ TEST (tensor_stream_test, video_gray8)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1939,6 +1961,7 @@ TEST (tensor_stream_test, video_gray8_padding)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -1981,6 +2004,7 @@ TEST (tensor_stream_test, video_gray8_3f_padding)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2023,6 +2047,7 @@ TEST (tensor_stream_test, audio_s8)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2065,6 +2090,7 @@ TEST (tensor_stream_test, audio_u8_100f)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2107,6 +2133,7 @@ TEST (tensor_stream_test, audio_s16)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2149,6 +2176,7 @@ TEST (tensor_stream_test, audio_u16_1000f)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2191,6 +2219,7 @@ TEST (tensor_stream_test, audio_s32)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2233,6 +2262,7 @@ TEST (tensor_stream_test, audio_u32)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2275,6 +2305,7 @@ TEST (tensor_stream_test, audio_f32)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -2317,6 +2348,7 @@ TEST (tensor_stream_test, audio_f64)
 
   gst_element_set_state (g_test_data.pipeline, GST_STATE_PLAYING);
   g_main_loop_run (g_test_data.loop);
+  g_usleep (jitter);
   gst_element_set_state (g_test_data.pipeline, GST_STATE_NULL);
 
   /** check eos message */
@@ -4620,14 +4652,30 @@ TEST (tensor_stream_test, tensor_decoder_property)
 int
 main (int argc, char **argv)
 {
+  gchar *jitter_cmd_arg = NULL;
+  const GOptionEntry main_entries[] = {
+    {"customdir", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &custom_dir,
+          "A directory containing custom sub-plugins to use this test",
+        "build/nnstreamer_example/custom_example_passthrough"},
+    {"jitter", 'j', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &jitter_cmd_arg,
+          "Jitter in ms between starting and stopping test pipelines",
+        "0 (default)"},
+    {NULL}
+  };
+  GError *error = NULL;
+  GOptionContext *optionctx;
   testing::InitGoogleTest (&argc, argv);
-  int optind;
-  for(optind = 1; optind < argc && argv[optind][0] == '-'; optind++){
-    switch(argv[optind][1]){
-    case 'd': custom_dir=g_strdup(argv[optind+1]); break;
-    default:
-      break;
-    }
+
+  optionctx = g_option_context_new (NULL);
+  g_option_context_add_main_entries (optionctx, main_entries, NULL);
+
+  if (!g_option_context_parse (optionctx, &argc, &argv, &error)) {
+    g_print ("option parsing failed: %s\n", error->message);
+  }
+
+  if (jitter_cmd_arg != NULL) {
+    jitter = (gulong) g_ascii_strtoull (jitter_cmd_arg, NULL, 10) *
+        MSEC_PER_USEC;
   }
 
   gst_init (&argc, &argv);


### PR DESCRIPTION
This PR is required to enable build-time tests NNStreamer on macOS deployed with Travis CI and mainly focuses on fixing that unittest_sink is failed.

In low performance machines such as VMs in the cloud,  there are several cases that the pipelines cannot finish their job until the pipeline is stopped.  Moreover, sometimes they even cannot keeo the given framerate so that few buffers are lost while testing. To work around this issue, this PR adds command-line options for adding jitter between start and stop pipe qnd controlling the speed of tests made of videotestsrc-based single pipeline.

Resolves a sub-item of #1608
See also: https://github.com/nnsuite/homebrew-neural-network

*Self evaluation:**
1. Build test: [*] Passed [ ]Failed [ ]Skipped
2. Run test: [*] Passed [ ]Failed [ ]Skipped

After merging this PR, only one failed test case remains.

![Screenshot_20191022-004105_Samsung Internet](https://user-images.githubusercontent.com/2772376/67222281-ef977480-f467-11e9-817f-8bde28f72121.jpg)


Signed-off-by: Wook Song <wook16.song@samsung.com>