### PR TITLE
[Decoder/Sub] mem error case in img segment

### DIFF
--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -87,6 +87,10 @@ NNSTREAMER_DECODER_PE_SRCS := \
     $(NNSTREAMER_EXT_HOME)/tensor_decoder/tensordec-pose.c \
     $(NNSTREAMER_EXT_HOME)/tensor_decoder/tensordec-font.c
 
+# decoder image segment
+NNSTREAMER_DECODER_IS_SRCS := \
+    $(NNSTREAMER_EXT_HOME)/tensor_decoder/tensordec-imagesegment.c
+
 # common features
 NO_AUDIO := false
 


### PR DESCRIPTION
1. handle allocation failure case
2. fix possible mem leak to get the out caps
3. add definition to include img segment in android-libray

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
