### PR TITLE
[Build] Include pip include path to find numpy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -207,6 +207,15 @@ if get_option('enable-python')
     python2_incs = run_command(pg_pkgconfig, ['python-2.7', '--cflags']).stdout().strip().split()
     if cc.has_header('numpy/arrayobject.h', args: python2_incs)
       have_python2 = true
+    else
+      python2_pkg_incs = run_command('python2.7', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")']).stdout().strip().split()
+      python2_pkg_incs += '-I' + run_command('python2.7', ['-m', 'site', '--user-site']).stdout().strip() + '/numpy/core/include'
+      message('Numpy is not found in the default python include path. Searching for site/dist-packages include path...')
+      if cc.has_header('numpy/arrayobject.h', args: python2_pkg_incs)
+        have_python2 = true
+      else
+        message('Numpy is not found in both paths. NNStreamer-Python2.7 is disabled.')
+      endif
     endif
   endif
 
@@ -216,6 +225,15 @@ if get_option('enable-python')
     python3_incs = run_command(pg_pkgconfig, ['python3', '--cflags']).stdout().strip().split()
     if cc.has_header('numpy/arrayobject.h', args: python3_incs)
       have_python3 = true
+    else
+      python3_pkg_incs = run_command('python3', ['-c', 'import site\nfor i in site.getsitepackages(): print("-I" + i + "/numpy/core/include")']).stdout().strip().split()
+      python3_pkg_incs += '-I' + run_command('python3', ['-m', 'site', '--user-site']).stdout().strip() + '/numpy/core/include'
+      message('Numpy is not found in the default python include path. Searching for site/dist-packages include path...')
+      if cc.has_header('numpy/arrayobject.h', args: python3_pkg_incs)
+        have_python3 = true
+      else
+        message('Numpy is not found in both paths. NNStreamer-Python3 is disabled.')
+      endif
     endif
   endif
 endif


### PR DESCRIPTION
When numpy is installed using pip, meson couldn't find
numpy/arrayobject.h.

I included pip include path to find numpy.

This patch resolves #1805.

Signed-off-by: Injae Kang <abcinje@gmail.com>