### PR TITLE
[nnfw] Adding nnfw base test for verification @open sesame 11/4 14:51

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -37,9 +37,19 @@
 
 #include <nnfw.h>
 
+/** backends supported by nnfw */
+#define NNFW_CPU_BACKEND  "cpu"
+#define NNFW_GPU_BACKEND  "acl_cl"
+#define NNFW_NEON_BACKEND "acl_neon"
+#define NNFW_SRCN_BACKEND  "srcn"
+#define NNFW_DEFAULT_BACKEND NNFW_CPU_BACKEND
+
 void init_filter_nnfw (void) __attribute__ ((constructor));
 void fini_filter_nnfw (void) __attribute__ ((destructor));
 
+/**
+ * @brief private data structure for the nnfw framework
+ */
 typedef struct
 {
   nnfw_tensorinfo i_in;
@@ -81,6 +91,13 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     err = -EINVAL;
     g_printerr ("Cannot create nnfw-runtime session");
     goto unalloc_exit;
+  }
+
+  status = nnfw_set_default_backend(pdata->session, NNFW_DEFAULT_BACKEND);
+  if (status != NNFW_STATUS_NO_ERROR) {
+    err = -ENXIO;
+    g_printerr ("Cannot load the model file: %s", prop->model_file);
+    goto session_exit;
   }
 
   status = nnfw_load_model_from_file (pdata->session, prop->model_file);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -100,9 +100,9 @@ endif
 unittest_tests_install_dir = join_paths(unittest_install_dir,'tests')
 
 tensor_filter_ext_enabled = get_option('enable-tensorflow-lite') or \
-    get_option('enable-python') or  get_option('enable-tensorflow') or \
-    get_option('enable-pytorch') or get_option('enable-caffe2')
-
+    get_option('enable-python') or get_option('enable-tensorflow') or \
+    get_option('enable-pytorch') or get_option('enable-caffe2') or \
+    get_option('enable-nnfw-runtime')
 if get_option('install-test') and (get_option('enable-capi') or tensor_filter_ext_enabled)
   install_subdir('test_models', install_dir: unittest_tests_install_dir)
 endif

--- a/tests/test_models/models/metadata/MANIFEST
+++ b/tests/test_models/models/metadata/MANIFEST
@@ -1,0 +1,7 @@
+{
+  "major-version" : "1",
+  "minor-version" : "0",
+  "patch-version" : "0",
+  "models"      : [ "add.tflite" ],
+  "model-types" : [ "tflite" ]
+}

--- a/tests/tizen_nnfw_runtime/meson.build
+++ b/tests/tizen_nnfw_runtime/meson.build
@@ -2,7 +2,7 @@ unittest_nnfw_runtime_raw = executable('unittest_nnfw_runtime_raw',
   'unittest_tizen_nnfw_runtime_raw.cpp',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep, gtest_dep, nnfw_plugin_dep],
   install: get_option('install-test'),
-  install_dir: unittest_install_dir,
+  install_dir: join_paths(unittest_install_dir,'tests'),
 )
 
 test('unittest_nnfw_runtime_raw', unittest_nnfw_runtime_raw, args: ['--gst-plugin-path=../..'])

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cpp
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cpp
@@ -22,7 +22,7 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, check_existence)
 }
 
 /**
- * @brief Test nnfw subplugin with failing open/flose (no model file)
+ * @brief Test nnfw subplugin with failing open/close (no model file)
  */
 TEST (nnstreamer_nnfw_runtime_raw_functions, open_close_00_n)
 {
@@ -32,13 +32,58 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, open_close_00_n)
     .fw_opened = 0,
     .model_file = "null.nnfw",
   };
-  void *data;
+  void *data = NULL;
 
   const GstTensorFilterFramework *sp = nnstreamer_filter_find ("nnfw");
   EXPECT_NE (sp, (void *) NULL);
 
   ret = sp->open (&prop, &data);
   EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Test nnfw subplugin with successful open/close
+ */
+TEST (nnstreamer_nnfw_runtime_raw_functions, open_close_01_n)
+{
+  int ret;
+  void *data = NULL;
+  gchar *test_model;
+  gchar *model_path;
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+
+  ASSERT_NE (root_path, nullptr);
+
+  /** nnfw needs a directory with model file and metadata in that directory */
+  model_path = g_build_filename (root_path, "tests", "test_models", "models",
+      NULL);
+  GstTensorFilterProperties prop = {
+    .fwname = "nnfw",
+    .fw_opened = 0,
+    .model_file = model_path,
+  };
+
+  test_model = g_build_filename (model_path, "add.tflite", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+  g_free (test_model);
+
+  test_model = g_build_filename (model_path, "metadata", "MANIFEST", NULL);
+  ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
+  g_free (test_model);
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("nnfw");
+  EXPECT_NE (sp, (void *) NULL);
+
+  /** close without open, should not crash */
+  sp->close (&prop, &data);
+
+  /** open and close successfully */
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+  sp->close (&prop, &data);
+
+  /** close twice, should not crash */
+  sp->close (&prop, &data);
 }
 
 /**


### PR DESCRIPTION
Added nnfw base testing scenario for verification along with a few bug fixes                                                             
NNFW repo has been updated to test with cpu backend                                                                                      
However, that patch has not been uploaded to main tizen repo                                                                             
So, in order to test this patch, clone nnfw repo and build locally                                                                       
Also, building nnfw repo installs libbackend_acl_cl.so in /usr/lib in emulator                                                           
Delete this file to test nnstreamer with cpu backend with nnfw successfully
This is because libbackend_acl_cl.so exists, but libOpencl is not.

Refer https://github.com/nnsuite/nnstreamer/issues/1677 for more details.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>