### PR TITLE
[C-API] Use mock tizen_error.h when building C-API for Non-Tizen platform

### DIFF
--- a/api/capi/include/platform/tizen_error.h
+++ b/api/capi/include/platform/tizen_error.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ */
+/**
+ * @file tizen_error.h
+ * @date 24 October 2019
+ * @brief C-API internal header emulating tizen_error.h for Non-Tizen platforms
+ * @see	https://github.com/nnsuite/nnstreamer
+ * @author Wook Song <wook16.song@samsung.com>
+ * @bug No known bugs except for NYI items
+ */
+
+#ifndef __NTZN_TIZEN_ERROR_H__
+#define __NTZN_TIZEN_ERROR_H__
+
+#include <errno.h>
+#define TIZEN_ERROR_NONE (0)
+#define TIZEN_ERROR_INVALID_PARAMETER (-EINVAL)
+#define TIZEN_ERROR_STREAMS_PIPE (-ESTRPIPE)
+#define TIZEN_ERROR_TRY_AGAIN (-EAGAIN)
+#define TIZEN_ERROR_UNKNOWN (-1073741824LL)
+#define TIZEN_ERROR_TIMED_OUT (TIZEN_ERROR_UNKNOWN + 1)
+#define TIZEN_ERROR_NOT_SUPPORTED (TIZEN_ERROR_UNKNOWN + 2)
+#define TIZEN_ERROR_PERMISSION_DENIED (-EACCES)
+
+#endif /* __NTZN_TIZEN_ERROR_H__ */

--- a/api/capi/meson.build
+++ b/api/capi/meson.build
@@ -18,9 +18,13 @@ if meson.project_name() != 'nnstreamer'
 endif
 
 
+capi_inc = []
+if not get_option('enable-tizen')
+  capi_inc += include_directories ('include/platform')
+endif
 inc = include_directories('include')
 nninc = include_directories('../../gst')
-capi_inc = [inc, nninc]
+capi_inc += [inc, nninc]
 
 capi_main = []
 capi_main += join_paths(meson.current_source_dir(), 'src', 'nnstreamer-capi-pipeline.c')
@@ -37,6 +41,8 @@ capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer
 if get_option('enable-tizen')
   # header for Tizen internal API
   capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'nnstreamer-tizen-internal.h')
+else
+  capi_devel_main += join_paths(meson.current_source_dir(), 'include', 'platform', 'tizen_error.h')
 endif
 
 # Dependencies

--- a/debian/rules
+++ b/debian/rules
@@ -58,5 +58,4 @@ override_dh_auto_install:
 
 override_dh_install:
 	dh_install --sourcedir=debian/tmp --list-missing
-	patch -R -p1 -i ./packaging/non_tizen_build.patch
 # Add --fail-missing option after adding *.install files for all subpackages.

--- a/meson.build
+++ b/meson.build
@@ -227,19 +227,6 @@ if get_option('enable-nnfw')
   # This also enables nnfw as a subplugin for Tizen.
 endif
 
-# Patch for non-tizen build
-patch_file = join_paths(meson.current_source_dir(), 'packaging', 'non_tizen_build.patch')
-if (not get_option('enable-tizen')) and get_option('enable-capi')
-  r = run_command('patch', '-R', '--dry-run', '-sfp1', '-i', patch_file)
-  if (r.returncode() != 0)
-    r = run_command('patch', '-p1', '-i', patch_file)
-    if (r.returncode() != 0)
-      message('Non-Tizen mode support failed')
-    endif
-  endif
-  message('CAPI is in non-Tizen mode')
-endif
-
 # Build nnstreamer (common, plugins)
 subdir('gst')
 

--- a/packaging/generate-tarball.sh
+++ b/packaging/generate-tarball.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+NNS_PKG_NAME=$1
+VERSION=$2
+
+tar xzf ${NNS_PKG_NAME}-${VERSION}.tar.gz
+rm -f ${NNS_PKG_NAME}-$VERSION.tar.gz
+rm -rf ${NNS_PKG_NAME}-$VERSION/api/capi/include/platform
+tar czf ${NNS_PKG_NAME}-$VERSION.tar.gz ${NNS_PKG_NAME}-${VERSION}/*

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -21,6 +21,7 @@ Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
 License:	LGPL-2.1
 Source0:	nnstreamer-%{version}.tar.gz
+Source1:	generate-tarball.sh
 Source1001:	nnstreamer.manifest
 %if %{with tizen}
 Source1002:	capi-nnstreamer.manifest
@@ -244,7 +245,11 @@ Note that there is no .pc file for this package because nnstreamer.pc file may b
 %setup -q
 cp %{SOURCE1001} .
 %if %{with tizen}
+pushd %{_sourcedir}
+sh %{SOURCE1} %{name} %{version}
+popd
 cp %{SOURCE1002} .
+rm -rf ./api/capi/include/platform
 %endif
 cp %{SOURCE1001} ./nnstreamer-cpp.manifest
 


### PR DESCRIPTION
In order to build C-API for Non-Tizen platforms, nnstreamer.h should be modified or patched at build time to emulate some Tizen-dependent symbols.  Instead, this PR adds a mock header, tizen_error.h, which emulates symbols required to build C-API and includes system header. In addition, the rpm spec file is also modified to filter out the mock header so that any Tizne packages do not contain that header.

Fixes: #1796 
Overrides: #1800 
See also: #1795

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Note that the build script for Android API will be addresses in anther PR.

Signed-off-by: Wook Song <wook16.song@samsung.com>