### PR TITLE
[Filter/Custom] Fix compiler complaints @open sesame 10/25 20:38

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -58,7 +58,7 @@ static int
 custom_loadlib (const GstTensorFilterProperties * prop, void **private_data)
 {
   internal_data *ptr;
-  char *dlsym_error;
+  const char *dlsym_error;
 
   if (*private_data != NULL) {
     /** @todo : Check the integrity of filter->data and filter->model_file, nnfw */


### PR DESCRIPTION
Recent TAOS-CI/Android complains:

.../tensor_filter_custom.c: In function 'custom_loadlib':
.../tensor_filter_custom.c:95:15: warning: assignment discards 'const' qualifier from pointer target type
   dlsym_error = dlerror ();
               ^

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

ps. need #1828