### PR TITLE
[C-API] Remove unnecessary asterisk on header file - @open sesame 11/11 17:31

### DIFF
--- a/api/capi/doc/nnstreamer_doc.h
+++ b/api/capi/doc/nnstreamer_doc.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * This library is free software; you can redistribute it and/or

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * This library is free software; you can redistribute it and/or

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * This library is free software; you can redistribute it and/or


### PR DESCRIPTION
This patch removes an unnecessary asterisk on header file for doxygen.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

### Notice
After running Tizen Native API Check script tool, this issue is reported by Sunggyu Choi.



