### PR TITLE
[caffe2] Do first run with try/catch 

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2_core.h
@@ -55,6 +55,7 @@ private:
 
   char *init_model_path;
   char *pred_model_path;
+  bool first_run;
 
   GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
   GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */


### PR DESCRIPTION
First run after configuring the tensor filter with caffe2 framework is now run with a try/catch

Check #1809  for more details

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>

cc. @helloahn 