### PR TITLE
[nnfw/single] enable nnfw for single API

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -488,8 +488,12 @@ ml_single_open (ml_single_h * single, const char *model,
       }
       break;
     case ML_NNFW_TYPE_MVNC:
-      g_object_set (filter_obj, "framework", "movidius-ncsdk2", "model", model, NULL);
       /** @todo Verify this! (this code is not tested) */
+      g_object_set (filter_obj, "framework", "movidius-ncsdk2", "model", model, NULL);
+      break;
+    case ML_NNFW_TYPE_NNFW:
+      /* We can get the tensor meta from tf-lite model. */
+      g_object_set (filter_obj, "framework", "nnfw", "model", model, NULL);
       break;
     default:
       /** @todo Add other fw later. */

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -13,7 +13,6 @@ if get_option('enable-nnfw-runtime')
   endif
   nnstreamer_filter_nnfw_deps = [glib_dep, gst_dep, nnstreamer_dep, nnfw_dep]
 
-
   nnfw_plugin_lib = shared_library('nnstreamer_filter_nnfw',
     nnstreamer_filter_nnfw_sources,
     dependencies: nnstreamer_filter_nnfw_deps,

--- a/meson.build
+++ b/meson.build
@@ -270,6 +270,7 @@ if get_option('enable-test')
   nnstreamer_test_conf.set('ENABLE_SYMBOLIC_LINK', false)
   nnstreamer_test_conf.set('TORCH_USE_GPU', false)
   nnstreamer_test_conf.set('ELEMENT_RESTRICTION_CONFIG', '')
+  nnstreamer_test_conf.set('NNFW_RUNTIME_PRIORITIZE', false)
 
   configure_file(input: 'nnstreamer.ini.in', output: 'nnstreamer-test.ini',
     install: get_option('install-test'),
@@ -285,6 +286,7 @@ nnstreamer_install_conf.merge_from(nnstreamer_conf)
 nnstreamer_install_conf.set('ENABLE_ENV_VAR', get_option('enable-env-var'))
 nnstreamer_install_conf.set('ENABLE_SYMBOLIC_LINK', get_option('enable-symbolic-link'))
 nnstreamer_install_conf.set('TORCH_USE_GPU', get_option('enable-pytorch-use-gpu'))
+nnstreamer_install_conf.set('NNFW_RUNTIME_PRIORITIZE', get_option('nnfw-runtime-prioritize'))
 
 # Element restriction
 restriction_config = ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,5 +19,6 @@ option('enable-element-restriction', type: 'boolean', value: false) # true to re
 option('restricted-elements', type: 'string', value: '')
 option('enable-tflite-nnapi-delegation', type: 'boolean', value: false) # true to enable tensorflow-lite to delegate nnapi interpretation to nnfw backend in tizen
 option('enable-nnfw-runtime', type: 'boolean', value: false) # true to enable nnfw tensor filter element
+option('nnfw-runtime-prioritize', type: 'boolean', value: false) # true to set higher priority for nnfw for tflite extension files in auto mode
 option('enable-cppfilter', type: 'boolean', value: true)
 option('enable-tizen-sensor', type: 'boolean', value: false)

--- a/nnstreamer.ini.in
+++ b/nnstreamer.ini.in
@@ -19,4 +19,8 @@ enable_nnapi=False
 [pytorch]
 enable_use_gpu=@TORCH_USE_GPU@
 
+# Set 1 or True if you want to prioritize nnfw over tensorflow lite for .tflite extension model files when automatically selecting framework for tensor filter.
+[nnfw-runtime]
+prioritize_tflite_ext=@NNFW_RUNTIME_PRIORITIZE@
+
 @ELEMENT_RESTRICTION_CONFIG@


### PR DESCRIPTION
- Update the nnfw framework input model format to work with file path
- Enable nnfw for single API
    - nnfw and tensorflow-lite both support tflite extensions. Added meson option to set default behavior which prioritizes tensorflow-lite
- Add invoke test for nnfw with single API

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor pk.kapoor@samsung.com