### PR TITLE
[C-API] make other mediatypes available with appsrc

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -169,6 +169,7 @@ typedef struct _ml_pipeline_element {
   gulong handle_id;
 
   GMutex lock; /**< Lock for internal values */
+  gboolean is_media_stream;
 } ml_pipeline_element;
 
 /**

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -407,6 +407,7 @@ int ml_pipeline_src_input_data (ml_pipeline_src_h src_handle, ml_tensors_data_h 
 
 /**
  * @brief Gets a handle for the tensors information of given src node.
+ * @details If the mediatype is not other/tensor or other/tensors, @a info handle may not be correct. If want to use other media types, you MUST set the correct properties.
  * @since_tizen 5.5
  * @remarks If the function succeeds, @a info handle must be released using ml_tensors_info_destroy().
  * @param[in] src_handle The source handle returned by ml_pipeline_src_get_handle().

--- a/api/capi/src/nnstreamer-capi-pipeline.c
+++ b/api/capi/src/nnstreamer-capi-pipeline.c
@@ -88,6 +88,7 @@ construct_element (GstElement * e, ml_pipeline * p, const char *name,
   ret->size = 0;
   ret->maxid = 0;
   ret->handle_id = 0;
+  ret->is_media_stream = FALSE;
   g_mutex_init (&ret->lock);
   return ret;
 }
@@ -922,6 +923,20 @@ ml_pipeline_src_parse_tensors_info (ml_pipeline_element * elem)
 
       if (caps) {
         found = get_tensors_info_from_caps (caps, &elem->tensors_info);
+
+        if (!found && gst_caps_is_fixed (caps)) {
+          GstStructure *caps_s;
+          const gchar *mimetype;
+
+          caps_s = gst_caps_get_structure (caps, 0);
+          mimetype = gst_structure_get_name (caps_s);
+
+          if (!g_str_equal (mimetype, "other/tensor") &&
+              !g_str_equal (mimetype, "other/tensors")) {
+            elem->is_media_stream = TRUE;
+          }
+        }
+
         gst_caps_unref (caps);
       }
 
@@ -931,13 +946,14 @@ ml_pipeline_src_parse_tensors_info (ml_pipeline_element * elem)
           elem->size += sz;
         }
       } else {
-        ml_logw
+        if (!elem->is_media_stream) {
+          ml_logw
             ("Cannot find caps. The pipeline is not yet negotiated for src element [%s].",
             elem->name);
-        gst_object_unref (elem->src);
-        elem->src = NULL;
-
-        ret = ML_ERROR_TRY_AGAIN;
+          gst_object_unref (elem->src);
+          elem->src = NULL;
+          ret = ML_ERROR_TRY_AGAIN;
+        }
       }
     }
   }
@@ -1069,25 +1085,27 @@ ml_pipeline_src_input_data (ml_pipeline_src_h h, ml_tensors_data_h data,
     goto destroy_data;
   }
 
-  if (elem->tensors_info.num_tensors != _data->num_tensors) {
-    ml_loge
-        ("The src push of [%s] cannot be handled because the number of tensors in a frame mismatches. %u != %u",
-        elem->name, elem->tensors_info.num_tensors, _data->num_tensors);
-
-    ret = ML_ERROR_INVALID_PARAMETER;
-    goto destroy_data;
-  }
-
-  for (i = 0; i < elem->tensors_info.num_tensors; i++) {
-    size_t sz = ml_tensor_info_get_size (&elem->tensors_info.info[i]);
-
-    if (sz != _data->tensors[i].size) {
+  if (!elem->is_media_stream){
+    if (elem->tensors_info.num_tensors != _data->num_tensors) {
       ml_loge
-          ("The given input tensor size (%d'th, %zu bytes) mismatches the source pad (%zu bytes)",
-          i, _data->tensors[i].size, sz);
+          ("The src push of [%s] cannot be handled because the number of tensors in a frame mismatches. %u != %u",
+          elem->name, elem->tensors_info.num_tensors, _data->num_tensors);
 
       ret = ML_ERROR_INVALID_PARAMETER;
       goto destroy_data;
+    }
+
+    for (i = 0; i < elem->tensors_info.num_tensors; i++) {
+      size_t sz = ml_tensor_info_get_size (&elem->tensors_info.info[i]);
+
+      if (sz != _data->tensors[i].size) {
+        ml_loge
+            ("The given input tensor size (%d'th, %zu bytes) mismatches the source pad (%zu bytes)",
+            i, _data->tensors[i].size, sz);
+
+        ret = ML_ERROR_INVALID_PARAMETER;
+        goto destroy_data;
+      }
     }
   }
 


### PR DESCRIPTION
Currently only 'other/tensor' and 'other/tensors' are available for `appsrc` with C-API.
Since there are many `media types`(video, audio, text, octet) that should be used as a `src` data, and they cannot be used currently, this commit makes them available with a partial restriction.

With this commit, I checked the `video/x-raw` works properly, and others will be tested with other sample apps.

Since there will be restriction, however, we need to discuss this method is desirable.

Signed-off-by: HyoungJoo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped