### PR TITLE
[Tests/Src/IIO] Fix Coverity defects in a macro that generates tests 

### DIFF
--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -1129,7 +1129,6 @@ TEST (test_tensor_src_iio, \
   data_buffer = (gchar *) malloc (bytes_to_read); \
   ASSERT_TRUE (data_buffer != NULL); \
   ret = read (fd, data_buffer, bytes_to_read); \
-  ASSERT_GE (ret, 0); \
   bytes_read = static_cast<size_t>(ret); \
   EXPECT_EQ (bytes_read, bytes_to_read); \
   expect_val_mask = G_MAXUINT64 >> (64 - data_bits); \


### PR DESCRIPTION
This PR addresses the Coverity defects in GENERATE_TESTS_TO_VERIFY_DATA_WO_TRIGGER, which is a macro for test generation. 

- Fix defects about resource leak found from Coverity
  - These defects are caused by the previous PR #1859 
- Fix TOCTOU and NEGATIVE_RETURNS defects as well

Signed-off-by: Wook Song <wook16.song@samsung.com>
CC: @kparichay