### PR TITLE
[CodeClean] cleanup sources and fix mem leak in api  @open sesame 11/14 12:50

### DIFF
--- a/api/android/api/src/main/jni/nnstreamer-native.h
+++ b/api/android/api/src/main/jni/nnstreamer-native.h
@@ -34,10 +34,6 @@
 #include "nnstreamer-capi-private.h"
 #include "nnstreamer_plugin_api_filter.h"
 
-#ifndef DBG
-#define DBG FALSE
-#endif
-
 #define TAG "NNStreamer-native"
 
 #define nns_logi(...) \
@@ -51,12 +47,6 @@
 
 #define nns_logd(...) \
     __android_log_print (ANDROID_LOG_DEBUG, TAG, __VA_ARGS__)
-
-#if (DBG)
-#define print_log nns_logd
-#else
-#define print_log(...)
-#endif
 
 #if GLIB_SIZEOF_VOID_P == 8
 #define CAST_TO_LONG(p) (jlong)(p)

--- a/api/capi/include/nnstreamer-single.h
+++ b/api/capi/include/nnstreamer-single.h
@@ -125,7 +125,7 @@ int ml_single_invoke (ml_single_h single, const ml_tensors_data_h input, ml_tens
  * @retval #ML_ERROR_TIMED_OUT Failed to get the result from sink element.
  *
  */
-static inline int ml_single_invoke_dynamic (ml_single_h single, const ml_tensors_data_h input, const ml_tensors_info_h in_info, ml_tensors_data_h *output, ml_tensors_info_h *out_info);
+int ml_single_invoke_dynamic (ml_single_h single, const ml_tensors_data_h input, const ml_tensors_info_h in_info, ml_tensors_data_h *output, ml_tensors_info_h *out_info);
 
 /*************
  * UTILITIES *
@@ -178,15 +178,15 @@ int ml_single_set_input_info (ml_single_h single, const ml_tensors_info_h info);
  * @details Note that a model/framework may not support setting such information.
  * @since_tizen 6.0
  * @param[in] single The model handle.
- * @param[in] info The handle of input tensors information.
- * @param[out] info The handle of output tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
+ * @param[in] in_info The handle of input tensors information.
+ * @param[out] out_info The handle of output tensors information. The caller is responsible for freeing the information with ml_tensors_info_destroy().
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_NOT_SUPPORTED This implies that the given framework does not support dynamic dimensions.
  *         Use ml_single_set_input_info/ml_single_get_output_info APIs instead for this framework.
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
-static inline int ml_single_update_info (ml_single_h single, const ml_tensors_info_h in_info, ml_tensors_info_h *out_info);
+int ml_single_update_info (ml_single_h single, const ml_tensors_info_h in_info, ml_tensors_info_h *out_info);
 
 /**
  * @brief Sets the maximum amount of time to wait for an output, in milliseconds.
@@ -199,52 +199,6 @@ static inline int ml_single_update_info (ml_single_h single, const ml_tensors_in
  * @retval #ML_ERROR_INVALID_PARAMETER Fail. The parameter is invalid.
  */
 int ml_single_set_timeout (ml_single_h single, unsigned int timeout);
-
-/*****************************
- * STATIC INLINE DEFINITIONS *
- ****************************/
-
-/**
- * @brief Invokes the model with the given input data with the given info.
- */
-static inline int ml_single_invoke_dynamic (ml_single_h single,
-    const ml_tensors_data_h input, const ml_tensors_info_h in_info,
-    ml_tensors_data_h *output, ml_tensors_info_h *out_info)
-{
-  int status;
-  ml_tensors_info_h cur_in_info;
-
-  status = ml_single_get_input_info (single, &cur_in_info);
-  if (status != ML_ERROR_NONE)
-    return status;
-
-  status = ml_single_update_info (single, in_info, out_info);
-  if (status != ML_ERROR_NONE)
-    return status;
-
-  status = ml_single_invoke (single, input, output);
-  if (status != ML_ERROR_NONE) {
-    ml_single_set_input_info (single, cur_in_info);
-    ml_tensors_info_destroy (*out_info);
-  }
-
-  return status;
-}
-
-/**
- * @brief Sets the information (tensor dimension, type, name and so on) of required input data for the given model.
- */
-static inline int ml_single_update_info (ml_single_h single,
-    const ml_tensors_info_h in_info, ml_tensors_info_h *out_info)
-{
-  int status;
-
-  status = ml_single_set_input_info (single, in_info);
-  if (status != ML_ERROR_NONE)
-    return status;
-
-  return ml_single_get_output_info (single, out_info);
-}
 
 /**
  * @}

--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -100,23 +100,23 @@ ml_tensors_info_initialize (ml_tensors_info_s * info)
 /**
  * @brief Validates the given tensor info is valid.
  */
-static int
+static gboolean
 ml_tensor_info_validate (const ml_tensor_info_s * info)
 {
   guint i;
 
   if (!info)
-    return ML_ERROR_INVALID_PARAMETER;
+    return FALSE;
 
   if (info->type < 0 || info->type >= ML_TENSOR_TYPE_UNKNOWN)
-    return ML_ERROR_INVALID_PARAMETER;
+    return FALSE;
 
   for (i = 0; i < ML_TENSOR_RANK_LIMIT; i++) {
     if (info->dimension[i] == 0)
-      return ML_ERROR_INVALID_PARAMETER;
+      return FALSE;
   }
 
-  return ML_ERROR_NONE;
+  return TRUE;
 }
 
 /**
@@ -142,8 +142,7 @@ ml_tensors_info_validate (const ml_tensors_info_h info, bool * valid)
   *valid = false;
 
   for (i = 0; i < tensors_info->num_tensors; i++) {
-    /* Failed if returned value is not 0 (ML_ERROR_NONE) */
-    if (ml_tensor_info_validate (&tensors_info->info[i]) != ML_ERROR_NONE)
+    if (!ml_tensor_info_validate (&tensors_info->info[i]))
       goto done;
   }
 
@@ -904,6 +903,11 @@ ml_validate_model_file (const char *model, ml_nnfw_type_e * nnfw)
       ml_loge ("NNFW is not supported.");
       status = ML_ERROR_NOT_SUPPORTED;
       break;
+    case ML_NNFW_TYPE_MVNC:
+      /** @todo Need to check method for NCSDK2 */
+      ml_loge ("Intel Movidius NCSDK2 is not supported.");
+      status = ML_ERROR_NOT_SUPPORTED;
+      break;
     default:
       status = ML_ERROR_INVALID_PARAMETER;
       break;
@@ -945,6 +949,13 @@ ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw,
       {
         /** @todo Need to check method for NNFW */
         ml_logw ("NNFW is not supported.");
+        goto done;
+      }
+      break;
+    case ML_NNFW_TYPE_MVNC:
+      /** @todo Condition to support Movidius NCSDK2 */
+      if (nnstreamer_filter_find ("movidius-ncsdk2") == NULL) {
+        ml_logw ("Intel Movidius NCSDK2 is not supported.");
         goto done;
       }
       break;

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -4695,9 +4695,10 @@ TEST (tensor_stream_test, tensor_decoder_property)
 
 #include <tensor_filter_custom_easy.h>
 
-/** * @brief In-Code Test Function for custom-easy filter
+/**
+ * @brief In-Code Test Function for custom-easy filter
  */
-int cef_func_safe_memcpy (void *data, const GstTensorFilterProperties *prop,
+static int cef_func_safe_memcpy (void *data, const GstTensorFilterProperties *prop,
     const GstTensorMemory *in, GstTensorMemory *out)
 {
   unsigned int t;


### PR DESCRIPTION
1. remove static inline function in header for sam score
2. release handle when called invoke-dynamic
3. return type to validate tensors info
4. add condition to check ncsdk2
5. clean unnecessary code in android native

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
