### PR TITLE
[Github] Remove an unintended blank in the template file for PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ See also: #456, #789
 
 **Self evaluation:**
 1. Build test: [ ]Passed [ ]Failed [*]Skipped
-2. Run test: [ ]Passed [ ]Failed [* ]Skipped
+2. Run test: [ ]Passed [ ]Failed [*]Skipped
 
 **How to evaluate:**
 1. Describe how to evaluate in order to be reproduced by reviewer(s).


### PR DESCRIPTION
This patch removes an unintended blank in the self-evaluation section of the template file for PR.

Signed-off-by: Wook Song <wook16.song@samsung.com>