### PR TITLE
[spec/meson] Update nnstreamer package to support c++14 language standard @open sesame 11/21 14:11

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: nnstreamer
 Section: libs
 Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
-Build-Depends: gcc (>=5), ninja-build, meson (>=0.50),
- debhelper (>=9),
+Build-Depends: gcc-9 | gcc-8 | gcc-7 | gcc-6 | gcc-5 (>=5.4),
+ ninja-build, meson (>=0.50), debhelper (>=9),
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
  gstreamer1.0-tools, gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  libgtest-dev, ssat, libpng-dev, libopencv-dev, liborc-0.4-dev,

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project('nnstreamer', 'c', 'cpp',
     'werror=true',
     'warning_level=1',
     'c_std=gnu89',
-    'cpp_std=c++11'
+    'cpp_std=c++14'
   ]
 )
 

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -9,7 +9,7 @@
 %bcond_with tizen
 
 Name:		nnstreamer
-Summary:	gstremaer plugins for neural networks
+Summary:	gstreamer plugins for neural networks
 # Synchronize the version information among Ubuntu, Tizen, Android, and Meson.
 # 1. Ubuntu : ./debian/changelog
 # 2. Tizen  : ./packaging/nnstreamer.spec
@@ -252,6 +252,9 @@ rm -rf ./api/capi/include/platform
 cp %{SOURCE1001} ./nnstreamer-cpp.manifest
 
 %build
+# Remove compiler flags for meson to decide the cpp version
+CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-std=gnu++11||"`
+
 %if 0%{?testcoverage}
 CXXFLAGS="${CXXFLAGS} -fprofile-arcs -ftest-coverage"
 CFLAGS="${CFLAGS} -fprofile-arcs -ftest-coverage"


### PR DESCRIPTION
Update nnstreamer package to support c++14 language standard
This is primarily needed to support armnn tensor filter subplugin
armnn headers use c++14 compliant code

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

More info in #1817

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>