### PR TITLE
[Common] change return type

### DIFF
--- a/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
+++ b/ext/nnstreamer/tensor_decoder/tensordec-imagelabel.c
@@ -236,13 +236,13 @@ il_decode (void **pdata, const GstTensorsConfig * config,
   GstMapInfo out_info;
   GstMemory *out_mem;
 
-  guint bpe = gst_tensor_get_element_size (config->info.info[0].type);
+  gsize bpe = gst_tensor_get_element_size (config->info.info[0].type);
   tensor_element max_val;
   guint max_index = 0;
-  size_t num_data;              /* Size / bpe */
+  gsize num_data;              /* Size / bpe */
   void *input_data;
 
-  size_t size;
+  gsize size;
   char *str;
 
   g_assert (bpe > 0);

--- a/gst/nnstreamer/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api.h
@@ -302,17 +302,17 @@ extern gchar *
 gst_tensor_get_dimension_string (const tensor_dim dim);
 
 /**
- * @brief Count the number of elemnts of a tensor
+ * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension
  */
-extern gsize
+extern gulong
 gst_tensor_get_element_count (const tensor_dim dim);
 
 /**
  * @brief Get element size of tensor type (byte per element)
  */
-extern guint
+extern gsize
 gst_tensor_get_element_size (tensor_type type);
 
 /**

--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -945,11 +945,11 @@ gst_tensor_get_dimension_string (const tensor_dim dim)
 }
 
 /**
- * @brief Count the number of elemnts of a tensor
+ * @brief Count the number of elements of a tensor
  * @return The number of elements. 0 if error.
  * @param dim The tensor dimension
  */
-gsize
+gulong
 gst_tensor_get_element_count (const tensor_dim dim)
 {
   gsize count = 1;
@@ -965,7 +965,7 @@ gst_tensor_get_element_count (const tensor_dim dim)
 /**
  * @brief Get element size of tensor type (byte per element)
  */
-guint
+gsize
 gst_tensor_get_element_size (tensor_type type)
 {
   return tensor_element_size[type];

--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -594,7 +594,8 @@ gst_tensor_converter_chain (GstPad * pad, GstObject * parent, GstBuffer * buf)
   switch (self->in_media_type) {
     case _NNS_VIDEO:
     {
-      guint color, width, height, type;
+      guint color, width, height;
+      gsize type;
 
       color = config->info.dimension[0];
       width = config->info.dimension[1];

--- a/gst/nnstreamer/tensor_merge/gsttensormerge.c
+++ b/gst/nnstreamer/tensor_merge/gsttensormerge.c
@@ -475,8 +475,8 @@ gst_tensor_merge_generate_mem (GstTensorMerge * tensor_merge,
   uint8_t *inptr, *outptr;
   int num_mem = tensor_merge->tensors_config.info.num_tensors;
   int i, j, k, l;
-  size_t outSize = 0;
-  guint element_size;
+  gsize outSize = 0;
+  gsize element_size;
   tensor_dim dim;
   tensor_type type;
 

--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -410,7 +410,7 @@ gst_tensor_split_get_splited (GstTensorSplit * split, GstBuffer * buffer,
   GstMemory *mem;
   tensor_dim *dim;
   int i;
-  size_t size, offset;
+  gsize size, offset;
   GstMapInfo src_info, dest_info;
 
   size = 0;

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -1035,9 +1035,9 @@ gst_tensor_transform_dimchg (GstTensorTransform * filter,
   int to = filter->data_dimchg.to;
   int i, j, k;
   unsigned int loopLimit = 1;
-  size_t loopBlockSize = gst_tensor_get_element_size (in_tensor_type);
-  size_t copyblocksize = gst_tensor_get_element_size (in_tensor_type);
-  size_t copyblocklimit = 1;
+  gsize loopBlockSize = gst_tensor_get_element_size (in_tensor_type);
+  gsize copyblocksize = gst_tensor_get_element_size (in_tensor_type);
+  gsize copyblocklimit = 1;
 
   if (from == to) {
     /** Useless memcpy. Do not call this or @todo do "IP" operation */
@@ -1106,13 +1106,13 @@ static GstFlowReturn
 gst_tensor_transform_typecast (GstTensorTransform * filter,
     const uint8_t * inptr, uint8_t * outptr)
 {
-  gsize num = gst_tensor_get_element_count (filter->in_config.info.dimension);
+  gulong num = gst_tensor_get_element_count (filter->in_config.info.dimension);
   tensor_type in_tensor_type = filter->in_config.info.type;
   tensor_type out_tensor_type = filter->out_config.info.type;
-  guint in_element_size, out_element_size;
+  gsize in_element_size, out_element_size;
 
   tensor_transform_operand_s value;
-  size_t i, data_idx;
+  gsize i, data_idx;
 
 #ifdef HAVE_ORC
   if (orc_supported (filter)) {
@@ -1154,7 +1154,7 @@ static GstFlowReturn
 gst_tensor_transform_arithmetic (GstTensorTransform * filter,
     const uint8_t * inptr, uint8_t * outptr)
 {
-  gsize num = gst_tensor_get_element_count (filter->in_config.info.dimension);
+  gulong num = gst_tensor_get_element_count (filter->in_config.info.dimension);
   tensor_type in_tensor_type = filter->in_config.info.type;
   tensor_type out_tensor_type = filter->out_config.info.type;
   guint in_element_size, out_element_size;
@@ -1162,7 +1162,7 @@ gst_tensor_transform_arithmetic (GstTensorTransform * filter,
   GSList *walk;
   tensor_transform_operator_s *op_s;
   tensor_transform_operand_s value;
-  size_t i, data_idx;
+  gsize i, data_idx;
 
 #ifdef HAVE_ORC
   if (orc_supported (filter)) {
@@ -1272,8 +1272,8 @@ gst_tensor_transform_transpose (GstTensorTransform * filter,
   gboolean checkdim = FALSE;
   uint32_t *fromDim = filter->in_config.info.dimension;
   tensor_type in_tensor_type = filter->in_config.info.type;
-  size_t type_size = gst_tensor_get_element_size (in_tensor_type);
-  size_t indexI, indexJ, SL, SI, SJ, SK;
+  gsize type_size = gst_tensor_get_element_size (in_tensor_type);
+  gsize indexI, indexJ, SL, SI, SJ, SK;
   for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
     from = i;
     to = filter->data_transpose.trans_order[i];

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -124,9 +124,10 @@ pt_invoke (void *private_data, const GstTensorFilterProperties * prop,
     const GstTensorMemory * input, GstTensorMemory * output)
 {
   pt_data *data = private_data;
-  uint32_t ox, oy, x, y, z, elementsize;
+  uint32_t ox, oy, x, y, z;
   uint32_t oidx0, oidx1, oidx2;
   uint32_t iidx0, iidx1, iidx2;
+  size_t elementsize;
 
   assert (data);
   assert (input);

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
@@ -125,10 +125,10 @@ pt_allocate_invoke (void *private_data,
     GstTensorMemory * output)
 {
   pt_data *data = private_data;
-  uint32_t ox, oy, x, y, z, elementsize;
+  uint32_t ox, oy, x, y, z;
   uint32_t oidx0, oidx1, oidx2;
   uint32_t iidx0, iidx1, iidx2;
-  size_t size;
+  size_t size, elementsize;
 
   assert (data);
   assert (input);

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -3532,7 +3532,7 @@ TEST (tensor_stream_test, typecast_int32)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_INT32;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3583,7 +3583,7 @@ TEST (tensor_stream_test, typecast_uint32)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_UINT32;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3634,7 +3634,7 @@ TEST (tensor_stream_test, typecast_int16)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_INT16;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3685,7 +3685,7 @@ TEST (tensor_stream_test, typecast_uint16)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_UINT16;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3736,7 +3736,7 @@ TEST (tensor_stream_test, typecast_float64)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_FLOAT64;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3787,7 +3787,7 @@ TEST (tensor_stream_test, typecast_float32)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_FLOAT32;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3838,7 +3838,7 @@ TEST (tensor_stream_test, typecast_int64)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_INT64;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));
@@ -3889,7 +3889,7 @@ TEST (tensor_stream_test, typecast_uint64)
   const guint num_buffers = 2;
   const tensor_type t_type = _NNS_UINT64;
   TestOption option = { num_buffers, TEST_TYPE_TYPECAST, t_type };
-  guint t_size = gst_tensor_get_element_size (t_type);
+  gsize t_size = gst_tensor_get_element_size (t_type);
   guint timeout_id;
 
   ASSERT_TRUE (_setup_pipeline (option));


### PR DESCRIPTION
change improper return type to get tensor element size/count.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
