### PR TITLE
[Tests] Fix Coverity defects in the bmp-to-png tool

### DIFF
--- a/tests/bmp2png.c
+++ b/tests/bmp2png.c
@@ -253,7 +253,7 @@ main (int argc, char *argv[])
   bmp.width = width;
   bmp.height = height;
 
-  bmp.pixels = calloc (width * height, sizeof (pixel_t));
+  bmp.pixels = calloc (bmp.width * bmp.height, sizeof (pixel_t));
 
   for (y = (int) height - 1; y >= 0; y--) {
     for (x = 0; x < (int) width; x++) {


### PR DESCRIPTION
This patch fixes unintended-sign-extension defects reported by Coverity in the bmp-to-png tool.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**

1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped