### PR TITLE
[tests/coverity] Fix coverity issues related to gtest main

### DIFF
--- a/tests/common/unittest_common.cpp
+++ b/tests/common/unittest_common.cpp
@@ -760,6 +760,18 @@ TEST (conf_custom, env_str_01)
 int
 main (int argc, char **argv)
 {
-  testing::InitGoogleTest (&argc, argv);
-  return RUN_ALL_TESTS ();
+  int ret = -1;
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
+  try {
+    ret = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return ret;
 }

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -2995,9 +2995,20 @@ TEST (test_tensor_filter, reopen_tflite_02_p)
 int
 main (int argc, char **argv)
 {
-  testing::InitGoogleTest (&argc, argv);
+  int ret = -1;
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
 
   gst_init (&argc, &argv);
 
-  return RUN_ALL_TESTS ();
+  try {
+    ret = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return ret;
 }

--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -4781,6 +4781,7 @@ TEST (tensor_filter_custom_easy, in_code_func_01)
 int
 main (int argc, char **argv)
 {
+  int ret = -1;
   gchar *jitter_cmd_arg = NULL;
   gchar *fps_cmd_arg = NULL;
   const GOptionEntry main_entries[] = {
@@ -4797,7 +4798,11 @@ main (int argc, char **argv)
   };
   GError *error = NULL;
   GOptionContext *optionctx;
-  testing::InitGoogleTest (&argc, argv);
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
 
   optionctx = g_option_context_new (NULL);
   g_option_context_add_main_entries (optionctx, main_entries, NULL);
@@ -4820,5 +4825,10 @@ main (int argc, char **argv)
 
   gst_init (&argc, &argv);
 
-  return RUN_ALL_TESTS ();
+  try {
+    ret = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+  return ret;
 }

--- a/tests/nnstreamer_source/unittest_src_iio.cpp
+++ b/tests/nnstreamer_source/unittest_src_iio.cpp
@@ -1623,7 +1623,20 @@ TEST (test_tensor_src_iio, data_verify_freq_generic_type)
 int
 main (int argc, char **argv)
 {
-  testing::InitGoogleTest (&argc, argv);
+  int ret = -1;
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
+
   gst_init (&argc, &argv);
-  return RUN_ALL_TESTS ();
+
+  try {
+    ret = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+
+  return ret;
 }


### PR DESCRIPTION
Add try/catch for exceptions thrown by function calls in main bosy when using gtest

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>