### PR TITLE
[TensorFilter] Add a callback of tensor filter for model update in runtime

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -202,6 +202,15 @@ typedef struct _GstTensorFilterFramework
        *
        * @param[in] data the data element.
        */
+
+  int (*reloadModel) (const GstTensorFilterProperties * prop, void **private_data);
+      /**< Optional. tensor_filter.c will call it when a model property is newly configured.
+       * @todo add more detail comments.
+       *
+       * @param[in] prop read-only property values
+       * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, close() frees private_data and set NULL.
+       * @return 0 if ok. < 0 if error.
+       */
 } GstTensorFilterFramework;
 
 /* extern functions for subplugin management, exist in tensor_filter.c */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -41,7 +41,7 @@ typedef struct _GstTensorFilterPrivate
   /* internal properties for tensor-filter */
   gboolean silent; /**< Verbose mode if FALSE. int instead of gboolean for non-glib custom plugins */
   gboolean configured; /**< True if already successfully configured tensor metadata */
-  gboolean updatable_model; /**<  a given model to the filter is updatable if TRUE */
+  gboolean is_updatable; /**<  a given model to the filter is updatable if TRUE */
   GstTensorsConfig in_config; /**< input tensor info */
   GstTensorsConfig out_config; /**< output tensor info */
 } GstTensorFilterPrivate;


### PR DESCRIPTION
This PR adds a callback, `reloadModel()`, of tensor filter for model
update in runtime. When the model property is updated, this callback
will be called if `is-updatable` is TRUE.

Also, it adds an event handler to update a model in the same pipeline.
On receiving a model update event, it calls `set_property()` of `PROP_MODEL`.

Related issue: #1900

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped


