### PR TITLE
[Dist/Tizen] Fix integration error with libarmcl

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -85,6 +85,8 @@ BuildRequires:	gst-plugins-base-devel
 # Tizen 5.5 M2+ support nn-runtime (nnfw)
 # As of 2019-09-24, unfortunately, nnfw does not support pkg-config
 BuildRequires:  nnfw-devel
+BuildRequires:  libarmcl
+BuildConflicts: libarmcl-release
 %define		enable_nnfw_runtime	-Denable-nnfw-runtime=true
 %define		enable_nnfw_r	1
 %endif


### PR DESCRIPTION
With recent changes in the dependencies between
libarmcl and nnfw, nnfw incurs have-choice-for
errors for its users.

Fixing this requires some overlap periods for the
integration system; thus, we need this workaround for a while
until the OBS eliminates obsolete packages (libarmcl-release)

This is to be group-SR'ed with armcl.git in Tizen;
thus, this won't be able to pass CI-Tizen build until
everything gets fixed up.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
