### PR TITLE
[C-Api/Single] check invalid tensor info @open sesame 12/05 15:11

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -246,9 +246,13 @@ typedef struct _ml_pipeline_valve {
 
 /**
  * @brief Macro to check the tensors info is valid.
- * @since_tizen 5.5
  */
-#define ml_tensors_info_is_valid(i,v) (ml_tensors_info_validate ((i), &(v)) == ML_ERROR_NONE && (v))
+#define ml_tensors_info_is_valid(i) ({bool v; (ml_tensors_info_validate ((i), &v) == ML_ERROR_NONE && v);})
+
+/**
+ * @brief Macro to compare the tensors info.
+ */
+#define ml_tensors_info_is_equal(i1,i2) ({bool e; (ml_tensors_info_compare ((i1), (i2), &e) == ML_ERROR_NONE && e);})
 
 /**
  * @brief Gets the byte size of the given tensor info.
@@ -264,6 +268,20 @@ size_t ml_tensor_info_get_size (const ml_tensor_info_s *info);
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
 int ml_tensors_info_initialize (ml_tensors_info_s *info);
+
+/**
+ * @brief Compares the given tensors information.
+ * @details If the function returns an error, @a equal is not changed.
+ * @since_tizen 6.0
+ * @param[in] info1 The handle of tensors information to be compared.
+ * @param[in] info2 The handle of tensors information to be compared.
+ * @param[out] equal @c true if given tensors information is equal, @c false if if it's not equal.
+ * @return @c 0 on success. Otherwise a negative error value.
+ * @retval #ML_ERROR_NONE Successful
+ * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
+ * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
+ */
+int ml_tensors_info_compare (const ml_tensors_info_h info1, const ml_tensors_info_h info2, bool *equal);
 
 /**
  * @brief Frees the tensors info pointer.
@@ -289,6 +307,7 @@ GstCaps * ml_tensors_info_get_caps (const ml_tensors_info_s *info);
 
 /**
  * @brief Creates a tensor data frame wihout buffer with the given tensors information.
+ * @details If @a info is null, this allocates data handle with empty tensor data.
  * @param[in] info The handle of tensors information for the allocation.
  * @param[out] data The handle of tensors data.
  * @return @c 0 on success. Otherwise a negative error value.

--- a/tests/tizen_capi/unittest_tizen_capi.cpp
+++ b/tests/tizen_capi/unittest_tizen_capi.cpp
@@ -1366,6 +1366,56 @@ TEST (nnstreamer_capi_util, tensors_info)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
+/**
+ * @brief Test utility functions
+ */
+TEST (nnstreamer_capi_util, compare_info)
+{
+  ml_tensors_info_h info1, info2;
+  ml_tensor_dimension dim;
+  int status;
+
+  status = ml_tensors_info_create (&info1);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_tensors_info_create (&info2);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  dim[0] = 3;
+  dim[1] = 4;
+  dim[2] = 4;
+  dim[3] = 1;
+
+  ml_tensors_info_set_count (info1, 1);
+  ml_tensors_info_set_tensor_type (info1, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (info1, 0, dim);
+
+  ml_tensors_info_set_count (info2, 1);
+  ml_tensors_info_set_tensor_type (info2, 0, ML_TENSOR_TYPE_UINT8);
+  ml_tensors_info_set_tensor_dimension (info2, 0, dim);
+
+  /* compare info */
+  EXPECT_TRUE (ml_tensors_info_is_equal (info1, info2));
+
+  /* change type */
+  ml_tensors_info_set_tensor_type (info2, 0, ML_TENSOR_TYPE_UINT16);
+  EXPECT_FALSE (ml_tensors_info_is_equal (info1, info2));
+
+  /* validate info */
+  EXPECT_TRUE (ml_tensors_info_is_valid (info2));
+
+  /* validate invalid dimension */
+  dim[3] = 0;
+  ml_tensors_info_set_tensor_dimension (info2, 0, dim);
+  EXPECT_FALSE (ml_tensors_info_is_valid (info2));
+
+  status = ml_tensors_info_destroy (info1);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+
+  status = ml_tensors_info_destroy (info2);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+}
+
 #ifdef ENABLE_TENSORFLOW_LITE
 /**
  * @brief Test NNStreamer single shot (tensorflow-lite)


### PR DESCRIPTION
Check input/output tensor info when opening the nn model.
If given info is not matched with model, try to change input info for dynamic mode.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
