### PR TITLE
Policy Update: Test Tizen Features in ARM, always.

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -285,26 +285,30 @@ meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir
 
 ninja -C build %{?_smp_mflags}
 
+export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)
+
+pushd build
+export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
+export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
+export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
+%if 0%{?enable_nnfw_r}
+    ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw --gst-plugin-path=. --gtest_output="xml:unittest_nnfw_runtime_raw.xml"
+%endif
 %if 0%{?unit_test}
-    export NNSTREAMER_BUILD_ROOT_PATH=$(pwd)
-    pushd build
-    export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
-    export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
-    export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
-    export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
     ./tests/unittest_common --gtest_output="xml:unittest_common.xml"
     ./tests/unittest_sink --gst-plugin-path=. --gtest_output="xml:unittest_sink.xml"
     ./tests/unittest_plugins --gst-plugin-path=. --gtest_output="xml:unittest_plugins.xml"
     ./tests/unittest_src_iio --gst-plugin-path=. --gtest_output="xml:unittest_src_iio.xml"
     ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=. --gtest_output="xml:unittest_tizen_capi.xml"
-%if 0%{?enable_nnfw_r}
-    ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw --gst-plugin-path=. --gtest_output="xml:unittest_nnfw_runtime_raw.xml"
 %endif
 %if %{with tizen}
     ln -s ext/nnstreamer/tensor_source/*.so .
     ./tests/tizen_capi/unittest_tizen_sensor --gst-plugin-path=. --gtest_output="xml:unittest_tizen_sensor.xml"
 %endif
-    popd
+popd
+
+%if 0%{?unit_test}
     pushd tests
     ssat -n
     popd


### PR DESCRIPTION

Because TAOS-CI skips unittests for ARM/ARM64 because of the latency,
we need to enable unittests for ARM-only tests unconditionally
if the test-target features are ARM-only.

Especially, this will help preventing regressions from other packages
in Tizen by enabling unit-tests in Tizen build (build.tizen.org) for
those selected features.


Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

ps. We will enable the full unit tests in all arch for Tizen build soon, in order to prevent regressions from other packages.

ps2. This will enforce testing nnfw and sensor-fr in Tizen for every SR.