### PR TITLE
[PROP/MODEL] Revise the model property to support multiple model files

### DIFF
--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -352,7 +352,8 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
   if (G_UNLIKELY (!priv->fw) || G_UNLIKELY (!priv->fw->invoke_NN))
     return FALSE;
   if (G_UNLIKELY (!priv->fw->run_without_model) &&
-      G_UNLIKELY (!priv->prop.model_file))
+      G_UNLIKELY (!(priv->prop.model_files &&
+          priv->prop.num_models > 0 && priv->prop.model_files[0])))
     return FALSE;
 
   /** start if not already started */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.c
@@ -70,13 +70,20 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
     void **private_data)
 {
   caffe2_data *cf2;
+
+  if (prop->num_models != 2) {
+    g_critical ("Caffe2 requires two model files\n");
+    return -1;
+  }
+
+  /* In caffe2, model_files[0] is a init model, and model_files[1] is a pred model */
   if (*private_data != NULL) {
     /** @todo : Check the integrity of filter->data and filter->model_file, nnfw */
     cf2 = *private_data;
-    if (g_strcmp0 (prop->model_file,
-            caffe2_core_getPredModelPath (cf2->caffe2_private_data)) != 0 ||
-        g_strcmp0 (prop->model_file_sub,
-            caffe2_core_getInitModelPath (cf2->caffe2_private_data)) != 0) {
+    if (g_strcmp0 (prop->model_files[0],
+            caffe2_core_getInitModelPath (cf2->caffe2_private_data)) != 0 ||
+        g_strcmp0 (prop->model_files[1],
+            caffe2_core_getPredModelPath (cf2->caffe2_private_data)) != 0) {
       caffe2_close (prop, private_data);
     } else {
       return 1;
@@ -88,8 +95,8 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
     return -1;
   }
 
-  cf2->caffe2_private_data = caffe2_core_new (prop->model_file,
-      prop->model_file_sub);
+  cf2->caffe2_private_data = caffe2_core_new (prop->model_files[0],
+      prop->model_files[1]);
   if (cf2->caffe2_private_data) {
     if (caffe2_core_init (cf2->caffe2_private_data, prop)) {
       g_critical ("failed to initialize the object: Caffe2");

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2_core.cc
@@ -45,8 +45,8 @@ std::map <char*, Tensor*> Caffe2Core::inputTensorMap;
 Caffe2Core::Caffe2Core (const char * _model_path, const char *_model_path_sub)
 {
   g_assert (_model_path != NULL && _model_path_sub != NULL);
-  pred_model_path = g_strdup (_model_path);
-  init_model_path = g_strdup (_model_path_sub);
+  init_model_path = g_strdup (_model_path);
+  pred_model_path = g_strdup (_model_path_sub);
   first_run = true;
 
   gst_tensors_info_init (&inputTensorMeta);

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -148,9 +148,9 @@ _mvncsdk2_open (const GstTensorFilterProperties * prop, void **private_data)
   /**
    * 2. Initialize graph (model) handle
    */
-  ret_code = ncGraphCreate (prop->model_file, &handle_graph);
+  ret_code = ncGraphCreate (prop->model_files[0], &handle_graph);
   if (ret_code != NC_OK) {
-    g_printerr ("Cannot create graph handle for \"%s\"\n", prop->model_file);
+    g_printerr ("Cannot create graph handle for \"%s\"\n", prop->model_files[0]);
     goto err_destroy_device_h;
   }
 
@@ -166,10 +166,10 @@ _mvncsdk2_open (const GstTensorFilterProperties * prop, void **private_data)
   /**
    * 4. Send model (graph) to the device
    */
-  file_model = g_mapped_file_new (prop->model_file, FALSE, NULL);
+  file_model = g_mapped_file_new (prop->model_files[0], FALSE, NULL);
   if (file_model == NULL) {
     g_printerr ("Failed to g_mapped_file_new for the model file, \"%s\"\n",
-        prop->model_file);
+        prop->model_files[0]);
     goto err_destroy_graph_h;
   }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -73,7 +73,7 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
 
   if (*private_data != NULL) {
     pdata = *private_data;
-    if (g_strcmp0 (prop->model_file, pdata->model_path) != 0) {
+    if (g_strcmp0 (prop->model_files[0], pdata->model_path) != 0) {
       nnfw_close (prop, private_data);  /* "reopen" */
     } else {
       return 1;
@@ -93,10 +93,10 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto unalloc_exit;
   }
 
-  status = nnfw_load_model_from_file (pdata->session, prop->model_file);
+  status = nnfw_load_model_from_file (pdata->session, prop->model_files[0]);
   if (status != NNFW_STATUS_NO_ERROR) {
     err = -EINVAL;
-    g_printerr ("Cannot load the model file: %s", prop->model_file);
+    g_printerr ("Cannot load the model file: %s", prop->model_files[0]);
     goto session_exit;
   }
 
@@ -104,11 +104,11 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
   if (status != NNFW_STATUS_NO_ERROR) {
     err = -EINVAL;
     g_printerr ("nnfw-runtime cannot prepare the session for %s",
-        prop->model_file);
+        prop->model_files[0]);
     goto session_exit;
   }
 
-  pdata->model_path = g_strdup (prop->model_file);
+  pdata->model_path = g_strdup (prop->model_files[0]);
   return 0;
 
 session_exit:

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.c
@@ -164,14 +164,15 @@ static int
 py_loadScriptFile (const GstTensorFilterProperties * prop, void **private_data)
 {
   /**
-   * prop->model_file contains the path of a python script
+   * prop->model_files[0] contains the path of a python script
    * prop->custom contains its arguments seperated by ' '
    */
   py_data *py;
 
   if (*private_data != NULL) {
     py = *private_data;
-    if (g_strcmp0 (prop->model_file, py_core_getScriptPath (py->py_private_data)) != 0) {
+    if (g_strcmp0 (prop->model_files[0],
+          py_core_getScriptPath (py->py_private_data)) != 0) {
       py_close (prop, private_data);
     } else {
       return 1;
@@ -184,7 +185,8 @@ py_loadScriptFile (const GstTensorFilterProperties * prop, void **private_data)
     return -1;
   }
 
-  py->py_private_data = py_core_new (prop->model_file, prop->custom_properties);
+  py->py_private_data = py_core_new (prop->model_files[0],
+      prop->custom_properties);
 
   if (py->py_private_data) {
     if (py_core_init (py->py_private_data, prop)) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.c
@@ -73,7 +73,7 @@ torch_loadModelFile (const GstTensorFilterProperties * prop,
   gboolean torch_use_gpu;
   if (*private_data != NULL) {
     torch = *private_data;
-    if (g_strcmp0 (prop->model_file,
+    if (g_strcmp0 (prop->model_files[0],
             torch_core_getModelPath (torch->torch_private_data)) != 0) {
       torch_close (prop, private_data);
     } else {
@@ -90,7 +90,7 @@ torch_loadModelFile (const GstTensorFilterProperties * prop,
     return -1;
   }
 
-  torch->torch_private_data = torch_core_new (prop->model_file);
+  torch->torch_private_data = torch_core_new (prop->model_files[0]);
 
   if (torch->torch_private_data) {
     if (torch_core_init (torch->torch_private_data, prop, torch_use_gpu)) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.c
@@ -73,7 +73,8 @@ tf_loadModelFile (const GstTensorFilterProperties * prop, void **private_data)
 
   if (*private_data != NULL) {
     tf = *private_data;
-    if (g_strcmp0 (prop->model_file, tf_core_getModelPath (tf->tf_private_data)) != 0) {
+    if (g_strcmp0 (prop->model_files[0],
+          tf_core_getModelPath (tf->tf_private_data)) != 0) {
       tf_close (prop, private_data);
     } else {
       return 1;
@@ -86,7 +87,7 @@ tf_loadModelFile (const GstTensorFilterProperties * prop, void **private_data)
     return -1;
   }
 
-  tf->tf_private_data = tf_core_new (prop->model_file);
+  tf->tf_private_data = tf_core_new (prop->model_files[0]);
 
   if (tf->tf_private_data) {
     if (tf_core_init (tf->tf_private_data, prop)) {

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.c
@@ -71,9 +71,9 @@ tflite_loadModelFile (const GstTensorFilterProperties * prop,
   tflite_data *tf;
 
   if (*private_data != NULL) {
-    /** @todo : Check the integrity of filter->data and filter->model_file, nnfw */
+    /** @todo : Check the integrity of filter->data and filter->model_files, nnfw */
     tf = *private_data;
-    if (g_strcmp0 (prop->model_file,
+    if (g_strcmp0 (prop->model_files[0],
             tflite_core_getModelPath (tf->tflite_private_data)) != 0) {
       tflite_close (prop, private_data);
     } else {
@@ -86,7 +86,7 @@ tflite_loadModelFile (const GstTensorFilterProperties * prop,
     return -1;
   }
 
-  tf->tflite_private_data = tflite_core_new (prop->model_file, prop->accl_str);
+  tf->tflite_private_data = tflite_core_new (prop->model_files[0], prop->accl_str);
   if (tf->tflite_private_data) {
     if (tflite_core_init (tf->tflite_private_data)) {
       g_printerr ("failed to initialize the object: Tensorflow-lite");

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -100,8 +100,8 @@ typedef struct _GstTensorFilterProperties
 {
   const char *fwname; /**< The name of NN Framework */
   int fw_opened; /**< TRUE IF open() is called or tried. Use int instead of gboolean because this is refered by custom plugins. */
-  const char *model_file; /**< Filepath to the model file (as an argument for NNFW). char instead of gchar for non-glib custom plugins */
-  const char *model_file_sub; /**< Filepath to the init model file (as an argument for NNFW). Some frameworks need this file to initialize the graph(caffe, caffe2) */
+  const char **model_files; /**< Filepath to the model file (as an argument for NNFW). char instead of gchar for non-glib custom plugins */
+  int num_models; /**< number of model files. Some frameworks need multiple model files to initialize the graph (caffe, caffe2) */
 
   int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo input_meta; /**< configured input tensor info */

--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -338,14 +338,15 @@ gst_tensor_filter_transform (GstBaseTransform * trans,
   if (G_UNLIKELY (!priv->fw))
     goto unknown_framework;
   if (G_UNLIKELY (!priv->fw->run_without_model) &&
-      G_UNLIKELY (!prop->model_file))
+      G_UNLIKELY (!(prop->model_files &&
+              prop->num_models > 0 && prop->model_files[0])))
     goto unknown_model;
   if (G_UNLIKELY (!priv->fw->invoke_NN))
     goto unknown_invoke;
 
   /* 0. Check all properties. */
   silent_debug ("Invoking %s with %s model\n", priv->fw->name,
-      GST_STR_NULL (prop->model_file));
+      GST_STR_NULL (prop->model_files[0]));
 
   /* 1. Set input tensors from inbuf. */
   g_assert (gst_buffer_n_memory (inbuf) == prop->input_meta.num_tensors);

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -65,12 +65,14 @@ custom_loadlib (const GstTensorFilterProperties * prop, void **private_data)
     return 1;
   }
 
-  if (!prop->model_file || prop->model_file[0] == '\0') {
+  if (!prop->model_files || prop->num_models != 1 ||
+      !prop->model_files[0] || prop->model_files[0][0] == '\0') {
     /* The .so file path is not given */
     return -1;
   }
 
-  if (!nnsconf_validate_file (NNSCONF_PATH_CUSTOM_FILTERS, prop->model_file)) {
+  if (!nnsconf_validate_file (NNSCONF_PATH_CUSTOM_FILTERS,
+          prop->model_files[0])) {
     /* Cannot load the library */
     return -1;
   }
@@ -82,7 +84,7 @@ custom_loadlib (const GstTensorFilterProperties * prop, void **private_data)
   }
 
   /* Load .so if this is the first time for this instance. */
-  ptr->handle = dlopen (prop->model_file, RTLD_NOW);
+  ptr->handle = dlopen (prop->model_files[0], RTLD_NOW);
   if (!ptr->handle) {
     g_free (ptr);
     *private_data = NULL;

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -94,12 +94,12 @@ custom_open (const GstTensorFilterProperties * prop, void **private_data)
   rd = g_new (runtime_data, 1);
   if (!rd)
     return -ENOMEM;
-  rd->model = get_subplugin (NNS_EASY_CUSTOM_FILTER, prop->model_file);
+  rd->model = get_subplugin (NNS_EASY_CUSTOM_FILTER, prop->model_files[0]);
 
   if (NULL == rd->model) {
     g_critical
         ("Cannot find the easy-custom model, \"%s\". You should provide a valid model name of easy-custom.",
-        prop->model_file);
+        prop->model_files[0]);
     g_free (rd);
     return -EINVAL;
   }

--- a/tests/nnstreamer_plugins/unittest_plugins.cpp
+++ b/tests/nnstreamer_plugins/unittest_plugins.cpp
@@ -2966,12 +2966,17 @@ TEST (test_tensor_filter, reopen_tflite_02_p)
       "mobilenet_v1_1.0_224_quant.tflite", NULL);
   ASSERT_TRUE (g_file_test (test_model, G_FILE_TEST_EXISTS));
 
+  const gchar *model_files[] = {
+    test_model, NULL,
+  };
+
   /* prepare properties */
   prop = g_new0 (GstTensorFilterProperties, 1);
   ASSERT_TRUE (prop != NULL);
 
   prop->fwname = fw_name;
-  prop->model_file = test_model;
+  prop->model_files = model_files;
+  prop->num_models = 1;
 
   ASSERT_TRUE (fw && fw->open && fw->close);
 

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cpp
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cpp
@@ -27,10 +27,14 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, check_existence)
 TEST (nnstreamer_nnfw_runtime_raw_functions, open_close_00_n)
 {
   int ret;
+  const gchar *model_files[] = {
+    "null.nnfw", NULL,
+  };
   GstTensorFilterProperties prop = {
     .fwname = "nnfw",
     .fw_opened = 0,
-    .model_file = "null.nnfw",
+    .model_files = model_files,
+    .num_models = 1,
   };
   void *data = NULL;
 
@@ -57,10 +61,14 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, open_close_01_n)
   /** nnfw needs a directory with model file and metadata in that directory */
   model_path = g_build_filename (root_path, "tests", "test_models", "models",
       NULL);
+  const gchar *model_files[] = {
+    model_path, NULL,
+  };
   GstTensorFilterProperties prop = {
     .fwname = "nnfw",
     .fw_opened = 0,
-    .model_file = model_path,
+    .model_files = model_files,
+    .num_models = 1,
   };
 
   test_model = g_build_filename (model_path, "add.tflite", NULL);
@@ -103,10 +111,14 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, get_dimension)
   /** nnfw needs a directory with model file and metadata in that directory */
   model_path = g_build_filename (root_path, "tests", "test_models", "models",
       NULL);
+  const gchar *model_files[] = {
+    model_path, NULL,
+  };
   GstTensorFilterProperties prop = {
     .fwname = "nnfw",
     .fw_opened = 0,
-    .model_file = model_path,
+    .model_files = model_files,
+    .num_models = 1,
   };
 
   test_model = g_build_filename (model_path, "add.tflite", NULL);
@@ -181,10 +193,14 @@ TEST (nnstreamer_nnfw_runtime_raw_functions, invoke)
   /** nnfw needs a directory with model file and metadata in that directory */
   model_path = g_build_filename (root_path, "tests", "test_models", "models",
       NULL);
+  const gchar *model_files[] = {
+    model_path, NULL,
+  };
   GstTensorFilterProperties prop = {
     .fwname = "nnfw",
     .fw_opened = 0,
-    .model_file = model_path,
+    .model_files = model_files,
+    .num_models = 1,
   };
 
   /** this model adds 2 to the input data passed in float format */


### PR DESCRIPTION
This PR revises the model property to support multiple model files.
Also,` tensor_filter_common.c` now does not handle FW-specific model file
semantic info (e.g., pred/init files).

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

CC: @jaeyun-jung 

