### PR TITLE
[TFLITE/RELOAD] Revise tflite sub-plugin to support model reloading

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.cc
@@ -57,6 +57,361 @@
   "(?<!!)" ACCL_NEON_STR ")?"
 
 /**
+ * @brief TFLiteInterpreter constructor
+ */
+TFLiteInterpreter::TFLiteInterpreter ()
+{
+  interpreter = nullptr;
+  model = nullptr;
+#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
+  nnfw_delegate = nullptr;
+#endif
+  model_path = nullptr;
+
+  g_mutex_init (&mutex);
+
+  gst_tensors_info_init (&inputTensorMeta);
+  gst_tensors_info_init (&outputTensorMeta);
+}
+
+/**
+ * @brief TFLiteInterpreter desctructor
+ */
+TFLiteInterpreter::~TFLiteInterpreter ()
+{
+  g_mutex_clear (&mutex);
+  g_free (model_path);
+
+  gst_tensors_info_free (&inputTensorMeta);
+  gst_tensors_info_free (&outputTensorMeta);
+}
+
+/**
+ * @brief Internal implementation of TFLiteCore's invoke()
+ */
+int
+TFLiteInterpreter::invoke (const GstTensorMemory * input,
+    GstTensorMemory * output, bool use_nnapi)
+{
+#if (DBG)
+  gint64 start_time = g_get_real_time ();
+#endif
+
+  std::vector <int> tensors_idx;
+  int tensor_idx;
+  TfLiteTensor *tensor_ptr;
+  TfLiteStatus status;
+
+  for (int i = 0; i < outputTensorMeta.num_tensors; ++i) {
+    tensor_idx = interpreter->outputs ()[i];
+    tensor_ptr = interpreter->tensor (tensor_idx);
+
+    g_assert (tensor_ptr->bytes == output[i].size);
+    tensor_ptr->data.raw = (char *) output[i].data;
+    tensors_idx.push_back (tensor_idx);
+  }
+
+  for (int i = 0; i < inputTensorMeta.num_tensors; ++i) {
+    tensor_idx = interpreter->inputs ()[i];
+    tensor_ptr = interpreter->tensor (tensor_idx);
+
+    g_assert (tensor_ptr->bytes == input[i].size);
+    tensor_ptr->data.raw = (char *) input[i].data;
+    tensors_idx.push_back (tensor_idx);
+  }
+
+#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
+  if (use_nnapi)
+    status = nnfw_delegate->Invoke (interpreter.get());
+  else
+#endif
+    status = interpreter->Invoke ();
+
+  /** if it is not `nullptr`, tensorflow makes `free()` the memory itself. */
+  int tensorSize = tensors_idx.size ();
+  for (int i = 0; i < tensorSize; ++i) {
+    interpreter->tensor (tensors_idx[i])->data.raw = nullptr;
+  }
+
+#if (DBG)
+  gint64 stop_time = g_get_real_time ();
+  g_message ("Invoke() is finished: %" G_GINT64_FORMAT,
+      (stop_time - start_time));
+#endif
+
+  if (status != kTfLiteOk) {
+    g_critical ("Failed to invoke");
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * @brief Internal implementation of TFLiteCore's loadModel()
+ * @return 0 if OK. non-zero if error.
+ */
+int
+TFLiteInterpreter::loadModel (bool use_nnapi)
+{
+#if (DBG)
+  gint64 start_time = g_get_real_time ();
+#endif
+
+  if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
+    g_critical ("the file of model_path (%s) is not valid (not regular)\n", model_path);
+    return -1;
+  }
+  model = tflite::FlatBufferModel::BuildFromFile (model_path);
+  if (!model) {
+    g_critical ("Failed to mmap model\n");
+    return -1;
+  }
+  /* If got any trouble at model, active below code. It'll be help to analyze. */
+  /* model->error_reporter (); */
+
+  interpreter = nullptr;
+
+  tflite::ops::builtin::BuiltinOpResolver resolver;
+  tflite::InterpreterBuilder (*model, resolver) (&interpreter);
+  if (!interpreter) {
+    g_critical ("Failed to construct interpreter\n");
+    return -2;
+  }
+
+  interpreter->UseNNAPI (use_nnapi);
+
+#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
+  if (use_nnapi) {
+    nnfw_delegate.reset (new ::nnfw::tflite::NNAPIDelegate);
+    if (nnfw_delegate->BuildGraph (interpreter) != kTfLiteOk) {
+      g_critical ("Fail to BuildGraph");
+      return -3;
+    }
+  }
+#endif
+
+  /** set allocation type to dynamic for in/out tensors */
+  int tensor_idx;
+
+  int tensorSize = interpreter->inputs ().size ();
+  for (int i = 0; i < tensorSize; ++i) {
+    tensor_idx = interpreter->inputs ()[i];
+    interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
+  }
+
+  tensorSize = interpreter->outputs ().size ();
+  for (int i = 0; i < tensorSize; ++i) {
+    tensor_idx = interpreter->outputs ()[i];
+    interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
+  }
+
+  if (interpreter->AllocateTensors () != kTfLiteOk) {
+    g_critical ("Failed to allocate tensors\n");
+    return -2;
+  }
+#if (DBG)
+  gint64 stop_time = g_get_real_time ();
+  g_message ("Model is loaded: %" G_GINT64_FORMAT, (stop_time - start_time));
+#endif
+  return 0;
+}
+
+/**
+ * @brief	return the data type of the tensor
+ * @param tfType	: the defined type of Tensorflow Lite
+ * @return the enum of defined _NNS_TYPE
+ */
+tensor_type
+TFLiteInterpreter::getTensorType (TfLiteType tfType)
+{
+  switch (tfType) {
+    case kTfLiteFloat32:
+      return _NNS_FLOAT32;
+    case kTfLiteUInt8:
+      return _NNS_UINT8;
+    case kTfLiteInt32:
+      return _NNS_INT32;
+    case kTfLiteBool:
+      return _NNS_INT8;
+    case kTfLiteInt64:
+      return _NNS_INT64;
+    case kTfLiteString:
+    default:
+      /** @todo Support other types */
+      break;
+  }
+
+  return _NNS_END;
+}
+
+/**
+ * @brief	return the Dimension of Tensor.
+ * @param tensor_idx	: the real index of model of the tensor
+ * @param[out] dim	: the array of the tensor
+ * @return 0 if OK. non-zero if error.
+ * @note assume that the interpreter lock was already held.
+ */
+int
+TFLiteInterpreter::getTensorDim (int tensor_idx, tensor_dim dim)
+{
+  TfLiteIntArray *tensor_dims = interpreter->tensor (tensor_idx)->dims;
+  int len = tensor_dims->size;
+  g_assert (len <= NNS_TENSOR_RANK_LIMIT);
+
+  /* the order of dimension is reversed at CAPS negotiation */
+  std::reverse_copy (tensor_dims->data, tensor_dims->data + len, dim);
+
+  /* fill the remnants with 1 */
+  for (int i = len; i < NNS_TENSOR_RANK_LIMIT; ++i) {
+    dim[i] = 1;
+  }
+
+  return 0;
+}
+
+/**
+ * @brief extract and store the information of given tensor list
+ * @param tensor_idx_list list of index of tensors in tflite interpreter
+ * @param[out] tensorMeta tensors to set the info into
+ * @return 0 if OK. non-zero if error.
+ */
+int
+TFLiteInterpreter::setTensorProp (const std::vector<int> &tensor_idx_list,
+    GstTensorsInfo * tensorMeta)
+{
+  tensorMeta->num_tensors = tensor_idx_list.size ();
+
+  for (int i = 0; i < tensorMeta->num_tensors; ++i) {
+    if (getTensorDim (tensor_idx_list[i], tensorMeta->info[i].dimension)) {
+      g_critical ("failed to get the dimension of input tensors");
+      return -1;
+    }
+    tensorMeta->info[i].type =
+        getTensorType (interpreter->tensor (tensor_idx_list[i])->type);
+
+#if (DBG)
+    gchar *dim_str =
+        gst_tensor_get_dimension_string (tensorMeta->info[i].dimension);
+    g_message ("tensorMeta[%d] >> type:%d, dim[%s]",
+        i, tensorMeta->info[i].type, dim_str);
+    g_free (dim_str);
+#endif
+  }
+  return 0;
+}
+
+/**
+ * @brief extract and store the information of input tensors
+ * @return 0 if OK. non-zero if error.
+ */
+int
+TFLiteInterpreter::setInputTensorProp ()
+{
+  return setTensorProp (interpreter->inputs (), &inputTensorMeta);
+}
+
+/**
+ * @brief extract and store the information of output tensors
+ * @return 0 if OK. non-zero if error.
+ */
+int
+TFLiteInterpreter::setOutputTensorProp ()
+{
+  return setTensorProp (interpreter->outputs (), &outputTensorMeta);
+}
+
+/**
+ * @brief set the Dimension for Input Tensor.
+ * @param info Structure for input tensor info.
+ * @return 0 if OK. non-zero if error.
+ * @note rank can be changed dependent on the model
+ */
+int
+TFLiteInterpreter::setInputTensorsInfo (const GstTensorsInfo * info)
+{
+  TfLiteStatus status;
+  const std::vector<int> &input_idx_list = interpreter->inputs();
+
+  /** Cannot change the number of inputs */
+  if (info->num_tensors != input_idx_list.size ())
+    return -EINVAL;
+
+  for (int tensor_idx = 0; tensor_idx < info->num_tensors; ++tensor_idx) {
+    tensor_type tf_type;
+    const GstTensorInfo *tensor_info;
+    int input_rank;
+
+    tensor_info = &info->info[tensor_idx];
+
+    /** cannot change the type of input */
+    tf_type = getTensorType (
+        interpreter->tensor (input_idx_list[tensor_idx])->type);
+    if (tf_type != tensor_info->type)
+      return -EINVAL;
+
+    /**
+     * Given that the rank intended by the user cannot be exactly determined,
+     * iterate over all possible ranks starting from MAX rank to the actual rank
+     * of the dimension array. In case of none of these ranks work, return error
+     */
+    input_rank = gst_tensor_info_get_rank (&info->info[tensor_idx]);
+    for (int rank = NNS_TENSOR_RANK_LIMIT; rank >= input_rank; rank--) {
+			std::vector<int> dims(rank);
+      /* the order of dimension is reversed at CAPS negotiation */
+      for (int idx = 0; idx < rank; ++idx) {
+        /** check overflow when storing uint32_t in int container */
+        if (tensor_info->dimension[rank - idx - 1] > INT_MAX)
+          return -ERANGE;
+        dims[idx] = tensor_info->dimension[rank - idx - 1];
+      }
+
+      status = interpreter->ResizeInputTensor (input_idx_list[tensor_idx], dims);
+      if (status != kTfLiteOk)
+        continue;
+
+      break;
+    }
+
+    /** return error when none of the ranks worked */
+    if (status != kTfLiteOk)
+      return -EINVAL;
+  }
+
+  status = interpreter->AllocateTensors ();
+  if (status != kTfLiteOk)
+    return -EINVAL;
+
+  return 0;
+}
+
+/**
+ * @brief update the model path
+ */
+void
+TFLiteInterpreter::setModelPath (const char *_model_path)
+{
+  if (_model_path) {
+    g_free (model_path);
+    model_path = g_strdup (_model_path);
+  }
+}
+
+/**
+ * @brief Move the ownership of interpreter internal members
+ */
+void
+TFLiteInterpreter::moveInternals (TFLiteInterpreter& interp)
+{
+  interpreter = std::move (interp.interpreter);
+  model = std::move (interp.model);
+#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
+  nnfw_delegate = std::move (interp.nnfw_delegate);
+#endif
+  setModelPath (interp.getModelPath ());
+}
+
+/**
  * @brief	TFLiteCore creator
  * @param	_model_path	: the logical path to '{model_name}.tflite' file
  * @param	accelerators  : the accelerators property set for this subplugin
@@ -66,25 +421,14 @@
 TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 {
   g_assert (_model_path != NULL);
-  model_path = g_strdup (_model_path);
-  interpreter = nullptr;
-  model = nullptr;
+
+  interpreter.setModelPath (_model_path);
 
   setAccelerator (accelerators);
-  g_warning ("nnapi = %d, accl = %s", use_nnapi, get_accl_hw_str(accelerator));
 
-  gst_tensors_info_init (&inputTensorMeta);
-  gst_tensors_info_init (&outputTensorMeta);
-}
-
-/**
- * @brief	TFLiteCore Destructor
- * @return	Nothing
- */
-TFLiteCore::~TFLiteCore ()
-{
-  gst_tensors_info_free (&inputTensorMeta);
-  gst_tensors_info_free (&outputTensorMeta);
+#if (DBG)
+  g_message ("nnapi = %d, accl = %s", use_nnapi, get_accl_hw_str(accelerator));
+#endif
 }
 
 void TFLiteCore::setAccelerator (const char * accelerators)
@@ -160,13 +504,19 @@ TFLiteCore::init ()
 }
 
 /**
- * @brief	get the model path
- * @return the model path.
+ * @brief	compare the model path
+ * @return TRUE if tflite core has the same model path
  */
-const char *
-TFLiteCore::getModelPath ()
+gboolean
+TFLiteCore::compareModelPath (const char *model_path)
 {
-  return model_path;
+  gboolean is_same;
+
+  interpreter.lock ();
+  is_same = (g_strcmp0 (model_path, interpreter.getModelPath ()) == 0);
+  interpreter.unlock ();
+
+  return is_same;
 }
 
 /**
@@ -177,128 +527,13 @@ TFLiteCore::getModelPath ()
 int
 TFLiteCore::loadModel ()
 {
-#if (DBG)
-  gint64 start_time = g_get_real_time ();
-#endif
+  int err;
 
-  if (!interpreter) {
-    if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
-      g_critical ("the file of model_path (%s) is not valid (not regular)\n", model_path);
-      return -1;
-    }
-    model =
-        std::unique_ptr <tflite::FlatBufferModel>
-        (tflite::FlatBufferModel::BuildFromFile (model_path));
-    if (!model) {
-      g_critical ("Failed to mmap model\n");
-      return -1;
-    }
-    /* If got any trouble at model, active below code. It'll be help to analyze. */
-    /* model->error_reporter (); */
+  interpreter.lock ();
+  err = interpreter.loadModel (use_nnapi);
+  interpreter.unlock ();
 
-    tflite::ops::builtin::BuiltinOpResolver resolver;
-    tflite::InterpreterBuilder (*model, resolver) (&interpreter);
-    if (!interpreter) {
-      g_critical ("Failed to construct interpreter\n");
-      return -2;
-    }
-
-    interpreter->UseNNAPI(use_nnapi);
-
-#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
-    if (use_nnapi) {
-      nnfw_delegate.reset (new ::nnfw::tflite::NNAPIDelegate);
-      if (nnfw_delegate->BuildGraph (interpreter.get()) != kTfLiteOk) {
-        g_critical ("Fail to BuildGraph");
-        return -3;
-      }
-    }
-#endif
-
-    /** set allocation type to dynamic for in/out tensors */
-    int tensor_idx;
-
-    int tensorSize = interpreter->inputs ().size ();
-    for (int i = 0; i < tensorSize; ++i) {
-      tensor_idx = interpreter->inputs ()[i];
-      interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
-    }
-
-    tensorSize = interpreter->outputs ().size ();
-    for (int i = 0; i < tensorSize; ++i) {
-      tensor_idx = interpreter->outputs ()[i];
-      interpreter->tensor (tensor_idx)->allocation_type = kTfLiteDynamic;
-    }
-
-    if (interpreter->AllocateTensors () != kTfLiteOk) {
-      g_critical ("Failed to allocate tensors\n");
-      return -2;
-    }
-  }
-#if (DBG)
-  gint64 stop_time = g_get_real_time ();
-  g_message ("Model is loaded: %" G_GINT64_FORMAT, (stop_time - start_time));
-#endif
-  return 0;
-}
-
-/**
- * @brief	return the data type of the tensor
- * @param tfType	: the defined type of Tensorflow Lite
- * @return the enum of defined _NNS_TYPE
- */
-tensor_type
-TFLiteCore::getTensorType (TfLiteType tfType)
-{
-  switch (tfType) {
-    case kTfLiteFloat32:
-      return _NNS_FLOAT32;
-    case kTfLiteUInt8:
-      return _NNS_UINT8;
-    case kTfLiteInt32:
-      return _NNS_INT32;
-    case kTfLiteBool:
-      return _NNS_INT8;
-    case kTfLiteInt64:
-      return _NNS_INT64;
-    case kTfLiteString:
-    default:
-      /** @todo Support other types */
-      break;
-  }
-
-  return _NNS_END;
-}
-
-/**
- * @brief extract and store the information of given tensor list
- * @param tensor_idx_list list of index of tensors in tflite interpreter
- * @param[out] tensorMeta tensors to set the info into
- * @return 0 if OK. non-zero if error.
- */
-int
-TFLiteCore::setTensorProp (const std::vector<int> &tensor_idx_list,
-    GstTensorsInfo * tensorMeta)
-{
-  tensorMeta->num_tensors = tensor_idx_list.size ();
-
-  for (int i = 0; i < tensorMeta->num_tensors; ++i) {
-    if (getTensorDim (tensor_idx_list[i], tensorMeta->info[i].dimension)) {
-      g_critical ("failed to get the dimension of input tensors");
-      return -1;
-    }
-    tensorMeta->info[i].type =
-        getTensorType (interpreter->tensor (tensor_idx_list[i])->type);
-
-#if (DBG)
-    gchar *dim_str =
-        gst_tensor_get_dimension_string (tensorMeta->info[i].dimension);
-    g_message ("tensorMeta[%d] >> type:%d, dim[%s]",
-        i, tensorMeta->info[i].type, dim_str);
-    g_free (dim_str);
-#endif
-  }
-  return 0;
+  return err;
 }
 
 /**
@@ -308,7 +543,13 @@ TFLiteCore::setTensorProp (const std::vector<int> &tensor_idx_list,
 int
 TFLiteCore::setInputTensorProp ()
 {
-  return setTensorProp (interpreter->inputs (), &inputTensorMeta);
+  int err;
+
+  interpreter.lock ();
+  err = interpreter.setInputTensorProp ();
+  interpreter.unlock ();
+
+  return err;
 }
 
 /**
@@ -318,31 +559,13 @@ TFLiteCore::setInputTensorProp ()
 int
 TFLiteCore::setOutputTensorProp ()
 {
-  return setTensorProp (interpreter->outputs (), &outputTensorMeta);
-}
+  int err;
 
-/**
- * @brief	return the Dimension of Tensor.
- * @param tensor_idx	: the real index of model of the tensor
- * @param[out] dim	: the array of the tensor
- * @return 0 if OK. non-zero if error.
- */
-int
-TFLiteCore::getTensorDim (int tensor_idx, tensor_dim dim)
-{
-  TfLiteIntArray *tensor_dims = interpreter->tensor (tensor_idx)->dims;
-  int len = tensor_dims->size;
-  g_assert (len <= NNS_TENSOR_RANK_LIMIT);
+  interpreter.lock ();
+  err = interpreter.setOutputTensorProp ();
+  interpreter.unlock ();
 
-  /* the order of dimension is reversed at CAPS negotiation */
-  std::reverse_copy (tensor_dims->data, tensor_dims->data + len, dim);
-
-  /* fill the remnants with 1 */
-  for (int i = len; i < NNS_TENSOR_RANK_LIMIT; ++i) {
-    dim[i] = 1;
-  }
-
-  return 0;
+  return err;
 }
 
 /**
@@ -354,7 +577,10 @@ TFLiteCore::getTensorDim (int tensor_idx, tensor_dim dim)
 int
 TFLiteCore::getInputTensorDim (GstTensorsInfo * info)
 {
-  gst_tensors_info_copy (info, &inputTensorMeta);
+  interpreter.lock ();
+  gst_tensors_info_copy (info, interpreter.getInputTensorsInfo());
+  interpreter.unlock ();
+
   return 0;
 }
 
@@ -367,7 +593,10 @@ TFLiteCore::getInputTensorDim (GstTensorsInfo * info)
 int
 TFLiteCore::getOutputTensorDim (GstTensorsInfo * info)
 {
-  gst_tensors_info_copy (info, &outputTensorMeta);
+  interpreter.lock ();
+  gst_tensors_info_copy (info, interpreter.getOutputTensorsInfo());
+  interpreter.unlock ();
+
   return 0;
 }
 
@@ -380,60 +609,76 @@ TFLiteCore::getOutputTensorDim (GstTensorsInfo * info)
 int
 TFLiteCore::setInputTensorDim (const GstTensorsInfo * info)
 {
-  TfLiteStatus status;
-  const std::vector<int> &input_idx_list = interpreter->inputs ();
+  int err;
 
-  /** Cannot change the number of inputs */
-  if (info->num_tensors != input_idx_list.size ())
-    return -EINVAL;
+  interpreter.lock ();
+  err = interpreter.setInputTensorsInfo (info);
+  interpreter.unlock ();
 
-  for (int tensor_idx = 0; tensor_idx < info->num_tensors; ++tensor_idx) {
-    tensor_type tf_type;
-    const GstTensorInfo *tensor_info;
-    int input_rank;
+  return err;
+}
 
-    tensor_info = &info->info[tensor_idx];
+/**
+ * @brief	reload a model
+ * @param	tflite	: the class object
+ * @param[in] model_path : the path of model file
+ * @return 0 if OK. non-zero if error.
+ * @note reloadModel() is asynchronously called with other callbacks. But, it requires
+ *       extra memory size enough to temporarily hold both models during this function.
+ */
+int
+TFLiteCore::reloadModel (const char * _model_path)
+{
+  int err;
 
-    /** cannot change the type of input */
-    tf_type = getTensorType (
-        interpreter->tensor (input_idx_list[tensor_idx])->type);
-    if (tf_type != tensor_info->type)
-      return -EINVAL;
+  interpreter_sub.lock ();
+  interpreter_sub.setModelPath (_model_path);
 
-    /**
-     * Given that the rank intended by the user cannot be exactly determined,
-     * iterate over all possible ranks starting from MAX rank to the actual rank
-     * of the dimension array. In case of none of these ranks work, return error
-     */
-    input_rank = gst_tensor_info_get_rank (&info->info[tensor_idx]);
-    for (int rank = NNS_TENSOR_RANK_LIMIT; rank >= input_rank; rank--) {
-			std::vector<int> dims(rank);
-      /* the order of dimension is reversed at CAPS negotiation */
-      for (int idx = 0; idx < rank; ++idx) {
-        /** check overflow when storing uint32_t in int container */
-        if (tensor_info->dimension[rank - idx - 1] > INT_MAX)
-          return -ERANGE;
-        dims[idx] = tensor_info->dimension[rank - idx - 1];
-      }
-
-      status = interpreter->ResizeInputTensor(input_idx_list[tensor_idx], dims);
-      if (status != kTfLiteOk)
-        continue;
-
-      break;
-    }
-
-    /** return error when none of the ranks worked */
-    if (status != kTfLiteOk)
-      return -EINVAL;
-
+  /**
+   * load a model into sub interpreter. This loading overhead is indenendent
+   * with main one's activities.
+   */
+  err = interpreter_sub.loadModel (use_nnapi);
+  if (err != 0) {
+    g_critical ("Failed to load model %s\n", _model_path);
+    goto out_unlock;
+  }
+  err = interpreter_sub.setInputTensorProp ();
+  if (err != 0) {
+    g_critical ("Failed to initialize input tensor\n");
+    goto out_unlock;
+  }
+  err = interpreter_sub.setOutputTensorProp ();
+  if (err != 0) {
+    g_critical ("Failed to initialize output tensor\n");
+    goto out_unlock;
   }
 
-  status = interpreter->AllocateTensors();
-  if (status != kTfLiteOk)
-    return -EINVAL;
+  /* Also, we need to check input/output tensors have the same info */
+  if (!gst_tensors_info_is_equal (
+        interpreter.getInputTensorsInfo (),
+        interpreter_sub.getInputTensorsInfo ()) ||
+      !gst_tensors_info_is_equal (
+        interpreter.getOutputTensorsInfo (),
+        interpreter_sub.getOutputTensorsInfo ())) {
+    g_critical ("The model has unmatched tensors info\n");
+    err = -EINVAL;
+    goto out_unlock;
+  }
 
-  return 0;
+  /**
+   * Everything is ready. let's move the model in sub interpreter to main one.
+   * But, it needs to wait if main interpreter is busy (e.g., invoke()).
+   */
+  interpreter.lock ();
+  interpreter.moveInternals (interpreter_sub);
+  /* after this, all callbacks will handle operations for the reloaded model */
+  interpreter.unlock ();
+
+out_unlock:
+  interpreter_sub.unlock ();
+
+  return err;
 }
 
 /**
@@ -445,58 +690,13 @@ TFLiteCore::setInputTensorDim (const GstTensorsInfo * info)
 int
 TFLiteCore::invoke (const GstTensorMemory * input, GstTensorMemory * output)
 {
-#if (DBG)
-  gint64 start_time = g_get_real_time ();
-#endif
+  int err;
 
-  std::vector <int> tensors_idx;
-  int tensor_idx;
-  TfLiteTensor *tensor_ptr;
-  TfLiteStatus status;
+  interpreter.lock ();
+  err = interpreter.invoke (input, output, use_nnapi);
+  interpreter.unlock ();
 
-  for (int i = 0; i < outputTensorMeta.num_tensors; ++i) {
-    tensor_idx = interpreter->outputs ()[i];
-    tensor_ptr = interpreter->tensor (tensor_idx);
-
-    g_assert (tensor_ptr->bytes == output[i].size);
-    tensor_ptr->data.raw = (char *) output[i].data;
-    tensors_idx.push_back (tensor_idx);
-  }
-
-  for (int i = 0; i < inputTensorMeta.num_tensors; ++i) {
-    tensor_idx = interpreter->inputs ()[i];
-    tensor_ptr = interpreter->tensor (tensor_idx);
-
-    g_assert (tensor_ptr->bytes == input[i].size);
-    tensor_ptr->data.raw = (char *) input[i].data;
-    tensors_idx.push_back (tensor_idx);
-  }
-
-#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
-  if (use_nnapi)
-    status = nnfw_delegate->Invoke (interpreter.get());
-  else
-#endif
-    status = interpreter->Invoke ();
-
-  /** if it is not `nullptr`, tensorflow makes `free()` the memory itself. */
-  int tensorSize = tensors_idx.size ();
-  for (int i = 0; i < tensorSize; ++i) {
-    interpreter->tensor (tensors_idx[i])->data.raw = nullptr;
-  }
-
-#if (DBG)
-  gint64 stop_time = g_get_real_time ();
-  g_message ("Invoke() is finished: %" G_GINT64_FORMAT,
-      (stop_time - start_time));
-#endif
-
-  if (status != kTfLiteOk) {
-    g_critical ("Failed to invoke");
-    return -1;
-  }
-
-  return 0;
+  return err;
 }
 
 /**
@@ -536,15 +736,15 @@ tflite_core_init (void * tflite)
 }
 
 /**
- * @brief	get the model path
+ * @brief	compare the model path
  * @param	tflite	: the class object
- * @return the model path.
+ * @return TRUE if tflite core has the same model path
  */
-const char *
-tflite_core_getModelPath (void * tflite)
+gboolean
+tflite_core_compareModelPath (void * tflite, const char * model_path)
 {
   TFLiteCore *c = (TFLiteCore *) tflite;
-  return c->getModelPath ();
+  return c->compareModelPath (model_path);
 }
 
 /**
@@ -626,6 +826,19 @@ tflite_core_setInputDim (void * tflite, const GstTensorsInfo * in_info,
   }
 
   return 0;
+}
+
+/**
+ * @brief	reload a model
+ * @param	tflite	: the class object
+ * @param[in] model_path : the path of model file
+ * @return 0 if OK. non-zero if error.
+ */
+int
+tflite_core_reloadModel (void * tflite, const char * model_path)
+{
+  TFLiteCore *c = (TFLiteCore *) tflite;
+  return c->reloadModel (model_path);
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite_core.h
@@ -38,44 +38,80 @@
 #endif
 
 /**
+ * @brief Wrapper class for TFLite Interpreter to support model switching
+ */
+class TFLiteInterpreter
+{
+public:
+  TFLiteInterpreter ();
+  ~TFLiteInterpreter ();
+
+  int invoke (const GstTensorMemory * input, GstTensorMemory * output, bool use_nnapi);
+  int loadModel (bool use_nnapi);
+  void moveInternals (TFLiteInterpreter& interp);
+
+  int setInputTensorProp ();
+  int setOutputTensorProp ();
+  int setInputTensorsInfo (const GstTensorsInfo * info);
+
+  void setModelPath (const char *model_path);
+  /** @brief get current model path */
+  const char *getModelPath () { return model_path; }
+
+  /** @brief return input tensor meta */
+  const GstTensorsInfo* getInputTensorsInfo () { return &inputTensorMeta; }
+  /** @brief return output tensor meta */
+  const GstTensorsInfo* getOutputTensorsInfo () { return &outputTensorMeta; }
+
+  /** @brief lock this interpreter */
+  void lock () { g_mutex_lock (&mutex); }
+  /** @brief unlock this interpreter */
+  void unlock () { g_mutex_unlock (&mutex); }
+
+private:
+  GMutex mutex;
+  char *model_path;
+
+  std::unique_ptr <tflite::Interpreter> interpreter;
+  std::unique_ptr <tflite::FlatBufferModel> model;
+#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
+  std::unique_ptr <nnfw::tflite::NNAPIDelegate> nnfw_delegate;
+#endif
+
+  GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
+  GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
+
+  tensor_type getTensorType (TfLiteType tfType);
+  int getTensorDim (int tensor_idx, tensor_dim dim);
+  int setTensorProp (const std::vector<int> &tensor_idx_list,
+      GstTensorsInfo * tensorMeta);
+};
+
+/**
  * @brief	ring cache structure
  */
 class TFLiteCore
 {
 public:
   TFLiteCore (const char *_model_path, const char *accelerators);
-  ~TFLiteCore ();
 
   int init ();
   int loadModel ();
-  const char* getModelPath ();
+  gboolean compareModelPath (const char *model_path);
   int setInputTensorProp ();
   int setOutputTensorProp ();
   int getInputTensorDim (GstTensorsInfo * info);
   int getOutputTensorDim (GstTensorsInfo * info);
   int setInputTensorDim (const GstTensorsInfo * info);
+  int reloadModel (const char * model_path);
   int invoke (const GstTensorMemory * input, GstTensorMemory * output);
 
 private:
-
-  char *model_path;
   bool use_nnapi;
   accl_hw accelerator;
 
-  GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
-  GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
-
-  std::unique_ptr <tflite::Interpreter> interpreter;
-  std::unique_ptr <tflite::FlatBufferModel> model;
-
-#ifdef ENABLE_TFLITE_NNAPI_DELEGATE
-  std::unique_ptr <nnfw::tflite::NNAPIDelegate> nnfw_delegate;
-#endif
-
-  tensor_type getTensorType (TfLiteType tfType);
-  int getTensorDim (int tensor_idx, tensor_dim dim);
-  int setTensorProp (const std::vector<int> &tensor_idx_list,
-      GstTensorsInfo * tensorMeta);
+  TFLiteInterpreter interpreter;
+  TFLiteInterpreter interpreter_sub;
 
   void setAccelerator (const char * accelerators);
 };
@@ -90,11 +126,12 @@ extern "C"
   void *tflite_core_new (const char *_model_path, const char *accelerators);
   void tflite_core_delete (void * tflite);
   int tflite_core_init (void * tflite);
-  const char *tflite_core_getModelPath (void * tflite);
+  gboolean tflite_core_compareModelPath (void * tflite, const char * model_path);
   int tflite_core_getInputDim (void * tflite, GstTensorsInfo * info);
   int tflite_core_getOutputDim (void * tflite, GstTensorsInfo * info);
   int tflite_core_setInputDim (void * tflite, const GstTensorsInfo * in_info,
       GstTensorsInfo * out_info);
+  int tflite_core_reloadModel (void * tflite, const char * model_path);
   int tflite_core_invoke (void * tflite, const GstTensorMemory * input,
       GstTensorMemory * output);
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -204,8 +204,7 @@ typedef struct _GstTensorFilterFramework
        */
 
   int (*reloadModel) (const GstTensorFilterProperties * prop, void **private_data);
-      /**< Optional. tensor_filter.c will call it when a model property is newly configured.
-       * @todo add more detail comments.
+      /**< Optional. tensor_filter.c will call it when a model property is newly configured. Also, 'is-updatable' property of the framework should be TRUE. This function reloads a new model specified in the 'prop' argument. Note that it requires extra memory size enough to temporarily hold both old and new models during this function to hide the reload overhead.
        *
        * @param[in] prop read-only property values
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, close() frees private_data and set NULL.


### PR DESCRIPTION
This PR revises tflite sub-plugin to support model reloading.

It implements an interpreter class with its own mutex, which wraps
existing codes. Also, it's designed to support interpreter switching
to hide the overhead of model reloading.

Related issue: #1900

**changelog**
V4: Add extra notes for a `reloadModel` callback.
V3: Add error handling for model mismatch
V2: Remove operator overloading

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


