### PR TITLE
[TYPO] Fix a typo of nnstreamer-cpp package in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,7 +62,7 @@ Depends: nnstreamer, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer CPP Filter Subplugin Support
  This package allows nnstreamer to support custom filters of C++ classes
 
-Package: nnsreamer-cpp-dev
+Package: nnstreamer-cpp-dev
 Architecture: any
 Multi-Arch: same
 Depends: nnstreamer-cpp, ${shlibs:Depends}, ${misc:Depends}


### PR DESCRIPTION
This PR fixes a typo of nnstreamer-cpp package in debian/control.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
