### PR TITLE
[DIST/DEBIAN] Add a missing debian package for nnstreamer-caffe2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,13 @@ Depends: nnstreamer, pytorch, ${shlibs:Depends}, ${misc:Depends}
 Description: NNStreamer Pytorch Support
  This package allows nnstreamer to support pytorch.
 
+Package: nnstreamer-caffe2
+Architecture: any
+Multi-Arch: same
+Depends: nnstreamer, pytorch, ${shlibs:Depends}, ${misc:Depends}
+Description: NNStreamer Caffe2 Support
+ This package allows nnstreamer to support caffe2.
+
 Package: nnstreamer-python2
 Architecture: any
 Multi-Arch: same


### PR DESCRIPTION
This PR adds a missing debian package for nnstreamer-caffe2.
Note that it has a dependency on PyTorch.

CC: @helloahn 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped
