### PR TITLE
Remove nnfw default backend configuration - @open sesame 12/09 17:36

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -93,13 +93,6 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto unalloc_exit;
   }
 
-  status = nnfw_set_default_backend(pdata->session, NNFW_DEFAULT_BACKEND);
-  if (status != NNFW_STATUS_NO_ERROR) {
-    err = -ENXIO;
-    g_printerr ("Cannot load the model file: %s", prop->model_file);
-    goto session_exit;
-  }
-
   status = nnfw_load_model_from_file (pdata->session, prop->model_file);
   if (status != NNFW_STATUS_NO_ERROR) {
     err = -EINVAL;


### PR DESCRIPTION
Now, nnfw will use available backend. Thus, no need to configure default backend manually.

**Self evaluation:**
Test on gbs build:

1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>

