### PR TITLE
[FIX] Add a missing g_clear_error() in unittest_sink.cpp

### DIFF
--- a/tests/nnstreamer_sink/unittest_sink.cpp
+++ b/tests/nnstreamer_sink/unittest_sink.cpp
@@ -4809,6 +4809,7 @@ main (int argc, char **argv)
 
   if (!g_option_context_parse (optionctx, &argc, &argv, &error)) {
     g_print ("option parsing failed: %s\n", error->message);
+    g_clear_error (&error);
   }
 
   if (jitter_cmd_arg != NULL) {


### PR DESCRIPTION
This PR adds a missing g_clear_error() in unittest_sink.cpp.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>