### PR TITLE
Release of 1.2.0 & Start of 1.3.0 development

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,18 @@
+1.0.0 -> 1.2.0:
+	- Tizen Sensor Framework Integration (tensor_src_tizensensor)
+	- Single C-API latency shortened by bypassing GST pipeline constructions
+	- NNFW-Runtime Integration (tensor_filter::nnfw)
+		- NNFW: https://git.tizen.org/cgit/platform/core/ml/nnfw/
+		- Integrated & tested along with ARMCL.
+	- C++ classes are suggested (WIP)
+	- Converter accepts external subplugins (tensor_converter::*)
+	- Custom-Easy mode (tensor_filter::custom_easy) for future "lambda func" support.
+	- Tizen ncsdk2 support
+	- Types for path configurations are no more hardcoded.
+	- Overall architecture improved/refactored (Lowered CC, DC, and so on)
+	- Fixes from 1.0.1 (Tizen 5.5 M2's stable/commercialization branch)
+	- Documentation updates and bugfixes.
+
 0.3.0 -> 1.0.0:
 	- Tizen Public C-API (Single & Pipeline) Reviewed and Confirmed!
 	- Tizen Public C#-API (Single) Reviewed and Confirmed!

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+1.2.0 -> 1.3.0:
+	- 1.3.0 is a devel version for 1.4.0 release.
+	- From 1.2.0, 1.even.x is a release and 1.odd.x is a devel version.
+	- When 1.3.x is "done", it will release 1.4.0 and move on to 1.5.0
+
 1.0.0 -> 1.2.0:
 	- Tizen Sensor Framework Integration (tensor_src_tizensensor)
 	- Single C-API latency shortened by bypassing GST pipeline constructions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+nnstreamer (1.2.0.0) unstable xenial bionic; urgency=medium
+
+  * 1.2.0 Release
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Wed, 11 Dec 2019 11:12:00 +0900
+
 nnstreamer (1.0.0.0) unstable xenial bionic; urgency=medium
 
-  * 1.0.0 Release (1.0 RC2). NNStreamer becomes 1.0 with Tizen 5.5 M2 official release.
+  * 1.0.0 Release (1.0 RC2 = 1.0 Release). NNStreamer becomes 1.0 with Tizen 5.5 M2 official release.
 
  -- MyungJoo Ham <myungjoo.ham@samsung.com>  Thu, 26 Sep 2019 15:39:00 +0900
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nnstreamer (1.3.0.0) unstable xenial bionic; urgency=medium
+
+  * 1.3.0 development starts
+
+ -- MyungJoo Ham <myungjoo.ham@samsung.com>  Wed, 11 Dec 2019 13:14:00 +0900
+
 nnstreamer (1.2.0.0) unstable xenial bionic; urgency=medium
 
   * 1.2.0 Release

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -5,7 +5,7 @@ $(warning NNSTREAMER_ROOT is not defined! Using $(LOCAL_PATH)/.. )
 NNSTREAMER_ROOT := $(LOCAL_PATH)/..
 endif
 
-NNSTREAMER_VERSION  := 1.0.0
+NNSTREAMER_VERSION  := 1.2.0
 
 NNSTREAMER_GST_HOME := $(NNSTREAMER_ROOT)/gst/nnstreamer
 NNSTREAMER_EXT_HOME := $(NNSTREAMER_ROOT)/ext/nnstreamer

--- a/jni/nnstreamer.mk
+++ b/jni/nnstreamer.mk
@@ -5,7 +5,7 @@ $(warning NNSTREAMER_ROOT is not defined! Using $(LOCAL_PATH)/.. )
 NNSTREAMER_ROOT := $(LOCAL_PATH)/..
 endif
 
-NNSTREAMER_VERSION  := 1.2.0
+NNSTREAMER_VERSION  := 1.3.0
 
 NNSTREAMER_GST_HOME := $(NNSTREAMER_ROOT)/gst/nnstreamer
 NNSTREAMER_EXT_HOME := $(NNSTREAMER_ROOT)/ext/nnstreamer

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
 
 project('nnstreamer', 'c', 'cpp',
-  version: '1.2.0',
+  version: '1.3.0',
   license: ['LGPL'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # If you are using Tizen 5.0+ or Ubuntu/Bionix+, you don't need to mind meson version.
 
 project('nnstreamer', 'c', 'cpp',
-  version: '1.0.0',
+  version: '1.2.0',
   license: ['LGPL'],
   meson_version: '>=0.50.0',
   default_options: [

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -15,7 +15,7 @@ Summary:	gstreamer plugins for neural networks
 # 2. Tizen  : ./packaging/nnstreamer.spec
 # 3. Android: ./jni/nnstreamer.mk
 # 4. Meson  : ./meson.build
-Version:	1.0.0
+Version:	1.2.0
 Release:	0
 Group:		Applications/Multimedia
 Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
@@ -471,8 +471,11 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %endif
 
 %changelog
+* Wed Dec 11 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Release of 1.2.0
+
 * Thu Sep 26 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
-- Release of 1.0.0 (1.0 RC2)
+- Release of 1.0.0 (1.0 RC2 == 1.0 Release for Tizen 5.5 M2)
 
 * Wed Aug 14 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 0.3.0 (1.0 RC1)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -472,6 +472,9 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %changelog
 * Wed Dec 11 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- 1.3.0 development starts
+
+* Wed Dec 11 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
 - Release of 1.2.0
 
 * Thu Sep 26 2019 MyungJoo Ham <myungjoo.ham@samsung.com>


### PR DESCRIPTION
Versioning Rule Proposal:

- 1.even.0 is the minor release.
- 1.even.1+ is a stability update for the minor release
- 1.odd.x is a developmental version.
- When 1.odd.x is completed, it will release 1.odd+1.0 and move on to 1.odd+2.0.


## Commit 1
> Release of nnstreamer 1.2.0
>
> New features are coming with 1.2.0

## Commit 2
> Release of 1.3.0, the development version
>
> When 1.3.x is completed, it will be released as 1.4.0 and
> 1.5.x development will be started

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>