### PR TITLE
[FIX/CONF] Remove unnecessary g_key_file_free()

### DIFF
--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -496,8 +496,6 @@ nnsconf_get_custom_value_string (const gchar * group, const gchar * key)
               NULL)) {
         value = g_key_file_get_string (key_file, group, key, NULL);
       }
-
-      g_key_file_free (key_file);
     }
 
     if (value)


### PR DESCRIPTION
This PR removes unnecessary `g_key_file_free()` because `g_autoptr`
already provides a cleanup process. This bug was detected by Valgrind.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
