### PR TITLE
[nnfw] nnfw fix for aarch64 @open sesame 12/12 15:44

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -95,6 +95,15 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto unalloc_exit;
   }
 
+  /**
+   * @todo: remove after fixes to nnfw package for aarch64
+   */
+  status = nnfw_set_available_backends(pdata->session, NNFW_DEFAULT_BACKEND);
+  if (status != NNFW_STATUS_NO_ERROR) {
+    err = -EINVAL;
+    g_printerr ("Cannot set nnfw-runtime backend to %s", NNFW_DEFAULT_BACKEND);
+    goto unalloc_exit;
+  }
   /** @note nnfw opens the first model listed in the MANIFEST file */
   model_path = g_path_get_dirname (prop->model_files[0]);
   meta_file = g_build_filename (model_path, "metadata", "MANIFEST", NULL);
@@ -107,7 +116,7 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     goto session_exit;
   }
 
-  /* @todo open using model_file once nnfw works with it */
+  /** @todo open using model_file once nnfw works with it */
   status = nnfw_load_model_from_file (pdata->session, model_path);
   if (status != NNFW_STATUS_NO_ERROR) {
     err = -EINVAL;


### PR DESCRIPTION
This PR adds temporary fix for aarch64 enabling successful build and
testing of nnfw plugin for nnstreamer
This PR will be reverted once the nnfw package fixes are applied.

After this PR and #1856, #1912 can go ahead.

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>