### PR TITLE
[Filter] property description

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -228,8 +228,8 @@ gst_tensor_filter_install_properties (GObjectClass * gobject_class)
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_MODEL,
       g_param_spec_string ("model", "Model filepath",
-          "File path to the model file. Separated with \
-          ',' in case of multiple model files(like caffe2)", "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+          "File path to the model file. Separated with ',' in case of multiple model files(like caffe2)",
+          "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   g_object_class_install_property (gobject_class, PROP_INPUT,
       g_param_spec_string ("input", "Input dimension",
           "Input tensor dimension from inner array, up to 4 dimensions ?", "",


### PR DESCRIPTION
Remove unnecessary space in the description.
(Using gst-inspect, the property model shows unnecessary space)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
