### PR TITLE
[nnfw] Set accelerator for nnfw

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -525,40 +525,16 @@ TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 #endif
 }
 
+/**
+ * @brief	Set the accelerator for the tf engine
+ */
 void TFLiteCore::setAccelerator (const char * accelerators)
 {
-  GRegex * nnapi_elem;
-  GMatchInfo * match_info;
-
-  if (accelerators == NULL) {
+  use_nnapi = TRUE;
+  accelerator = parse_accl_hw (accelerators, REGEX_ACCL_NNAPI,
+      REGEX_ACCL_NNAPI_ELEM);
+  if (accelerators == NULL || accelerator == ACCL_NONE)
     goto use_nnapi_ini;
-  }
-
-  /* If set by user, get the precise accelerator */
-  use_nnapi = (bool) g_regex_match_simple (REGEX_ACCL_NNAPI, accelerators,
-      G_REGEX_CASELESS, G_REGEX_MATCH_NOTEMPTY);
-  if (use_nnapi == TRUE) {
-    /** Default to auto mode */
-    accelerator = ACCL_AUTO;
-    nnapi_elem = g_regex_new (REGEX_ACCL_NNAPI_ELEM, G_REGEX_CASELESS,
-        G_REGEX_MATCH_NOTEMPTY, NULL);
-
-    /** Now match each provided element and get specific accelerator */
-    if (g_regex_match (nnapi_elem, accelerators, G_REGEX_MATCH_NOTEMPTY,
-          &match_info)) {
-
-      while (g_match_info_matches (match_info)) {
-        gchar *word = g_match_info_fetch (match_info, 0);
-        accelerator = get_accl_hw_type (word);
-        g_free (word);
-        break;
-      }
-    }
-    g_match_info_free (match_info);
-    g_regex_unref (nnapi_elem);
-  } else  {
-    goto use_nnapi_ini;
-  }
 
   return;
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -248,6 +248,13 @@ get_accl_hw_type (const char * str);
 extern const char *
 get_accl_hw_str (const accl_hw key);
 
+/**
+ * @brief parse user given string to extract accelerator based on given regex
+ */
+extern accl_hw
+parse_accl_hw (const char * accelerators, const char * regex_accl,
+    const char * regex_accl_elem);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Allow setting of accelerator for nnfw
Parsing accelerator moved to tensor_filter_common. Currently, used in
tflite and nnfw, and use directly for other filters like this.

Related Issue: #1849 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
