### PR TITLE
[FIX/LOG] Fix a wrong error message for custom-easy tensor filter @open sesame 12/23 21:25

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -382,10 +382,13 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
       g_assert (model_files);
       gst_tensor_filter_parse_modelpaths_string (prop, model_files);
 
-      for (idx = 0; idx < prop->num_models; idx++) {
-        if (!g_file_test (prop->model_files[idx], G_FILE_TEST_IS_REGULAR)) {
-          g_critical ("Cannot find the model file [%d]: %s\n",
-              idx, prop->model_files[idx]);
+      /* 'custom-easy' framework has a virtual model file */
+      if (g_strcmp0 (prop->fwname, "custom-easy") != 0) {
+        for (idx = 0; idx < prop->num_models; idx++) {
+          if (!g_file_test (prop->model_files[idx], G_FILE_TEST_IS_REGULAR)) {
+            g_critical ("Cannot find the model file [%d]: %s\n",
+                idx, prop->model_files[idx]);
+          }
         }
       }
 


### PR DESCRIPTION
This PR fixes the wrong log message for custom-easy tensor filter sub-plugin.
For this sub-plugin, we don't need to check whether the model path exists.

The below describes the original problem.
```
[----------] 1 test from tensor_filter_custom_easy
[ RUN      ] tensor_filter_custom_easy.in_code_func_01

** (unittest_sink:25055): CRITICAL **: Cannot find the model file [0]: safe_memcpy_10x10

[       OK ] tensor_filter_custom_easy.in_code_func_01 (1003 ms)
[----------] 1 test from tensor_filter_custom_easy (1003 ms total)
```

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [*]Skipped
