### PR TITLE
[plugin/hw] Add more HW accelerator and update implementation

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -127,7 +127,7 @@ typedef enum {
   ML_NNFW_TYPE_MVNC, /**< Intel NCSDK (libmvnc). */
   ML_NNFW_TYPE_OPENVINO, /**< Intel openVINO. */
   ML_NNFW_TYPE_VIVANTE, /**< VeriSilicon's Vivante (TBD) */
-  ML_NNFW_TYPE_CORAL_TPU, /**< Google Coral edge TPU (USB) */
+  ML_NNFW_TYPE_EDGE_TPU, /**< Google Coral edge TPU (USB) */
 } ml_nnfw_type_e;
 
 /**
@@ -135,11 +135,17 @@ typedef enum {
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_NNFW_HW_ANY = 0,      /**< Hardware resource is not specified. */
-  ML_NNFW_HW_AUTO = 1,     /**< Try to schedule and optimize if possible. */
-  ML_NNFW_HW_CPU = 0x1000, /**< 0x1000: any CPU. 0x1nnn: CPU # nnn-1. */
-  ML_NNFW_HW_GPU = 0x2000, /**< 0x2000: any GPU. 0x2nnn: GPU # nnn-1. */
-  ML_NNFW_HW_NPU = 0x3000, /**< 0x3000: any NPU. 0x3nnn: NPU # nnn-1. */
+  ML_NNFW_HW_ANY          = 0,      /**< Hardware resource is not specified. */
+  ML_NNFW_HW_AUTO         = 1,      /**< Try to schedule and optimize if possible. */
+  ML_NNFW_HW_CPU          = 0x1000, /**< 0x1000: any CPU. 0x1nnn: CPU # nnn-1. */
+  ML_NNFW_HW_CPU_NEON     = 0x1100, /**< 0x1100: NEON in CPU. */
+  ML_NNFW_HW_GPU          = 0x2000, /**< 0x2000: any GPU. 0x2nnn: GPU # nnn-1. */
+  ML_NNFW_HW_NPU          = 0x3000, /**< 0x3000: any NPU. 0x3nnn: NPU # nnn-1. */
+  ML_NNFW_HW_NPU_MOVIDIUS = 0x3001, /**< 0x3001: Intel Movidius Stick. */
+  ML_NNFW_HW_NPU_EDGE_TPU = 0x3002, /**< 0x3002: Google Coral Edge TPU (USB). */
+  ML_NNFW_HW_NPU_VIVANTE  = 0x3003, /**< 0x3003: VeriSilicon's Vivante (TBD). */
+  ML_NNFW_HW_NPU_SRCN     = 0x3004, /**< 0x3004: SRCN backend supported with NNFW-runtime. */
+  ML_NNFW_HW_NPU_SR       = 0x3100, /**< 0x3100: any SR made NPU. */
 } ml_nnfw_hw_e;
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -44,25 +44,16 @@
 #define NNFW_SRCN_BACKEND  "srcn"
 #define NNFW_DEFAULT_BACKEND NNFW_CPU_BACKEND
 
-/** Match all accelerators for nnapi at once */
-#define REGEX_ACCL_NNFW \
-  "(^(true)[:]?([(]?(" \
-  REGEX_ACCL_AUTO "|" \
-  REGEX_ACCL_DEF "|" \
-  REGEX_ACCL_CPU "|" \
-  REGEX_ACCL_GPU "|" \
-  REGEX_ACCL_SRCN "|" \
-  REGEX_ACCL_NEON ")*[)]?))"
-
-/** Match accelerator for nnapi one by one */
-#define REGEX_ACCL_NNFW_ELEM \
-  "(" \
-  "(?<!!)" ACCL_AUTO_STR "|" \
-  "(?<!!)" ACCL_DEF_STR "|" \
-  "(?<!!)" ACCL_CPU_STR "|" \
-  "(?<!!)" ACCL_GPU_STR "|" \
-  "(?<!!)" ACCL_SRCN_STR "|" \
-  "(?<!!)" ACCL_NEON_STR ")?"
+const gchar *nnfw_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  ACCL_CPU_NEON_STR,
+  ACCL_CPU_STR,
+  ACCL_GPU_STR,
+  ACCL_NPU_SRCN_STR,
+  ACCL_NPU_STR,
+  NULL
+};
 
 void init_filter_nnfw (void) __attribute__ ((constructor));
 void fini_filter_nnfw (void) __attribute__ ((destructor));
@@ -91,13 +82,14 @@ static void nnfw_close (const GstTensorFilterProperties * prop,
 static const char *
 nnfw_get_accelerator (nnfw_pdata *pdata, const char * accelerators)
 {
-  pdata->accelerator = parse_accl_hw (accelerators, REGEX_ACCL_NNFW,
-      REGEX_ACCL_NNFW_ELEM);
+  pdata->accelerator = parse_accl_hw (accelerators, nnfw_accl_support);
 
   switch (pdata->accelerator) {
-    case ACCL_SRCN:
+    case ACCL_NPU:
       return NNFW_SRCN_BACKEND;
-    case ACCL_NEON:
+    case ACCL_NPU_SRCN:
+      return NNFW_SRCN_BACKEND;
+    case ACCL_CPU_NEON:
       return NNFW_NEON_BACKEND;
     case ACCL_GPU:
       return NNFW_GPU_BACKEND;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -46,25 +46,15 @@
 #define DBG FALSE
 #endif
 
-/** Match all accelerators for nnapi at once */
-#define REGEX_ACCL_NNAPI \
-  "(^(true)[:]?([(]?(" \
-  REGEX_ACCL_AUTO "|" \
-  REGEX_ACCL_DEF "|" \
-  REGEX_ACCL_CPU "|" \
-  REGEX_ACCL_GPU "|" \
-  REGEX_ACCL_NPU "|" \
-  REGEX_ACCL_NEON ")*[)]?))"
-
-/** Match accelerator for nnapi one by one */
-#define REGEX_ACCL_NNAPI_ELEM \
-  "(" \
-  "(?<!!)" ACCL_AUTO_STR "|" \
-  "(?<!!)" ACCL_DEF_STR "|" \
-  "(?<!!)" ACCL_CPU_STR "|" \
-  "(?<!!)" ACCL_GPU_STR "|" \
-  "(?<!!)" ACCL_NPU_STR "|" \
-  "(?<!!)" ACCL_NEON_STR ")?"
+const gchar *tflite_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  ACCL_CPU_NEON_STR,
+  ACCL_CPU_STR,
+  ACCL_GPU_STR,
+  ACCL_NPU_STR,
+  NULL
+};
 
 /**
  * @brief Wrapper class for TFLite Interpreter to support model switching
@@ -530,8 +520,7 @@ TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 void TFLiteCore::setAccelerator (const char * accelerators)
 {
   use_nnapi = TRUE;
-  accelerator = parse_accl_hw (accelerators, REGEX_ACCL_NNAPI,
-      REGEX_ACCL_NNAPI_ELEM);
+  accelerator = parse_accl_hw (accelerators, tflite_accl_support);
   if (accelerators == NULL || accelerator == ACCL_NONE)
     goto use_nnapi_ini;
 

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -28,23 +28,17 @@
 
 /** Macros for accelerator types */
 #define ACCL_NONE_STR "none"
+#define ACCL_DEFAULT_STR  "default"
 #define ACCL_AUTO_STR "auto"
 #define ACCL_CPU_STR  "cpu"
+#define ACCL_CPU_NEON_STR  "cpu.neon"
 #define ACCL_GPU_STR  "gpu"
 #define ACCL_NPU_STR  "npu"
-#define ACCL_NEON_STR "neon"
-#define ACCL_SRCN_STR "srcn"
-#define ACCL_DEF_STR  "default"
-
-#define REGEX_ACCL_EACH_ELEM(ELEM) "[^!]" ELEM "[,]?"
-
-#define REGEX_ACCL_AUTO REGEX_ACCL_EACH_ELEM(ACCL_AUTO_STR)
-#define REGEX_ACCL_CPU  REGEX_ACCL_EACH_ELEM(ACCL_CPU_STR)
-#define REGEX_ACCL_GPU  REGEX_ACCL_EACH_ELEM(ACCL_GPU_STR)
-#define REGEX_ACCL_NPU  REGEX_ACCL_EACH_ELEM(ACCL_NPU_STR)
-#define REGEX_ACCL_NEON REGEX_ACCL_EACH_ELEM(ACCL_NEON_STR)
-#define REGEX_ACCL_SRCN REGEX_ACCL_EACH_ELEM(ACCL_SRCN_STR)
-#define REGEX_ACCL_DEF  REGEX_ACCL_EACH_ELEM(ACCL_DEF_STR)
+#define ACCL_NPU_MOVIDIUS_STR  "npu.movidius"
+#define ACCL_NPU_EDGE_TPU_STR  "npu.edgetpu"
+#define ACCL_NPU_VIVANTE_STR  "npu.vivante"
+#define ACCL_NPU_SRCN_STR  "npu.srcn" /** srcn hardware supported by nnfw */
+#define ACCL_NPU_SR_STR  "npu.sr"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,7 +54,7 @@ extern "C" {
  *          However, with NNFW will enable GPU/NEON etc.
  *
  *          Appropriate acceleration should be used with each framework. For
- *          example, ACCL_NEON is only supported with NNFW tensor filter. Using
+ *          example, ACCL_CPU_NEON is supported with NNFW tensor filter. Using
  *          ACCL_NEON with pytorch would result in a warning message, and
  *          the accelerator would fallback on ACCL_AUTO.
  *
@@ -72,22 +66,29 @@ extern "C" {
  *       the acceleration for a framework was disabled in the build, setting the
  *       accelerator while use a tensor filter with that framework will have no
  *       effect.
+ *
+ * @note Add definition of new accelerators to accl_hw_get_type() in
+ *       tensor_filter_common.c as well.
  */
 typedef enum
 {
   /**< no explicit acceleration */
-  ACCL_NONE = 0,    /**< no acceleration (defaults to CPU) */
-
-  /** Enables acceleration, 0xn000 any version of that device, 0xnxxx: device # xxx-1 */
-  ACCL_AUTO = 0x1,        /**< choose optimized device automatically */
-  ACCL_CPU  = 0x1000,     /**< specify device as CPU, if possible */
-  ACCL_GPU  = 0x2000,     /**< specify device as GPU, if possible */
-  ACCL_NPU  = 0x4000,     /**< specify device as NPU, if possible */
-  ACCL_NEON = 0x8000,     /**< specify device as NEON, if possible */
-  ACCL_SRCN = 0x10000,    /**< specify device as SRCN, if possible */
+  ACCL_NONE    = 0,          /**< no acceleration (defaults to CPU) */
 
   /** If there is no default config, and device needs to be specified, fallback to ACCL_AUTO */
-  ACCL_DEFAULT = 0x20000    /**< use default device configuration by the framework*/
+  ACCL_AUTO    = 0x1,        /**< choose optimized device automatically */
+  ACCL_DEFAULT = 0x2,     /**< use default device configuration by the framework */
+
+  /** Enables acceleration, 0xn000 any version of that device, 0xnxxx: device # xxx-1 */
+  ACCL_CPU          = 0x1000,     /**< specify device as CPU, if possible */
+  ACCL_CPU_NEON     = 0x1100,     /**< specify device as NEON in cpu, if possible */
+  ACCL_GPU          = 0x2000,     /**< specify device as GPU, if possible */
+  ACCL_NPU          = 0x4000,     /**< specify device as any NPU, if possible */
+  ACCL_NPU_MOVIDIUS = 0x4001,     /**< specify device as movidius, if possible */
+  ACCL_NPU_EDGE_TPU = 0x4002,     /**< specify device as edge tpu, if possible */
+  ACCL_NPU_VIVANTE  = 0x4003,     /**< specify device as vivante, if possible */
+  ACCL_NPU_SRCN     = 0x4004,     /**< specify device as srcn, if possible */
+  ACCL_NPU_SR       = 0x4100,     /**< specify device as any SR npu, if possible */
 } accl_hw;
 
 /**
@@ -252,8 +253,7 @@ get_accl_hw_str (const accl_hw key);
  * @brief parse user given string to extract accelerator based on given regex
  */
 extern accl_hw
-parse_accl_hw (const char * accelerators, const char * regex_accl,
-    const char * regex_accl_elem);
+parse_accl_hw (const char * accelerators, const char ** supported_accelerators);
 
 #ifdef __cplusplus
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -30,6 +30,39 @@
 #include "tensor_filter_common.h"
 
 /**
+ * Basic elements to form accelerator regex forming
+ */
+#define REGEX_ACCL_ELEM_START "("
+#define REGEX_ACCL_ELEM_PREFIX "(?<!!)"
+#define REGEX_ACCL_ELEM_SUFFIX ""
+#define REGEX_ACCL_ELEM_DELIMITER "|"
+#define REGEX_ACCL_ELEM_END ")?"
+
+#define REGEX_ACCL_START "(^(true)[:]?([(]?("
+#define REGEX_ACCL_PREFIX ""
+#define REGEX_ACCL_SUFFIX ""
+#define REGEX_ACCL_DELIMITER "|"
+#define REGEX_ACCL_END ")*[)]?))"
+
+const gchar *regex_accl_utils[] = {
+  REGEX_ACCL_START,
+  REGEX_ACCL_PREFIX,
+  REGEX_ACCL_SUFFIX,
+  REGEX_ACCL_DELIMITER,
+  REGEX_ACCL_END,
+  NULL
+};
+
+const gchar *regex_accl_elem_utils[] = {
+  REGEX_ACCL_ELEM_START,
+  REGEX_ACCL_ELEM_PREFIX,
+  REGEX_ACCL_ELEM_SUFFIX,
+  REGEX_ACCL_ELEM_DELIMITER,
+  REGEX_ACCL_ELEM_END,
+  NULL
+};
+
+/**
  * @brief Free memory
  */
 #define g_free_const(x) g_free((void*)(long)(x))
@@ -55,6 +88,68 @@ enum
   PROP_ACCELERATOR,
   PROP_IS_UPDATABLE,
 };
+
+/**
+ * @brief to get and register hardware accelerator backend enum
+ */
+static GType
+accl_hw_get_type (void)
+    G_GNUC_CONST;
+
+/**
+ * @brief copy the string from src to destination
+ * @param[in] dest destination string
+ * @param[in] src source string
+ * @return updated destination string
+ */
+     static gchar *strcpy2 (gchar * dest, const gchar * src)
+{
+  memcpy (dest, src, strlen (src));
+  return dest + strlen (src);
+}
+
+/**
+ * @brief create regex for the given string list and regex basic elements
+ * @param[in] enum_list list of strings to form regex for
+ * @param[in] regex_utils list of basic elements to form regex
+ * @return the formed regex (to be freed by the caller), NULL on error
+ */
+static gchar *
+create_regex (const gchar ** enum_list, const gchar ** regex_utils)
+{
+  gchar regex[4096];
+  gchar *regex_ptr = regex;
+  const gchar **strings = enum_list;
+  const gchar *iterator = *strings;
+  const gchar *escape_separator = "\\.";
+  const gchar *escape_chars = ".";
+  gchar **regex_split;
+  gchar *regex_escaped;
+
+  if (iterator == NULL)
+    return NULL;
+
+  /** create the regex string */
+  regex_ptr = strcpy2 (regex_ptr, regex_utils[0]);
+  regex_ptr = strcpy2 (regex_ptr, regex_utils[1]);
+  regex_ptr = strcpy2 (regex_ptr, iterator);
+  regex_ptr = strcpy2 (regex_ptr, regex_utils[2]);
+  for (iterator = strings[1]; iterator != NULL; iterator = *++strings) {
+    regex_ptr = strcpy2 (regex_ptr, regex_utils[3]);
+    regex_ptr = strcpy2 (regex_ptr, regex_utils[1]);
+    regex_ptr = strcpy2 (regex_ptr, iterator);
+    regex_ptr = strcpy2 (regex_ptr, regex_utils[2]);
+  }
+  regex_ptr = strcpy2 (regex_ptr, regex_utils[4]);
+  *regex_ptr = '\0';
+
+  /** escape the special characters */
+  regex_split = g_strsplit_set (regex, escape_chars, -1);
+  regex_escaped = g_strjoinv (escape_separator, regex_split);
+  g_strfreev (regex_split);
+
+  return regex_escaped;
+}
 
 /**
  * @brief Validate filter sub-plugin's data.
@@ -746,81 +841,73 @@ gst_tensor_filter_common_close_fw (GstTensorFilterPrivate * priv)
 accl_hw
 get_accl_hw_type (const gchar * key)
 {
-  if (!g_ascii_strncasecmp (key, ACCL_AUTO_STR, strlen (ACCL_AUTO_STR)))
-    return ACCL_AUTO;
-  else if (!g_ascii_strncasecmp (key, ACCL_CPU_STR, strlen (ACCL_CPU_STR)))
-    return ACCL_CPU;
-  else if (!g_ascii_strncasecmp (key, ACCL_GPU_STR, strlen (ACCL_GPU_STR)))
-    return ACCL_GPU;
-  else if (!g_ascii_strncasecmp (key, ACCL_NPU_STR, strlen (ACCL_NPU_STR)))
-    return ACCL_NPU;
-  else if (!g_ascii_strncasecmp (key, ACCL_NEON_STR, strlen (ACCL_NEON_STR)))
-    return ACCL_NEON;
-  else if (!g_ascii_strncasecmp (key, ACCL_SRCN_STR, strlen (ACCL_SRCN_STR)))
-    return ACCL_SRCN;
-  else if (!g_ascii_strncasecmp (key, ACCL_DEF_STR, strlen (ACCL_DEF_STR)))
-    return ACCL_DEFAULT;
+  GEnumClass *enum_class;
+  GEnumValue *enum_value;
 
-  return ACCL_NONE;             /* key == "none" or Not Found */
+  enum_class = g_type_class_ref (accl_hw_get_type ());
+  enum_value = g_enum_get_value_by_name (enum_class, key);
+  g_type_class_unref (enum_class);
+
+  if (enum_value == NULL)
+    return ACCL_NONE;
+  return enum_value->value;
 }
 
 /**
  * @brief return string based on accl_hw type
  * @param key The key enum value
  * @return Corresponding string. Returns ACCL_NONE_STR if not found.
+ * @note Do not free the returned char *
  */
 const gchar *
 get_accl_hw_str (const accl_hw key)
 {
-  switch (key) {
-    case ACCL_NONE:
-      return ACCL_NONE_STR;
-    case ACCL_AUTO:
-      return ACCL_AUTO_STR;
-    case ACCL_CPU:
-      return ACCL_CPU_STR;
-    case ACCL_GPU:
-      return ACCL_GPU_STR;
-    case ACCL_NPU:
-      return ACCL_NPU_STR;
-    case ACCL_NEON:
-      return ACCL_NEON_STR;
-    case ACCL_SRCN:
-      return ACCL_SRCN_STR;
-    case ACCL_DEFAULT:
-      return ACCL_DEF_STR;
-    default:                   /* Not found */
-      return ACCL_NONE_STR;
-  }
+  GEnumClass *enum_class;
+  GEnumValue *enum_value;
+
+  enum_class = g_type_class_ref (accl_hw_get_type ());
+  enum_value = g_enum_get_value (enum_class, key);
+  g_type_class_unref (enum_class);
+
+  if (enum_value == NULL)
+    return ACCL_NONE_STR;
+  return enum_value->value_name;
 }
 
 /**
  * @brief parse user given string to extract accelerator based on given regex
  * @param[in] accelerators user given input
- * @param[in] regex_accl regex to determine if accelerator or not
- * @param[in] regex_accl_elem regex to determine which accelerator
+ * @param[in] supported_accelerators list ofi supported accelerators
  * @return Corresponding string. Returns ACCL_NONE_STR if not found.
  */
 accl_hw
-parse_accl_hw (const gchar * accelerators, const gchar * regex_accl,
-    const gchar * regex_accl_elem)
+parse_accl_hw (const gchar * accelerators,
+    const gchar ** supported_accelerators)
 {
   GRegex *nnapi_elem;
   GMatchInfo *match_info;
   gboolean use_accl;
   accl_hw accl;
+  gchar *regex_accl = NULL;
+  gchar *regex_accl_elem = NULL;
 
   if (accelerators == NULL)
     return ACCL_DEFAULT;
 
   /* If set by user, get the precise accelerator */
+  regex_accl = create_regex (supported_accelerators, regex_accl_utils);
   use_accl = (gboolean) g_regex_match_simple (regex_accl, accelerators,
       G_REGEX_CASELESS, G_REGEX_MATCH_NOTEMPTY);
+  g_free (regex_accl);
   if (use_accl == TRUE) {
     /** Default to auto mode */
     accl = ACCL_AUTO;
-    nnapi_elem = g_regex_new (regex_accl_elem, G_REGEX_CASELESS,
-        G_REGEX_MATCH_NOTEMPTY, NULL);
+    regex_accl_elem =
+        create_regex (supported_accelerators, regex_accl_elem_utils);
+    nnapi_elem =
+        g_regex_new (regex_accl_elem, G_REGEX_CASELESS, G_REGEX_MATCH_NOTEMPTY,
+        NULL);
+    g_free (regex_accl_elem);
 
     /** Now match each provided element and get specific accelerator */
     if (g_regex_match (nnapi_elem, accelerators, G_REGEX_MATCH_NOTEMPTY,
@@ -840,4 +927,37 @@ parse_accl_hw (const gchar * accelerators, const gchar * regex_accl,
   }
 
   return accl;
+}
+
+/**
+ * @brief to get and register hardware accelerator backend enum
+ */
+static GType
+accl_hw_get_type (void)
+{
+  static volatile gsize g_accl_hw_type_id__volatile = 0;
+
+  if (g_once_init_enter (&g_accl_hw_type_id__volatile)) {
+    static const GEnumValue values[] = {
+      {ACCL_NONE, ACCL_NONE_STR, ACCL_NONE_STR},
+      {ACCL_DEFAULT, ACCL_DEFAULT_STR, ACCL_DEFAULT_STR},
+      {ACCL_AUTO, ACCL_AUTO_STR, ACCL_AUTO_STR},
+      {ACCL_CPU, ACCL_CPU_STR, ACCL_CPU_STR},
+      {ACCL_CPU_NEON, ACCL_CPU_NEON_STR, ACCL_CPU_NEON_STR},
+      {ACCL_GPU, ACCL_GPU_STR, ACCL_GPU_STR},
+      {ACCL_NPU, ACCL_NPU_STR, ACCL_NPU_STR},
+      {ACCL_NPU_MOVIDIUS, ACCL_NPU_MOVIDIUS_STR, ACCL_NPU_MOVIDIUS_STR},
+      {ACCL_NPU_EDGE_TPU, ACCL_NPU_EDGE_TPU_STR, ACCL_NPU_EDGE_TPU_STR},
+      {ACCL_NPU_VIVANTE, ACCL_NPU_VIVANTE_STR, ACCL_NPU_VIVANTE_STR},
+      {ACCL_NPU_SRCN, ACCL_NPU_SRCN_STR, ACCL_NPU_SRCN_STR},
+      {ACCL_NPU_SR, ACCL_NPU_SR_STR, ACCL_NPU_SR_STR},
+      {0, NULL, NULL}
+    };
+
+    GType g_accl_hw_type_id =
+        g_enum_register_static (g_intern_static_string ("accl_hw"), values);
+    g_once_init_leave (&g_accl_hw_type_id__volatile, g_accl_hw_type_id);
+  }
+
+  return g_accl_hw_type_id__volatile;
 }

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -130,9 +130,9 @@ if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; 
     cat info | grep "nnapi = 1, accl = auto"
     testResult $? 2-9 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi - based on ini
-    run_pipeline true:srcn
-    cat info | grep "nnapi = 1, accl = auto"
+    # Property reading test for nnapi
+    run_pipeline true:npu.srcn
+    cat info | grep "nnapi = 1, accl = npu"
     testResult $? 2-10 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
@@ -164,6 +164,11 @@ if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; 
     run_pipeline true:!npu,abcd,gpu
     cat info | grep "nnapi = 1, accl = gpu"
     testResult $? 2-16 "NNAPI activation test" 0 1
+
+    # Property reading test for nnapi
+    run_pipeline true:cpu.neon,cpu
+    cat info | grep "nnapi = 1, accl = cpu.neon"
+    testResult $? 2-17 "NNAPI activation test" 0 1
 fi
 
 report


### PR DESCRIPTION
Add TPU as a backend accelerator property option in list of hardware
accelerators
Move default accelerator to avoid changing default accelerator enum value
everytime a new backend device is added

Refer #1849 

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>