### PR TITLE
Dist/Tizen: add missing manifest for source-tizen-sensor

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -469,6 +469,7 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 
 %if %{with tizen}
 %files tizen-sensor
+%manifest nnstreamer.manifest
 %{gstlibdir}/libnnstreamer-tizen-sensor.so
 %endif
 


### PR DESCRIPTION
Because it has an executable (shared library), we need
SMACK manifest information.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
