### PR TITLE
[tflite] Acceleratator HW unittest should always pass

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -518,11 +518,10 @@ TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 
   interpreter.setModelPath (_model_path);
 
-  setAccelerator (accelerators);
-
-#if (DBG)
-  g_message ("nnapi = %d, accl = %s", use_nnapi, get_accl_hw_str(accelerator));
-#endif
+  if (accelerators != NULL) {
+    setAccelerator (accelerators);
+    g_message ("nnapi = %d, accl = %s", use_nnapi, get_accl_hw_str(accelerator));
+  }
 }
 
 /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -30,20 +30,6 @@
 #include "tensor_filter_common.h"
 
 /**
- * @brief Accelerator regex verification
- * @note more details in nnstreamer_plugin_api_filter.h with accl_hw
- */
-#define REGEX_ACCL_ALL \
-  "(^(true|false)[:]?([(]?(" \
-  REGEX_ACCL_AUTO "|" \
-  REGEX_ACCL_DEF "|" \
-  REGEX_ACCL_CPU "|" \
-  REGEX_ACCL_GPU "|" \
-  REGEX_ACCL_NPU "|" \
-  REGEX_ACCL_NEON "|" \
-  REGEX_ACCL_SRCN ")*[)]?))"
-
-/**
  * @brief Free memory
  */
 #define g_free_const(x) g_free((void*)(long)(x))
@@ -528,21 +514,6 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
       }
 
       prop->accl_str = g_value_dup_string (value);
-      /**
-       * Perform error check on the string passed,
-       * parsing the string and finalizing the hw is done in each subplugin
-       */
-      if (!g_regex_match_simple (REGEX_ACCL_ALL, prop->accl_str,
-              G_REGEX_CASELESS, 0)) {
-        g_critical
-            ("accelerator: \'%s\' is not valid string. "
-            "It should be in the form of BOOL:comma separated ACCELERATOR(s). "
-            "Example, if GPU, NPU can be used but not CPU - true:(GPU,NPU,!CPU)."
-            REGEX_ACCL_ALL "\n", prop->accl_str);
-        g_free_const (prop->accl_str);
-        prop->accl_str = NULL;
-      }
-
       break;
     }
     case PROP_IS_UPDATABLE:

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -78,6 +78,8 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} !
 # Fail test for invalid output properties
 gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} output=1:7 outputtype=int8 ! filesink location=tensorfilter.out.log" 3F_n 0 1 $PERFORMANCE
 
+# Test the backend setting done with tensorflow-lite
+# This also performs tests for generic backend configuration parsing
 if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; then
     function run_pipeline() {
         gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} accelerator=$1 ! filesink location=tensorfilter.out.log 2>info
@@ -86,82 +88,82 @@ if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; 
     # Property reading test for nnapi
     run_pipeline true:cpu,npu,gpu
     cat info | grep "nnapi = 1, accl = cpu"
-    testResult $? 2-1 "NNAPI activation test" 1 1
+    testResult $? 2-1 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!cpu
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-2 "NNAPI activation test" 1 1
+    testResult $? 2-2 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!npu,gpu
     cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-3 "NNAPI activation test" 1 1
+    testResult $? 2-3 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!npu,gpu,abcd
     cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-4 "NNAPI activation test" 1 1
+    testResult $? 2-4 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!npu,!abcd,gpu
     cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-5 "NNAPI activation test" 1 1
+    testResult $? 2-5 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:auto
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-6 "NNAPI activation test" 1 1
+    testResult $? 2-6 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:default,cpu
     cat info | grep "nnapi = 1, accl = default"
-    testResult $? 2-7 "NNAPI activation test" 1 1
+    testResult $? 2-7 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!cpu,default
     cat info | grep "nnapi = 1, accl = default"
-    testResult $? 2-8 "NNAPI activation test" 1 1
+    testResult $? 2-8 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!default
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-9 "NNAPI activation test" 1 1
+    testResult $? 2-9 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi - based on ini
     run_pipeline true:srcn
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-10 "NNAPI activation test" 1 1
+    testResult $? 2-10 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline false:abcd
     cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-11 "NNAPI activation test" 1 1
+    testResult $? 2-11 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline false
     cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-12 "NNAPI activation test" 1 1
+    testResult $? 2-12 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-13 "NNAPI activation test" 1 1
+    testResult $? 2-13 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true
     cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-14 "NNAPI activation test" 1 1
+    testResult $? 2-14 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline auto
     cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-15 "NNAPI activation test" 1 1
+    testResult $? 2-15 "NNAPI activation test" 0 1
 
     # Property reading test for nnapi
     run_pipeline true:!npu,abcd,gpu
     cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-16 "NNAPI activation test" 1 1
+    testResult $? 2-16 "NNAPI activation test" 0 1
 fi
 
 report


### PR DESCRIPTION
Tensorflow-lite unittest which tests for appropriate hardware accelerator backend parsing and testing
should always pass.

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>