### PR TITLE
[single/hw] Check hw support for framework @open sesame 1/716:07

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -423,7 +423,6 @@ ml_single_open (ml_single_h * single, const char *model,
 
   /**
    * 2. Determine hw
-   * @todo Now the param hw is ignored.
    * (Supposed CPU only) Support others later.
    */
   status = ml_check_nnfw_availability (nnfw, hw, &available);
@@ -454,6 +453,7 @@ ml_single_open (ml_single_h * single, const char *model,
 
   /**
    * 3. Construct a pipeline
+   * @todo Set the hw property
    * Set the pipeline desc with nnfw.
    */
   single_h->nnfw = nnfw;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -967,6 +967,20 @@ tflite_reloadModel (const GstTensorFilterProperties * prop, void **private_data)
   return core->reloadModel (prop->model_files[0]);
 }
 
+/**
+ * @brief The optional callback for GstTensorFilterFramework
+ * @param[in] hw backend accelerator hardware
+ * @return 0 if supported. -errno if not supported.
+ */
+static int
+tflite_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (tflite_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_tensorflow_lite[] = "tensorflow-lite";
 
 static GstTensorFilterFramework NNS_support_tensorflow_lite = {
@@ -982,6 +996,7 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .close = tflite_close,
   .destroyNotify = NULL,
   .reloadModel = tflite_reloadModel,
+  .checkAvailability = tflite_checkAvailability,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -211,6 +211,13 @@ typedef struct _GstTensorFilterFramework
        * @param[in/out] private_data A subplugin may save its internal private data here. The subplugin is responsible for alloc/free of this pointer. Normally, close() frees private_data and set NULL.
        * @return 0 if ok. < 0 if error.
        */
+
+  int (*checkAvailability) (accl_hw hw);
+      /**< Optional. Check if the provided hardware accelerator is supported. This check is static or dynamic based on framework support. Positive response of this check does not guarantee successful running of model with this accelerator. The static check can be performed without opening the framework.
+       *
+       * @param[in] hw backend accelerator hardware
+       * @return 0 if supported. -errno if not supported.
+       */
 } GstTensorFilterFramework;
 
 /* extern functions for subplugin management, exist in tensor_filter.c */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -893,6 +893,7 @@ parse_accl_hw (const gchar * accelerators,
   accl_hw accl;
   gchar *regex_accl = NULL;
   gchar *regex_accl_elem = NULL;
+  gboolean supported;
 
   if (accelerators == NULL)
     return ACCL_DEFAULT;
@@ -919,7 +920,10 @@ parse_accl_hw (const gchar * accelerators,
       while (g_match_info_matches (match_info)) {
         gchar *word = g_match_info_fetch (match_info, 0);
         accl = get_accl_hw_type (word);
+        supported = g_strv_contains (supported_accelerators, word);
         g_free (word);
+        if (!supported)
+          continue;
         break;
       }
     }

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1276,6 +1276,70 @@ TEST (nnstreamer_capi_util, availability_00)
 #endif  /* ENABLE_NNFW_RUNTIME */
 }
 
+#ifdef ENABLE_TENSORFLOW_LITE
+/**
+ * @brief Test NNStreamer Utility for checking availability of Tensorflow-lite backend
+ */
+TEST (nnstreamer_capi_util, availability_01)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_CPU_NEON, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of Tensorflow-lite backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_EDGE_TPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_VIVANTE, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_SRCN, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW_LITE, ML_NNFW_HW_NPU_SR, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+#endif /* ENABLE_TENSORFLOW_LITE */
+
 /**
  * @brief Test NNStreamer Utility for checking tensors info handle
  */
@@ -2832,7 +2896,6 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_01)
   ml_tensors_info_destroy (in_res);
   ml_tensors_info_destroy (out_res);
 }
-
 #endif /* ENABLE_TENSORFLOW_LITE */
 
 #ifdef ENABLE_NNFW_RUNTIME


### PR DESCRIPTION
Add implementation to check hw support for framework while checking for its availability.
Added unittests for this functionality with tensorflow-lite

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped    

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
