### PR TITLE
[Android/SNAP] build script for SNAP @open sesame 12/23 20:04

### DIFF
--- a/api/android/README.md
+++ b/api/android/README.md
@@ -128,7 +128,7 @@ Run the build script in NNStreamer.
 - Build options
   1. target_abi: Specify the ABI (armv7, arm64) to be built for with `--target_abi={TARGET-ABI}`.
   2. api_option: Get the minimized library with GStreamer core elements `--api_option=lite`.
-  3. run_unittest: Run the instrumentation test `--run_unittest=yes`. 
+  3. run_test: Run the instrumentation test `--run_test=yes`.
 
 ```bash
 $ cd $NNSTREAMER_ROOT
@@ -138,7 +138,7 @@ $ bash ./api/android/build-android-lib.sh
 After building the Android API, you can find the library(.aar) in `$NNSTREAMER_ROOT/android_lib`.
 - Build result
   1. nnstreamer.aar: NNStreamer library
-  2. nnstreamer-native.zip: shared objects and header files for native developer 
+  2. nnstreamer-native.zip: shared objects and header files for native developer
 
 #### Run the unit-test (Optional)
 
@@ -158,10 +158,10 @@ You can download these files from [nnsuite testcases repository](https://github.
 {INTERNAL_STORAGE}/nnstreamer/test/orange.png
 ```
 
-To check the testcases, run the build script with an option ```--run_unittest=yes```.
+To check the testcases, run the build script with an option ```--run_test=yes```.
 You can find the result in ```$NNSTREAMER_ROOT/android_lib```.
 
 ```bash
 $ cd $NNSTREAMER_ROOT
-$ bash ./api/android/build-android-lib.sh --run_unittest=yes
+$ bash ./api/android/build-android-lib.sh --run_test=yes
 ```

--- a/api/android/api/src/main/jni/Android.mk
+++ b/api/android/api/src/main/jni/Android.mk
@@ -16,6 +16,9 @@ else
 $(error Target arch ABI not supported: $(TARGET_ARCH_ABI))
 endif
 
+# SNAP (Samsung Neural Acceleration Platform)
+ENABLE_SNAP := false
+
 #------------------------------------------------------
 # API build option
 #------------------------------------------------------
@@ -25,6 +28,10 @@ NNSTREAMER_API_OPTION := all
 # external libs
 #------------------------------------------------------
 include $(LOCAL_PATH)/Android-tensorflow-lite-prebuilt.mk
+
+ifeq ($(ENABLE_SNAP), true)
+include $(LOCAL_PATH)/Android-snap.mk
+endif
 
 #------------------------------------------------------
 # nnstreamer
@@ -46,6 +53,11 @@ LOCAL_C_INCLUDES := $(NNSTREAMER_INCLUDES) $(NNSTREAMER_CAPI_INCLUDES)
 LOCAL_STATIC_LIBRARIES := nnstreamer tensorflow-lite cpufeatures
 LOCAL_SHARED_LIBRARIES := gstreamer_android
 LOCAL_LDLIBS := -llog -landroid
+
+ifeq ($(ENABLE_SNAP), true)
+LOCAL_CFLAGS += -DENABLE_SNAP=1
+LOCAL_STATIC_LIBRARIES += snap
+endif
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/api/android/api/src/main/jni/nnstreamer-native-api.c
+++ b/api/android/api/src/main/jni/nnstreamer-native-api.c
@@ -26,6 +26,9 @@
 /* nnstreamer plugins and sub-plugins declaration */
 GST_PLUGIN_STATIC_DECLARE (nnstreamer);
 extern void init_filter_tflite (void);
+#if defined (ENABLE_SNAP)
+extern void init_filter_snap (void);
+#endif
 extern void init_dv (void);
 extern void init_bb (void);
 extern void init_il (void);
@@ -490,10 +493,15 @@ nnstreamer_native_initialize (void)
   /* register nnstreamer plugins */
   GST_PLUGIN_STATIC_REGISTER (nnstreamer);
 
-  /* filter tensorflow-lite sub-plugin */
+  /* tensor-filter sub-plugin for tensorflow-lite */
   init_filter_tflite ();
 
-  /* decoder sub-plugins */
+#if defined (ENABLE_SNAP)
+  /* tensor-filter sub-plugin for snap */
+  init_filter_snap ();
+#endif
+
+  /* tensor-decoder sub-plugins */
   init_dv ();
   init_bb ();
   init_il ();


### PR DESCRIPTION
Update script to build Android library including SNAP.
Before running with option --enable_snap=yes, developer should define SNAP_DIRECTORY (dir path to SNAP sub-plugin and prebuilt library)

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
