### PR TITLE
[filter/ext] Replace asserts with error handling @open sesame 12/23 19:36

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -90,7 +90,6 @@ std::map <char*, Tensor*> Caffe2Core::inputTensorMap;
  */
 Caffe2Core::Caffe2Core (const char * _model_path, const char *_model_path_sub)
 {
-  g_assert (_model_path != NULL && _model_path_sub != NULL);
   init_model_path = g_strdup (_model_path);
   pred_model_path = g_strdup (_model_path_sub);
   first_run = true;
@@ -431,10 +430,10 @@ caffe2_close (const GstTensorFilterProperties * prop, void **private_data)
 {
   Caffe2Core *core = static_cast<Caffe2Core *>(*private_data);
 
-  g_assert (core);
+  if (!core)
+    return;
 
   delete core;
-
   *private_data = NULL;
 }
 
@@ -463,6 +462,7 @@ caffe2_loadModelFile (const GstTensorFilterProperties * prop,
   core = static_cast<Caffe2Core *>(*private_data);
   init_model = prop->model_files[0];
   pred_model = prop->model_files[1];
+  g_return_val_if_fail (init_model && pred_model, -1);
 
   if (core != NULL) {
     if (g_strcmp0 (init_model, core->getInitModelPath ()) == 0 &&
@@ -501,8 +501,6 @@ caffe2_open (const GstTensorFilterProperties * prop, void **private_data)
 {
   int status = caffe2_loadModelFile (prop, private_data);
 
-  g_assert (status >= 0);       /** This must be called only once */
-
   return status;
 }
 
@@ -519,8 +517,7 @@ caffe2_run (const GstTensorFilterProperties * prop, void **private_data,
     const GstTensorMemory * input, GstTensorMemory * output)
 {
   Caffe2Core *core = static_cast<Caffe2Core *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && input && output, -EINVAL);
 
   return core->run (input, output);
 }
@@ -536,8 +533,7 @@ caffe2_getInputDim (const GstTensorFilterProperties * prop, void **private_data,
     GstTensorsInfo * info)
 {
   Caffe2Core *core = static_cast<Caffe2Core *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getInputTensorDim (info);
 }
@@ -553,8 +549,7 @@ caffe2_getOutputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   Caffe2Core *core = static_cast<Caffe2Core *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getOutputTensorDim (info);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -72,8 +72,8 @@ void fini_filter_nnfw (void) __attribute__ ((destructor));
  */
 typedef struct
 {
-  nnfw_tensorinfo i_in;
-  nnfw_tensorinfo i_out;
+  GstTensorsInfo in_info;
+  GstTensorsInfo out_info;
   nnfw_session *session;
   gchar *model_file;
   accl_hw accelerator;
@@ -81,6 +81,8 @@ typedef struct
 
 static void nnfw_close (const GstTensorFilterProperties * prop,
     void **private_data);
+static int nnfw_tensors_info_get (const nnfw_pdata *pdata,
+    const gboolean is_input, GstTensorsInfo * info);
 
 /**
  * @brief parse user given input to extract accelerator to be used by nnfw
@@ -178,6 +180,13 @@ nnfw_open (const GstTensorFilterProperties * prop, void **private_data)
     err = -EINVAL;
     g_printerr ("nnfw-runtime cannot prepare the session for %s",
         prop->model_files[0]);
+    goto session_exit;
+  }
+
+  if (nnfw_tensors_info_get (pdata, TRUE, &pdata->in_info) ||
+      nnfw_tensors_info_get (pdata, FALSE, &pdata->out_info)) {
+    err = -EINVAL;
+    g_printerr ("Error retrieving input/output info from nnfw-runtime.");
     goto session_exit;
   }
 
@@ -346,14 +355,15 @@ nnfw_getInputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   nnfw_pdata *pdata;
-  int err = 0;
 
   g_return_val_if_fail (private_data != NULL, -EINVAL);
-
   pdata = (nnfw_pdata *) *private_data;
-  err = nnfw_tensors_info_get (pdata, TRUE, info);
 
-  return err;
+  g_return_val_if_fail (pdata != NULL, -EINVAL);
+  g_return_val_if_fail (info != NULL, -EINVAL);
+
+  gst_tensors_info_copy (info, &pdata->in_info);
+  return 0;
 }
 
 /**
@@ -364,14 +374,15 @@ nnfw_getOutputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   nnfw_pdata *pdata;
-  int err = 0;
 
   g_return_val_if_fail (private_data != NULL, -EINVAL);
-
   pdata = (nnfw_pdata *) *private_data;
-  err = nnfw_tensors_info_get (pdata, FALSE, info);
 
-  return err;
+  g_return_val_if_fail (pdata != NULL, -EINVAL);
+  g_return_val_if_fail (info != NULL, -EINVAL);
+
+  gst_tensors_info_copy (info, &pdata->out_info);
+  return 0;
 }
 
 /**
@@ -437,12 +448,17 @@ static int nnfw_tensor_memory_set (const GstTensorFilterProperties * prop,
     if (err != 0)
       return err;
 
-    if (is_input)
+    if (is_input) {
+      g_return_val_if_fail (mem[idx].size ==
+          gst_tensor_info_get_size (&pdata->in_info.info[idx]), -EINVAL);
       nnfw_status = nnfw_set_input (pdata->session, idx, nnfw_type,
         mem[idx].data, mem[idx].size);
-    else
+    } else {
+      g_return_val_if_fail (mem[idx].size ==
+          gst_tensor_info_get_size (&pdata->out_info.info[idx]), -EINVAL);
       nnfw_status = nnfw_set_output (pdata->session, idx, nnfw_type,
         mem[idx].data, mem[idx].size);
+    }
     if (nnfw_status != NNFW_STATUS_NO_ERROR)
       return -EINVAL;
   }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -501,7 +501,8 @@ torch_close (const GstTensorFilterProperties * prop, void **private_data)
 {
   TorchCore *core = static_cast < TorchCore * >(*private_data);
 
-  g_assert (core);
+  if (!core)
+    return;
 
   delete core;
 
@@ -569,8 +570,6 @@ torch_open (const GstTensorFilterProperties * prop, void **private_data)
 {
   gint status = torch_loadModelFile (prop, private_data);
 
-  g_assert (status >= 0);       /** This must be called only once */
-
   return status;
 }
 
@@ -587,8 +586,7 @@ torch_invoke (const GstTensorFilterProperties * prop, void **private_data,
     const GstTensorMemory * input, GstTensorMemory * output)
 {
   TorchCore *core = static_cast < TorchCore * >(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && input && output, -EINVAL);
 
   return core->invoke (input, output);
 }
@@ -604,8 +602,7 @@ torch_getInputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   TorchCore *core = static_cast < TorchCore * >(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getInputTensorDim (info);
 }
@@ -621,8 +618,7 @@ torch_getOutputDim (const GstTensorFilterProperties * prop,
     void **private_data, GstTensorsInfo * info)
 {
   TorchCore *core = static_cast < TorchCore * >(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getOutputTensorDim (info);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -597,10 +597,10 @@ tf_close (const GstTensorFilterProperties * prop, void **private_data)
 {
   TFCore *core = static_cast<TFCore *>(*private_data);
 
-  g_assert (core);
+  if (!core)
+    return;
 
   delete core;
-
   *private_data = NULL;
 }
 
@@ -660,8 +660,6 @@ tf_open (const GstTensorFilterProperties * prop, void **private_data)
 {
   int status = tf_loadModelFile (prop, private_data);
 
-  g_assert (status >= 0); /** This must be called only once */
-
   return status;
 }
 
@@ -677,8 +675,7 @@ tf_run (const GstTensorFilterProperties * prop, void **private_data,
     const GstTensorMemory * input, GstTensorMemory * output)
 {
   TFCore *core = static_cast<TFCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && input && output, -EINVAL);
 
   return core->run (input, output);
 }
@@ -694,8 +691,7 @@ tf_getInputDim (const GstTensorFilterProperties * prop, void **private_data,
     GstTensorsInfo * info)
 {
   TFCore *core = static_cast<TFCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getInputTensorDim (info);
 }
@@ -711,8 +707,7 @@ tf_getOutputDim (const GstTensorFilterProperties * prop, void **private_data,
     GstTensorsInfo * info)
 {
   TFCore *core = static_cast<TFCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getOutputTensorDim (info);
 }


### PR DESCRIPTION
Replace asserts with appropriate error handling in tensor filter extensions
This will allows test cases for failure scenarios and handle erronous inputs
via single-shot API gracefully with error return than shutting down with assert failure

Issue : #1959 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>