### PR TITLE
[filter/ext] Added basic unittests for all filter extensions

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -42,10 +42,7 @@ override_dh_auto_build:
 	ninja -C build
 
 override_dh_auto_test:
-	cd build && ./tests/unittest_common && cd ..
-	cd build && ./tests/unittest_sink --gst-plugin-path=. && cd ..
-	cd build && ./tests/unittest_plugins --gst-plugin-path=. && cd ..
-	cd build && ./tests/unittest_src_iio --gst-plugin-path=. && cd ..
+	./packaging/run_unittests_binaries.sh ./tests
 	# SKIP CAPI-UnitTest until we fix it. In Launchpad emulator, capi_src.dummy01 and single_invoke01/02 makes errors due to the slugghish issue.
 	# cd build && ./tests/tizen_capi/unittest_tizen_capi --gst-plugin-path=. && cd ..
 	cd tests && ssat -n && cd ..

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+##
+## @file run_unittests.sh
+## @author Parichay Kapoor <pk.kapoor@gmail.com>
+## @date Dec 20 2019
+## @brief Runs all the unittests binaries in the specified folder or file
+input=$1
+
+pushd build
+export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
+export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
+export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
+export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
+
+if [ -f "${input}" ]; then
+  echo $input
+  ${input} --gst-plugin-path=. --gtest_output="xml:${input##*/}.xml"
+elif [ -d "${input}" ]; then
+  filelist=(`find "${input}" -mindepth 1 -maxdepth 1 -type f -name "unittest_*"`)
+  for entry in "${filelist[@]}"
+  do
+    echo $entry
+    ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
+  done
+else
+  filename=${input##*/}
+  dirname=${input%/*}
+  filelist=(`find "${dirname}" -mindepth 1 -maxdepth 1 -type f -name "${filename}"`)
+  for entry in "${filelist[@]}"
+  do
+    ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
+  done
+fi
+
+popd

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,6 +138,9 @@ if get_option('enable-nnfw-runtime')
   subdir('tizen_nnfw_runtime')
 endif
 
+# Tensor filter extensions basic test cases
+subdir('nnstreamer_filter_extensions_common')
+
 # Install Unittest
 if get_option('install-test')
   install_data('gen24bBMP.py', install_dir: unittest_tests_install_dir)

--- a/tests/nnstreamer_filter_extensions_common/deploy.sh
+++ b/tests/nnstreamer_filter_extensions_common/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+##
+## @file deploy.sh
+## @author Parichay Kapoor <pk.kapoor@gmail.com>
+## @date Dec 19 2019
+## @brief This creates failure test cases for tensor filter extensions.
+BASEPATH=`dirname "$0"`
+
+ext_name=$1
+ext_nick_name=$2
+model_file=$3
+
+pushd $BASEPATH
+
+target_file=unittest_tizen_${ext_name}.cpp
+if [ ! -f "${target_file}" ]; then
+  cp unittest_tizen_template.cpp ${target_file}
+
+  sed -i "s|EXT_NAME|${ext_name}|" ${target_file}
+  sed -i "s|EXT_NICK_NAME|${ext_nick_name}|" ${target_file}
+  sed -i "s|MODEL_FILE|${model_file}|" ${target_file}
+fi
+
+popd

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -1,0 +1,49 @@
+tizen_apptest_deps = [
+  gtest_dep,
+  glib_dep
+]
+
+# TODO: enable for python
+
+# Format for adding subplugin into extensions -
+# [name, nick name, dependencies, model file name/folder path/file path]
+extensions = []
+
+extensions += [['custom', 'custom', nnstreamer_unittest_deps, '../build/nnstreamer_example/custom_example_passthrough/libnnstreamer_customfilter_passthrough.so']]
+
+if get_option('enable-tensorflow-lite')
+  extensions += [['tensorflow-lite', 'tflite', nnstreamer_filter_tflite_deps, 'mobilenet_v1_1.0_224_quant.tflite']]
+endif
+
+if get_option('enable-tensorflow')
+  extensions += [['tensorflow', 'tf', nnstreamer_filter_tf_deps, 'mnist.pb']]
+endif
+
+if get_option('enable-nnfw-runtime')
+  extensions += [['nnfw', 'nnfw', nnstreamer_filter_nnfw_deps, 'add.tflite']]
+endif
+
+if get_option('enable-pytorch')
+  extensions += [['pytorch', 'torch', nnstreamer_filter_torch_deps, 'pytorch_lenet5.pt']]
+endif
+
+if get_option('enable-caffe2')
+  extensions += [['caffe2', 'caffe2', nnstreamer_filter_caffe2_deps, 'caffe2_init_net.pb,caffe2_predict_net.pb']]
+endif
+
+foreach ext : extensions
+  gen_test_src = run_command('deploy.sh', ext[0], ext[1], ext[3])
+
+  if gen_test_src.returncode() == 0
+    exec = executable('unittest_tizen_' + ext[0],
+      ['unittest_tizen_' + ext[0] + '.cpp'],
+      dependencies: [tizen_apptest_deps, ext[2]],
+      install: get_option('install-test'),
+      install_dir: unittest_install_dir
+    )
+
+    test('unittest_tizen_' + ext[0], exec, args: ['--gst-plugin-path=../..'])
+  else
+    warning('Failed to generate basic unittest for ' + ext[0])
+  endif
+endforeach

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cpp
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cpp
@@ -1,0 +1,335 @@
+/**
+ * @file        unittest_tizen_EXT_NAME.cpp
+ * @date        19 Dec 2019
+ * @brief       Failure Unit tests for tensor filter extension (EXT_NAME).
+ * @see         https://github.com/nnsuite/nnstreamer
+ * @author      Parichay Kapoor <pk.kapoor@samsung.com>
+ * @bug         No known bugs
+ */
+
+#include <gtest/gtest.h>
+#include <glib.h>
+#include <glib/gstdio.h>        /* GStatBuf */
+#include <nnstreamer_plugin_api.h>
+#include <nnstreamer_plugin_api_filter.h>
+
+/**
+ * @brief Test EXT_NICK_NAME subplugin existence.
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, check_existence)
+{
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+}
+
+/**
+ * @brief Test EXT_NICK_NAME subplugin with failing open/close (no model file)
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, open_close_00_n)
+{
+  int ret;
+  const gchar *model_files[] = {
+    "null.EXT_NICK_NAME", NULL,
+  };
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = model_files,
+    .num_models = 1,
+  };
+  void *data = NULL;
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_NE (ret, 0);
+}
+
+/**
+ * @brief Get model file after validation checks
+ * @returns model file path, NULL on error
+ * @note caller has to be free the returned model file path
+ */
+static
+gchar ** get_model_files ()
+{
+  gchar *model_file, *model_filepath;
+  gchar *model_path;
+  const gchar *model_filenames = "MODEL_FILE";
+  const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
+  gchar **model_files, **model_files_iterator;
+  gchar *dirname;
+
+  if (root_path == NULL)
+    root_path = "..";
+
+  model_path = g_build_filename (root_path, "tests", "test_models", "models",
+      NULL);
+
+  model_files = g_strsplit (model_filenames, ",", 0);
+  model_files_iterator = model_files;
+  for (model_file = *model_files_iterator; model_file != NULL;
+      model_file = *++model_files_iterator) {
+
+    /** If input is already path, then dont add path */
+    dirname = g_path_get_dirname (model_file);
+    if (g_strcmp0 (dirname, ".") != 0)
+      model_filepath = g_strdup (model_file);
+    else
+      model_filepath = g_build_filename (model_path, model_file, NULL);
+    g_free (dirname);
+
+    if (!g_file_test (model_filepath, G_FILE_TEST_EXISTS)) {
+      g_free (model_filepath);
+      g_free (model_path);
+      g_strfreev (model_files);
+      model_files = NULL;
+      goto ret;
+    }
+
+    g_free (*model_files_iterator);
+    *model_files_iterator = model_filepath;
+  }
+  g_free (model_path);
+
+ret:
+  g_message ("%s\n", *model_files);
+  return model_files;
+}
+
+/**
+ * @brief Test EXT_NICK_NAME subplugin with successful open/close
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, open_close_01_n)
+{
+  int ret;
+  void *data = NULL;
+  gchar **model_files;
+
+  model_files = get_model_files ();
+  ASSERT_TRUE (model_files != nullptr);
+
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = const_cast<const char **>(model_files),
+    .num_models = (int) g_strv_length (model_files),
+  };
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  /** close without open, should not crash */
+  sp->close (&prop, &data);
+
+  /** open and close successfully */
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+  sp->close (&prop, &data);
+
+  /** close twice, should not crash */
+  sp->close (&prop, &data);
+  g_strfreev (model_files);
+}
+
+/**
+ * @brief Get input/output dimensions with EXT_NICK_NAME subplugin
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, get_dimension_fail_n)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorsInfo res;
+  gchar **model_files;
+
+  model_files = get_model_files ();
+  ASSERT_TRUE (model_files != nullptr);
+
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = const_cast<const char **>(model_files),
+    .num_models = (int) g_strv_length (model_files),
+  };
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  /** get input/output dimension without open */
+  ret = sp->getInputDimension (&prop, &data, &res);
+  EXPECT_NE (ret, 0);
+  ret = sp->getOutputDimension (&prop, &data, &res);
+  EXPECT_NE (ret, 0);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+
+  /** get input/output dimension unsuccessfully */
+  ret = sp->getInputDimension (&prop, &data, NULL);
+  EXPECT_NE (ret, 0);
+
+  ret = sp->getOutputDimension (&prop, &data, NULL);
+  EXPECT_NE (ret, 0);
+
+  sp->close (&prop, &data);
+  g_strfreev (model_files);
+}
+
+/**
+ * @brief Get input/output dimensions with EXT_NICK_NAME subplugin
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, get_dimension)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorsInfo res;
+  gchar **model_files;
+
+  model_files = get_model_files ();
+  ASSERT_TRUE (model_files != nullptr);
+
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = const_cast<const char **>(model_files),
+    .num_models = (int) g_strv_length (model_files),
+  };
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+
+  /** get input/output dimension successfully */
+  ret = sp->getInputDimension (&prop, &data, &res);
+  EXPECT_EQ (ret, 0);
+
+  ret = sp->getOutputDimension (&prop, &data, &res);
+  EXPECT_EQ (ret, 0);
+
+  sp->close (&prop, &data);
+  g_strfreev (model_files);
+}
+
+/**
+ * @brief Test EXT_NICK_NAME subplugin with unsuccessful invoke
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, invoke_fail_n)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  gchar **model_files;
+
+  model_files = get_model_files ();
+  ASSERT_TRUE (model_files != nullptr);
+
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = const_cast<const char **>(model_files),
+    .num_models = (int) g_strv_length (model_files),
+  };
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  /** invoke without open */
+  ret = sp->invoke_NN (&prop, &data, &input, &output);
+  EXPECT_NE (ret, 0);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+
+  input.type = output.type = _NNS_FLOAT32;
+  input.size = output.size = 1 * gst_tensor_get_element_size (output.type);
+  input.data = g_malloc(input.size);
+  output.data = g_malloc(output.size);
+
+  /** invoke unsuccessful */
+  ret = sp->invoke_NN (&prop, &data, NULL, NULL);
+  EXPECT_NE (ret, 0);
+  ret = sp->invoke_NN (&prop, &data, &input, NULL);
+  EXPECT_NE (ret, 0);
+  ret = sp->invoke_NN (&prop, &data, NULL, &output);
+  EXPECT_NE (ret, 0);
+
+  g_free (input.data);
+  g_free (output.data);
+
+  sp->close (&prop, &data);
+  g_strfreev (model_files);
+}
+
+/**
+ * @brief Test EXT_NICK_NAME subplugin with successful invoke
+ */
+TEST (nnstreamer_EXT_NICK_NAME_basic_functions, invoke)
+{
+  int ret;
+  void *data = NULL;
+  GstTensorMemory input, output;
+  gchar **model_files;
+  GstTensorsInfo res;
+  int num_inputs, num_outputs;
+
+  model_files = get_model_files ();
+  ASSERT_TRUE (model_files != nullptr);
+
+  GstTensorFilterProperties prop = {
+    .fwname = "EXT_NAME",
+    .fw_opened = 0,
+    .model_files = const_cast<const char **>(model_files),
+    .num_models = (int) g_strv_length (model_files),
+  };
+
+  const GstTensorFilterFramework *sp = nnstreamer_filter_find ("EXT_NAME");
+  EXPECT_NE (sp, (void *) NULL);
+
+  ret = sp->open (&prop, &data);
+  EXPECT_EQ (ret, 0);
+
+  ret = sp->getOutputDimension (&prop, &data, &res);
+  EXPECT_EQ (ret, 0);
+  output.size = gst_tensor_info_get_size (&res.info[0]);
+  output.type = res.info[0].type;
+  num_outputs = res.num_tensors;
+
+  ret = sp->getInputDimension (&prop, &data, &res);
+  EXPECT_EQ (ret, 0);
+  input.size = gst_tensor_info_get_size (&res.info[0]);
+  input.type = res.info[0].type;
+  num_inputs = res.num_tensors;
+
+  input.data = g_malloc(input.size);
+  output.data = g_malloc(output.size);
+
+  /** should never crash */
+  ret = sp->invoke_NN (&prop, &data, &input, &output);
+  /** should be successful for single input/output case */
+  if (num_inputs == 1 && num_outputs == 1)
+    EXPECT_EQ (ret, 0);
+
+  g_free (input.data);
+  g_free (output.data);
+
+  sp->close (&prop, &data);
+  g_strfreev (model_files);
+}
+
+/**
+ * @brief Main gtest
+ */
+int
+main (int argc, char **argv)
+{
+  int result;
+
+  testing::InitGoogleTest (&argc, argv);
+
+  result = RUN_ALL_TESTS ();
+
+  return result;
+}


### PR DESCRIPTION
Added basic unittests for all the the filter extensions
This creates failure cases of unittests for the interface defined with GstTensorFilterFramework
for most of the extensions, and performs basic unittests
Updated the unittest list in packaging files as well
    
Also added a script file to run all the test cases inside a folder
    
TODO:  python extensions in this as well

Issue: #1959

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor pk.kapoor@samsung.com