### PR TITLE
[python/ext] Added basic unittests for python @open sesame 12/24 15:38

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -177,18 +177,18 @@ foreach s : filter_sub_python_sources
 endforeach
 
 if have_python2
-  nnstreamer_filter_python_deps = [python2_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_python2_deps = [python2_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
   shared_library('nnstreamer_filter_python2',
     nnstreamer_filter_python_sources,
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python2_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_python2',
     nnstreamer_filter_python_sources,
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python2_deps,
     install: true,
     install_dir: nnstreamer_libdir
   )
@@ -196,25 +196,25 @@ if have_python2
   shared_library('nnstreamer_python2',
     'tensor_filter_python_api.c',
     name_prefix: '',
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python2_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 endif
 
 if have_python3
-  nnstreamer_filter_python_deps = [python3_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
+  nnstreamer_filter_python3_deps = [python3_dep, libdl_dep, glib_dep, gst_dep, nnstreamer_dep]
 
   shared_library('nnstreamer_filter_python3',
     nnstreamer_filter_python_sources,
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python3_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )
 
   static_library('nnstreamer_filter_python3',
     nnstreamer_filter_python_sources,
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python3_deps,
     install: true,
     install_dir: nnstreamer_libdir
   )
@@ -222,7 +222,7 @@ if have_python3
   shared_library('nnstreamer_python3',
     'tensor_filter_python_api.c',
     name_prefix: '',
-    dependencies: nnstreamer_filter_python_deps,
+    dependencies: nnstreamer_filter_python3_deps,
     install: true,
     install_dir: filter_subplugin_install_dir
   )

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -164,9 +164,6 @@ PYCore::PYCore (const char* _script_path, const char* _custom)
   handle = dlopen(libname, RTLD_LAZY | RTLD_GLOBAL);
   g_assert(handle);
 
-  Py_Initialize();
-  g_assert(Py_IsInitialized());
-
   _import_array();  /** for numpy */
 
   /**
@@ -196,19 +193,13 @@ PYCore::PYCore (const char* _script_path, const char* _custom)
   Py_XDECREF(sys_path);
   Py_XDECREF(sys_module);
 
-  /** Find nnstreamer_api module */
-  PyObject *api_module = PyImport_ImportModule("nnstreamer_python");
-  g_assert(api_module);
-  shape_cls = PyObject_GetAttrString(api_module, "TensorShape");
-  g_assert(shape_cls);
-  Py_XDECREF(api_module);
-
   gst_tensors_info_init (&inputTensorMeta);
   gst_tensors_info_init (&outputTensorMeta);
 
   callback_type = CB_END;
   core_obj = NULL;
   configured = false;
+  shape_cls = NULL;
 
   /** to prevent concurrent Python C-API calls */
   g_mutex_init (&py_mutex);
@@ -229,7 +220,6 @@ PYCore::~PYCore ()
     Py_XDECREF(shape_cls);
 
   PyErr_Clear();
-  Py_Finalize();
 
   dlclose(handle);
   g_mutex_clear (&py_mutex);
@@ -242,6 +232,18 @@ PYCore::~PYCore ()
 int
 PYCore::init (const GstTensorFilterProperties * prop)
 {
+  /** Find nnstreamer_api module */
+  PyObject *api_module = PyImport_ImportModule("nnstreamer_python");
+  if (api_module == NULL) {
+    return -EINVAL;
+  }
+
+  shape_cls = PyObject_GetAttrString(api_module, "TensorShape");
+  Py_XDECREF(api_module);
+
+  if (shape_cls == NULL)
+    return -EINVAL;
+
   gst_tensors_info_copy (&inputTensorMeta, &prop->input_meta);
   gst_tensors_info_copy (&outputTensorMeta, &prop->output_meta);
 
@@ -724,7 +726,9 @@ py_run (const GstTensorFilterProperties * prop, void **private_data,
 {
   PYCore *core = static_cast<PYCore *>(*private_data);
 
-  g_assert (core);
+  g_return_val_if_fail (core, -EINVAL);
+  g_return_val_if_fail (input, -EINVAL);
+  g_return_val_if_fail (output, -EINVAL);
 
   return core->run (input, output);
 }
@@ -757,8 +761,7 @@ py_setInputDim (const GstTensorFilterProperties * prop, void **private_data,
     const GstTensorsInfo * in_info, GstTensorsInfo * out_info)
 {
   PYCore *core = static_cast<PYCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && in_info && out_info, -EINVAL);
 
   return core->setInputTensorDim (in_info, out_info);
 }
@@ -774,8 +777,7 @@ py_getInputDim (const GstTensorFilterProperties * prop, void **private_data,
     GstTensorsInfo * info)
 {
   PYCore *core = static_cast<PYCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getInputTensorDim (info);
 }
@@ -791,8 +793,7 @@ py_getOutputDim (const GstTensorFilterProperties * prop, void **private_data,
     GstTensorsInfo * info)
 {
   PYCore *core = static_cast<PYCore *>(*private_data);
-
-  g_assert (core);
+  g_return_val_if_fail (core && info, -EINVAL);
 
   return core->getOutputTensorDim (info);
 }
@@ -805,8 +806,7 @@ py_close (const GstTensorFilterProperties * prop, void **private_data)
 {
   PYCore *core = static_cast<PYCore *>(*private_data);
 
-  g_assert (core);
-
+  g_return_if_fail (core != NULL);
   delete core;
 
   *private_data = NULL;
@@ -891,9 +891,8 @@ py_loadScriptFile (const GstTensorFilterProperties * prop, void **private_data)
 static int
 py_open (const GstTensorFilterProperties * prop, void **private_data)
 {
+  g_assert(Py_IsInitialized());
   int status = py_loadScriptFile (prop, private_data);
-
-  g_assert (status >= 0);   /** This must be called only once */
 
   return status;
 }
@@ -925,11 +924,15 @@ init_filter_py (void)
 {
   nnstreamer_filter_probe (&NNS_support_python);
   filter_framework = &NNS_support_python;
+  /** Python should be initialized and finalized only once */
+  Py_Initialize();
 }
 
 /** @brief Destruct the subplugin */
 void
 fini_filter_py (void)
 {
+  /** Python should be initialized and finalized only once */
+  Py_Finalize();
   nnstreamer_filter_exit (NNS_support_python.name);
 }

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -11,16 +11,33 @@ export GST_PLUGIN_PATH=$(pwd)/gst/nnstreamer
 export NNSTREAMER_CONF=$(pwd)/nnstreamer-test.ini
 export NNSTREAMER_FILTERS=$(pwd)/ext/nnstreamer/tensor_filter
 export NNSTREAMER_DECODERS=$(pwd)/ext/nnstreamer/tensor_decoder
+export PYTHONPATH=$(pwd)/ext/nnstreamer/tensor_filter/:$PYTHONPATH
+
+
+run_entry() {
+  entry=$1
+
+  if [[ $entry == *"python3"* ]]; then
+    pushd ext/nnstreamer/tensor_filter
+    ln -sf nnstreamer_python3.so nnstreamer_python.so
+    popd
+  elif [[ $entry == *"python2"* ]]; then
+    pushd ext/nnstreamer/tensor_filter
+    ln -sf nnstreamer_python2.so nnstreamer_python.so
+    popd
+  fi
+
+  echo $entry
+  ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
+}
 
 if [ -f "${input}" ]; then
-  echo $input
-  ${input} --gst-plugin-path=. --gtest_output="xml:${input##*/}.xml"
+  run_entry $input
 elif [ -d "${input}" ]; then
   filelist=(`find "${input}" -mindepth 1 -maxdepth 1 -type f -name "unittest_*"`)
   for entry in "${filelist[@]}"
   do
-    echo $entry
-    ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
+    run_entry $entry
   done
 else
   filename=${input##*/}
@@ -28,7 +45,7 @@ else
   filelist=(`find "${dirname}" -mindepth 1 -maxdepth 1 -type f -name "${filename}"`)
   for entry in "${filelist[@]}"
   do
-    ${entry} --gst-plugin-path=. --gtest_output="xml:${entry##*/}.xml"
+    run_entry $entry
   done
 fi
 

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -31,6 +31,14 @@ if get_option('enable-caffe2')
   extensions += [['caffe2', 'caffe2', nnstreamer_filter_caffe2_deps, 'caffe2_init_net.pb,caffe2_predict_net.pb']]
 endif
 
+if have_python2
+  extensions += [['python2', 'python2', nnstreamer_filter_python2_deps, 'passthrough.py']]
+endif
+
+if have_python3
+  extensions += [['python3', 'python3', nnstreamer_filter_python3_deps, 'passthrough.py']]
+endif
+
 foreach ext : extensions
   gen_test_src = run_command('deploy.sh', ext[0], ext[1], ext[3])
 


### PR DESCRIPTION
- Python initialize and finalize is done once for the module rather than doing it per object 
Doing initialization per object causes errors when importing modules
- Replaced Assert with appropriate error handing for python extension of tensor filter
- Added basic unittests for python which covers the failure cases

Issue: #1959

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor pk.kapoor@samsung.com