### PR TITLE
[Filter/OpenVino] Load a given network into the acceleration device 

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -307,6 +307,15 @@ if get_option('enable-openvino')
   openvino_deps = []
   openvino_cpp_args = []
   openvino_deps += dependency('openvino', required: true)
+  if cxx.has_header('ext_list.hpp')
+    openvino_cpuext_lib = cxx.find_library('cpu_extension', required: true)
+    if openvino_cpuext_lib.found()
+      openvino_cpp_args += '-D__OPENVINO_CPU_EXT__=1'
+      openvino_deps += openvino_cpuext_lib
+    else
+      error('Cannot find the shared object, libcpu_extension.')
+    endif
+  endif
   filter_sub_openvino_sources = ['tensor_filter_openvino.cc']
 
   nnstreamer_filter_openvino_sources = []


### PR DESCRIPTION
Related to https://github.com/nnsuite/nnstreamer/issues/1708.

After negotiated, the given neural network should be loaded into the acceleration device (note that, currently, CPU is the only supported one). This PR is a draft of the implementation of that mechanism.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped