### PR TITLE
[C-API] Set omitted enum value in pipeline buffer policy @open sesame 01/06 16:45

### DIFF
--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -188,8 +188,8 @@ typedef enum {
  * @since_tizen 5.5
  */
 typedef enum {
-  ML_PIPELINE_BUF_POLICY_AUTO_FREE,	/**< Default. Application should not deallocate this buffer. NNStreamer will deallocate when the buffer is no more needed */
-  ML_PIPELINE_BUF_POLICY_DO_NOT_FREE,		/**< This buffer is not to be freed by NNStreamer (i.e., it's a static object). However, be careful: NNStreamer might be accessing this object after the return of the API call. */
+  ML_PIPELINE_BUF_POLICY_AUTO_FREE      = 0, /**< Default. Application should not deallocate this buffer. NNStreamer will deallocate when the buffer is no more needed */
+  ML_PIPELINE_BUF_POLICY_DO_NOT_FREE    = 1, /**< This buffer is not to be freed by NNStreamer (i.e., it's a static object). However, be careful: NNStreamer might be accessing this object after the return of the API call. */
   ML_PIPELINE_BUF_POLICY_MAX,   /**< Max size of ml_pipeline_buf_policy_e structure */
 } ml_pipeline_buf_policy_e;
 


### PR DESCRIPTION
This patch explicitly set the enum value in pipeline buffer policy as
below.
* ML_PIPELINE_BUF_POLICY_AUTO_FREE: 0
* ML_PIPELINE_BUF_POLICY_DO_NOT_FREE: 1

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
