### PR TITLE
[Filter] Add an option to centralize checking the path of model files

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -660,6 +660,7 @@ static GstTensorFilterFramework NNS_support_armnn = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = armnn_invoke,
   .getInputDimension = armnn_getInputDim,
   .getOutputDimension = armnn_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -571,6 +571,7 @@ static GstTensorFilterFramework NNS_support_caffe2 = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = TRUE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = caffe2_run,
   .getInputDimension = caffe2_getInputDim,
   .getOutputDimension = caffe2_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -127,6 +127,7 @@ static GstTensorFilterFramework NNS_support_cpp = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = cpp_invoke,
   .getInputDimension = cpp_getInputDim,
   .getOutputDimension = cpp_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -377,6 +377,7 @@ static GstTensorFilterFramework NNS_support_edgetpu = {
   .allow_in_place = FALSE,
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = edgetpu_invoke,
   .getInputDimension = edgetpu_getInputDim,
   .getOutputDimension = edgetpu_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -411,6 +411,7 @@ static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
   .name = filter_subplugin_movidius_ncsdk2,
   .allow_in_place = FALSE,
   .allocate_in_invoke = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = _mvncsdk2_invoke,
   .getInputDimension = _mvncsdk2_getInputDim,
   .getOutputDimension = _mvncsdk2_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -496,6 +496,7 @@ static GstTensorFilterFramework NNS_support_nnfw = {
   .allow_in_place = FALSE,
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = nnfw_invoke,
   .getInputDimension = nnfw_getInputDim,
   .getOutputDimension = nnfw_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -397,6 +397,7 @@ static GstTensorFilterFramework NNS_support_openvino = {
   .allow_in_place = FALSE,
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = ov_invoke,
   .getInputDimension = ov_getInputDim,
   .getOutputDimension = ov_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -903,6 +903,7 @@ static GstTensorFilterFramework NNS_support_python = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = TRUE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = py_run,
   /** dimension-related callbacks are dynamically assigned */
   .getInputDimension = py_getInputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -630,6 +630,7 @@ static GstTensorFilterFramework NNS_support_pytorch = {
   .allow_in_place = FALSE,
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = torch_invoke,
   .getInputDimension = torch_getInputDim,
   .getOutputDimension = torch_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -730,6 +730,7 @@ static GstTensorFilterFramework NNS_support_tensorflow = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = TRUE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = tf_run,
   .getInputDimension = tf_getInputDim,
   .getOutputDimension = tf_getOutputDim,

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -973,6 +973,7 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
+  .verify_model_path = FALSE,
   .invoke_NN = tflite_invoke,
   .getInputDimension = tflite_getInputDim,
   .getOutputDimension = tflite_getOutputDim,

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -128,6 +128,7 @@ typedef struct _GstTensorFilterFramework
   int allow_in_place; /**< TRUE(nonzero) if InPlace transfer of input-to-output is allowed. Not supported in main, yet */
   int allocate_in_invoke; /**< TRUE(nonzero) if invoke_NN is going to allocate outputptr by itself and return the address via outputptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
   int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. */
+  int verify_model_path; /**< TRUE(nonzero) when the NNS framework, not the sub-plugin, should verify the path of model files. */
 
   int (*invoke_NN) (const GstTensorFilterProperties * prop, void **private_data,
       const GstTensorMemory * input, GstTensorMemory * output);


### PR DESCRIPTION
Currently, each sub-plugin of the tensor filter should check the validity of the path of the model files. In general, it leads to unnecessary code duplication.  Moreover, sometimes those are not checked
at all. This patch adds an option to centralize checking the path of model files so that each sub-plugin is in charge of the validity of model files only when this option is set to TRUE.

Signed-off-by: Wook Song <wook16.song@samsung.com>
