### PR TITLE
[Documentation] Modify the meson version required to build up-to-date

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -5,7 +5,7 @@ The following dependencies are needed to compile/build/run.
 * gcc/g++
 * gstreamer 1.0 and its relatives
 * glib 2.0
-* meson >= 0.42
+* meson >= 0.50
 
 ### Install via PPA repository (Debian/Ubuntu)
 


### PR DESCRIPTION
This patch modifies the meson version required to build up-to-date, 0.50.

Signed-off-by: Wook Song <wook16.song@samsung.com>