### PR TITLE
[Cpp/Ext] Renames file extensions of test source codes written in C++

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -14,7 +14,7 @@
  *
  */
 /**
- * @file	tensor_filter_cpp.cpp
+ * @file	tensor_filter_cpp.cc
  * @date	26 Sep 2019
  * @brief	Tensor_filter subplugin for C++ custom filters.
  * @see		http://github.com/nnsuite/nnstreamer

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -14,7 +14,7 @@
  *
  */
 /**
- * @file    tensor_filter_openvino.cpp
+ * @file    tensor_filter_openvino.cc
  * @date    23 Dec 2019
  * @brief   Tensor_filter subplugin for OpenVino (DLDT).
  * @see     http://github.com/nnsuite/nnstreamer

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -1,5 +1,5 @@
 /**
- * @file unittest_common.cpp
+ * @file unittest_common.cc
  * @date 31 May 2018
  * @author MyungJoo Ham <myungjoo.ham@samsung.com>
  * @brief Unit test module for NNStreamer common library

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -63,7 +63,7 @@ if gtest_dep.found()
 
   # Run unittest_common
   unittest_common = executable('unittest_common',
-    join_paths('common', 'unittest_common.cpp'),
+    join_paths('common', 'unittest_common.cc'),
     dependencies: [nnstreamer_unittest_deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
@@ -73,7 +73,7 @@ if gtest_dep.found()
 
   # Run unittest_sink
   unittest_sink = executable('unittest_sink',
-    join_paths('nnstreamer_sink', 'unittest_sink.cpp'),
+    join_paths('nnstreamer_sink', 'unittest_sink.cc'),
     dependencies: [nnstreamer_unittest_deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
@@ -83,7 +83,7 @@ if gtest_dep.found()
 
   # Run unittest_plugins
   unittest_plugins = executable('unittest_plugins',
-    join_paths('nnstreamer_plugins', 'unittest_plugins.cpp'),
+    join_paths('nnstreamer_plugins', 'unittest_plugins.cc'),
     dependencies: [nnstreamer_unittest_deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir
@@ -94,7 +94,7 @@ if gtest_dep.found()
   # Run unittest_src_iio
   if build_platform != 'macos'
     unittest_src_iio = executable('unittest_src_iio',
-      join_paths('nnstreamer_source', 'unittest_src_iio.cpp'),
+      join_paths('nnstreamer_source', 'unittest_src_iio.cc'),
       dependencies: [nnstreamer_unittest_deps],
       install: get_option('install-test'),
       install_dir: unittest_install_dir
@@ -106,7 +106,7 @@ if gtest_dep.found()
   # Armnn unittest
   if get_option('enable-armnn')
     unittest_filter_armnn = executable('unittest_filter_armnn',
-      join_paths('nnstreamer_filter_armnn', 'unittest_filter_armnn.cpp'),
+      join_paths('nnstreamer_filter_armnn', 'unittest_filter_armnn.cc'),
       dependencies: [glib_dep, gst_dep, nnstreamer_dep, gtest_dep, armnn_plugin_dep],
       install: get_option('install-test'),
       install_dir: unittest_install_dir

--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -1,5 +1,5 @@
 /**
- * @file        unittest_filter_armnn.cpp
+ * @file        unittest_filter_armnn.cc
  * @date        13 Dec 2019
  * @brief       Unit test for armnn tensor filter plugin.
  * @see         https://github.com/nnsuite/nnstreamer

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -1,5 +1,5 @@
 /**
- * @file	unittest_plugins.cpp
+ * @file	unittest_plugins.cc
  * @date	7 November 2018
  * @brief	Unit test for nnstreamer plugins. (testcases to check data conversion or buffer transfer)
  * @see		https://github.com/nnsuite/nnstreamer

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -1,5 +1,5 @@
 /**
- * @file	unittest_sink.cpp
+ * @file	unittest_sink.cc
  * @date	29 June 2018
  * @brief	Unit test for tensor sink plugin
  * @see		https://github.com/nnsuite/nnstreamer

--- a/tests/nnstreamer_source/unittest_src_iio.cc
+++ b/tests/nnstreamer_source/unittest_src_iio.cc
@@ -1,5 +1,5 @@
 /**
- * @file	unittest_src_iio.cpp
+ * @file	unittest_src_iio.cc
  * @date	22 March 2019
  * @brief	Unit test for tensor_src_iio
  * @see		https://github.com/nnsuite/nnstreamer

--- a/tests/tizen_capi/meson.build
+++ b/tests/tizen_capi/meson.build
@@ -5,7 +5,7 @@ tizen_apptest_deps = [
 ]
 
 unittest_tizen_capi = executable('unittest_tizen_capi',
-  'unittest_tizen_capi.cpp',
+  'unittest_tizen_capi.cc',
   dependencies: [tizen_apptest_deps],
   install: get_option('install-test'),
   install_dir: unittest_install_dir
@@ -33,7 +33,7 @@ if get_option('enable-tizen-sensor')
     unittest_sensor_helper_dep,
   ]
   unittest_tizen_sensor = executable('unittest_tizen_sensor',
-    ['unittest_tizen_sensor.cpp'],
+    ['unittest_tizen_sensor.cc'],
     dependencies: [tizen_sensor_apptest_deps],
     install: get_option('install-test'),
     install_dir: unittest_install_dir

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1,5 +1,5 @@
 /**
- * @file        unittest_tizen_capi.cpp
+ * @file        unittest_tizen_capi.cc
  * @date        13 Mar 2019
  * @brief       Unit test for Tizen CAPI of NNStreamer. Basis of TCT in the future.
  * @see         https://github.com/nnsuite/nnstreamer

--- a/tests/tizen_capi/unittest_tizen_sensor.cc
+++ b/tests/tizen_capi/unittest_tizen_sensor.cc
@@ -1,5 +1,5 @@
 /**
- * @file	unittest_tizen_sensor.cpp
+ * @file	unittest_tizen_sensor.cc
  * @date	25 Nov 2019
  * @brief	Unit test for NNStreamer's tensor-src-tizensensor.
  * @see		https://github.com/nnsuite/nnstreamer

--- a/tests/tizen_nnfw_runtime/meson.build
+++ b/tests/tizen_nnfw_runtime/meson.build
@@ -1,5 +1,5 @@
 unittest_nnfw_runtime_raw = executable('unittest_nnfw_runtime_raw',
-  'unittest_tizen_nnfw_runtime_raw.cpp',
+  'unittest_tizen_nnfw_runtime_raw.cc',
   dependencies: [glib_dep, gst_dep, nnstreamer_dep, gtest_dep, nnfw_plugin_dep],
   install: get_option('install-test'),
   install_dir: join_paths(unittest_install_dir,'tests'),

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -1,5 +1,5 @@
 /**
- * @file        unittest_tizen_capi.cpp
+ * @file        unittest_tizen_capi.cc
  * @date        13 Mar 2019
  * @brief       Unit test for Tizen CAPI of NNStreamer. Basis of TCT in the future.
  * @see         https://github.com/nnsuite/nnstreamer

--- a/tests/unittestcoverage.py
+++ b/tests/unittestcoverage.py
@@ -32,7 +32,7 @@
 #  $ unittestcoverage all /home/abuild/rpmbuild/BUILD/audri-1.1.1/ROS/
 #  Please use absolute path to the ROS module root dir
 #
-# Limitation of this version: supports c/c++ only (.c, .cpp, .h, .hpp)
+# Limitation of this version: supports c/c++ only (.c, .cc, .h, .hpp)
 #
 
 from __future__ import print_function
@@ -65,7 +65,7 @@ def auditEvaders(gcovOutput, path):
     for file in files:
       # TODO 1 : Support other than C/C++
       # TODO 2 : case insensitive
-      if file.endswith(".cpp") or file.endswith(".c") or \
+      if file.endswith(".cc") or file.endswith(".c") or \
          file.endswith(".h") or file.endswith(".hpp"):
         dprint(file)
 


### PR DESCRIPTION
This PR renames file extensions of test source codes written in C++
(i.e, *.cpp -> *.cc), which hurt the consistency.

Resolves #2003.

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped
