### PR TITLE
[tensor] Support data layout for tensor @open sesame 1/16 16:12

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -104,6 +104,7 @@ typedef struct {
   char *name;              /**< Name of each element in the tensor. */
   ml_tensor_type_e type;   /**< Type of each element in the tensor. */
   ml_tensor_dimension dimension;     /**< Dimension information. */
+  ml_tensor_layout_e layout;  /**< The layout of the tensor data */
 } ml_tensor_info_s;
 
 /**

--- a/api/capi/include/nnstreamer.h
+++ b/api/capi/include/nnstreamer.h
@@ -169,6 +169,17 @@ typedef enum _ml_tensor_type_e
 } ml_tensor_type_e;
 
 /**
+ * @brief Possible data format/layout of Tensor in NNStreamer.
+ * @since_tizen 6.0
+ */
+typedef enum _ml_tensor_layout_e
+{
+  ML_TENSOR_LAYOUT_NONE = 0,      /**< It has unknown layout or it does not care about the data layout */
+  ML_TENSOR_LAYOUT_NHWC,          /**< Channel first layout */
+  ML_TENSOR_LAYOUT_NCHW,          /**< Channel last layout */
+} ml_tensor_layout_e;
+
+/**
  * @brief Enumeration for the error codes of NNStreamer Pipelines.
  * @since_tizen 5.5
  */

--- a/gst/nnstreamer/nnstreamer_plugin_api.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api.h
@@ -127,6 +127,16 @@ gst_tensors_info_parse_types_string (GstTensorsInfo * info,
     const gchar * type_string);
 
 /**
+ * @brief Parse the string of layout
+ * @param info tensors info structure
+ * @param layout_string string of layout
+ * @return number of parsed layouts
+ */
+extern guint
+gst_tensors_info_parse_layouts_string (GstTensorsInfo * info,
+    const gchar * layout_string);
+
+/**
  * @brief Parse the string of names
  * @param info tensors info structure
  * @param name_string string of names
@@ -315,6 +325,13 @@ gst_tensor_get_element_count (const tensor_dim dim);
  */
 extern gsize
 gst_tensor_get_element_size (tensor_type type);
+
+/**
+ * @brief Get tensor layout from string input.
+ * @return Corresponding tensor_layout.
+ */
+extern tensor_layout
+gst_tensor_get_layout (const gchar * layoutstr);
 
 /**
  * @brief Get tensor type from string input.

--- a/gst/nnstreamer/tensor_transform/tensor_transform.c
+++ b/gst/nnstreamer/tensor_transform/tensor_transform.c
@@ -890,6 +890,7 @@ gst_tensor_transform_set_option_data (GstTensorTransform * filter)
       int i;
       gchar **strv = NULL;
 
+      /** TODO: update layout here */
       if (!g_regex_match_simple (REGEX_TRANSPOSE_OPTION, filter->option, 0, 0)) {
         g_critical
             ("%s: transpose: \'%s\' is not valid option string: it should be in the form of NEW_IDX_DIM0:NEW_IDX_DIM1:NEW_IDX_DIM2:3 (note that the index of the last dim is alwayes fixed to 3)\n",
@@ -1474,6 +1475,7 @@ gst_tensor_transform_convert_dimension (GstTensorTransform * filter,
       int to = filter->data_dimchg.to;
 
       out_info->type = in_info->type;
+      out_info->layout = in_info->layout;
 
       if (direction == GST_PAD_SINK) {
         for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {
@@ -1528,6 +1530,8 @@ gst_tensor_transform_convert_dimension (GstTensorTransform * filter,
 
     case GTT_TRANSPOSE:
       out_info->type = in_info->type;
+      /** TODO: update this layout based on transpose */
+      out_info->layout = in_info->layout;
 
       if (direction == GST_PAD_SINK) {
         for (i = 0; i < NNS_TENSOR_RANK_LIMIT; i++) {

--- a/gst/nnstreamer/tensor_typedef.h
+++ b/gst/nnstreamer/tensor_typedef.h
@@ -133,6 +133,16 @@ typedef union {
   uint64_t _uint64_t;
 } tensor_element;
 
+/**
+ * @brief Internal tensor layout format for other/tensor
+ */
+typedef enum _nns_tensor_layout
+{
+  _NNS_LAYOUT_NONE = 0,    /**< It has unknown layout or it does not care about the data layout */
+  _NNS_LAYOUT_NHWC,        /**< NHWC: channel last layout */
+  _NNS_LAYOUT_NCHW,        /**< NCHW: channel first layout */
+} tensor_layout;
+
 typedef uint32_t tensor_dim[NNS_TENSOR_RANK_LIMIT];
 
 /**
@@ -155,6 +165,7 @@ typedef struct
                    and some (tensorflow-lite) do not need this. */
   tensor_type type; /**< Type of each element in the tensor. User must designate this. */
   tensor_dim dimension; /**< Dimension. We support up to 4th ranks.  */
+  tensor_layout layout; /**< Layout. Channel first/channel last/none data layout */
 } GstTensorInfo;
 
 /**

--- a/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
+++ b/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
@@ -53,6 +53,7 @@ pt_init (const GstTensorFilterProperties * prop)
   for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
     data->info[0].dimension[i] = 1;
   data->info[0].type = _NNS_FLOAT32;
+
   data->info[1] = data->info[0];
   data->info[2] = data->info[0];
 

--- a/nnstreamer_example/custom_example_RNN/dummy_RNN.c
+++ b/nnstreamer_example/custom_example_RNN/dummy_RNN.c
@@ -52,6 +52,7 @@ pt_init (const GstTensorFilterProperties * prop)
   for (i = 3; i < NNS_TENSOR_RANK_LIMIT; i++)
     data->info[0].dimension[i] = 1;
   data->info[0].type = _NNS_UINT8;
+
   data->info[1] = data->info[0];
 
   return data;


### PR DESCRIPTION
Data layout added for other/tensor
Three data layouts are supported
- NHWC - referred as channels last
- NCHW - referred as channels first
- none - unknown or doesnt matter
These data layouts can be different for each other/tensor in other/tensors
Also added their basic support in single API

Refer #1986 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>