### PR TITLE
[subplugin/ext] Extensions not update their functions

### DIFF
--- a/api/capi/src/tensor_filter_single.c
+++ b/api/capi/src/tensor_filter_single.c
@@ -346,6 +346,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
 {
   GstTensorFilterPrivate *priv;
   guint i;
+  gboolean allocate_in_invoke;
 
   priv = &self->priv;
 
@@ -365,9 +366,10 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
   }
 
   /** Setup output buffer */
+  allocate_in_invoke = gst_tensor_filter_allocate_in_invoke (priv);
   for (i = 0; i < priv->prop.output_meta.num_tensors; i++) {
     /* allocate memory if allocate_in_invoke is FALSE */
-    if (priv->fw->allocate_in_invoke == FALSE) {
+    if (allocate_in_invoke == FALSE) {
       output[i].data = g_malloc (output[i].size);
       if (!output[i].data) {
         g_critical ("Failed to allocate the output tensor.");
@@ -380,7 +382,7 @@ g_tensor_filter_single_invoke (GTensorFilterSingle * self,
     return TRUE;
 
 error:
-  if (priv->fw->allocate_in_invoke == FALSE)
+  if (allocate_in_invoke == FALSE)
     for (i = 0; i < priv->prop.output_meta.num_tensors; i++)
       g_free (output[i].data);
   return FALSE;

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -72,15 +72,13 @@ private:
 
   Workspace workSpace;
   NetDef initNet, predictNet;
-  static std::map <char*, Tensor*> inputTensorMap;
+  std::map <char*, Tensor*> inputTensorMap;
 
   int initInputTensor ();
 };
 
 void init_filter_caffe2 (void) __attribute__ ((constructor));
 void fini_filter_caffe2 (void) __attribute__ ((destructor));
-
-std::map <char*, Tensor*> Caffe2Core::inputTensorMap;
 
 /**
  * @brief	Caffe2Core creator

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -556,6 +556,7 @@ caffe2_getOutputDim (const GstTensorFilterProperties * prop,
 
 /**
  * @brief The optional callback for GstTensorFilterFramework
+ * @param[in] private_data caffe2 plugin's private data
  * @param[in] data The data element.
  */
 static void

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -590,7 +590,7 @@ PYCore::run (const GstTensorMemory * input, GstTensorMemory * output)
   PyObject *param = PyList_New(0);
   for (unsigned int i = 0; i < inputTensorMeta.num_tensors; i++) {
     /** create a Numpy array wrapper (1-D) for NNS tensor data */
-    npy_intp input_dims[] = {(npy_intp) input[i].size};
+    npy_intp input_dims[] = {(npy_intp) (input[i].size / gst_tensor_get_element_size (input[i].type))};
     PyObject *input_array = PyArray_SimpleNewFromData(
         1, input_dims, getNumpyType(input[i].type), input[i].data);
     PyList_Append(param, input_array);
@@ -717,8 +717,8 @@ PYCore::getNumpyType (tensor_type tType)
  * @brief The mandatory callback for GstTensorFilterFramework
  * @param prop: property of tensor_filter instance
  * @param private_data : python plugin's private data
- * @param[in] input The array of input tensors
- * @param[out] output The array of output tensors
+ * @param input : The array of input tensors
+ * @param output : The array of output tensors
  */
 static int
 py_run (const GstTensorFilterProperties * prop, void **private_data,
@@ -735,7 +735,8 @@ py_run (const GstTensorFilterProperties * prop, void **private_data,
 
 /**
  * @brief The optional callback for GstTensorFilterFramework
- * @param[in] data The data element.
+ * @param data : The data element.
+ * @param private_data : python plugin's private data
  */
 static void
 py_destroyNotify (void **private_data, void *data)
@@ -745,8 +746,9 @@ py_destroyNotify (void **private_data, void *data)
   if (it != PYCore::outputArrayMap.end()){
     Py_XDECREF(it->second);
     PYCore::outputArrayMap.erase (it);
-  } else
+  } else {
     g_critical("Cannot find output data: 0x%lx", (unsigned long) data);
+  }
 }
 
 /**

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -714,7 +714,8 @@ tf_getOutputDim (const GstTensorFilterProperties * prop, void **private_data,
 
 /**
  * @brief The optional callback for GstTensorFilterFramework
- * @param[in] data The data element.
+ * @param data : The data element.
+ * @param private_data : tensorflow plugin's private data
  */
 static void
 tf_destroyNotify (void **private_data, void *data)

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -360,11 +360,11 @@ typedef struct _GstTensorFilterFramework
        */
 
        int (*allocateInInvoke) (void **private_data);
-			 /**< Optional. tensor_filter.c will call it when allocate_in_invoke is set to TRUE. This check if the provided model for the framework supports allocation at invoke or not. If this is not defined, then the value of allocate_in_invoke is assumed to be final for all models.
-				*
-				* @param[in] private_data A subplugin may save its internal private data here.
-				* @return 0 if supported. -errno if not supported.
-				*/
+       /**< Optional. tensor_filter.c will call it when allocate_in_invoke is set to TRUE. This check if the provided model for the framework supports allocation at invoke or not. If this is not defined, then the value of allocate_in_invoke is assumed to be final for all models.
+        *
+        * @param[in] private_data A subplugin may save its internal private data here.
+        * @return 0 if supported. -errno if not supported.
+        */
     };
 
     /**

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -416,6 +416,27 @@ gst_tensor_filter_parse_modelpaths_string (GstTensorFilterProperties * prop,
   }
 }
 
+/**
+ * @brief check if the allocate_in_invoke is valid for the framework
+ * @param[in] priv Struct containing the properties of the object
+ * @return TRUE if valid, FALSE on error
+ */
+gboolean
+gst_tensor_filter_allocate_in_invoke (GstTensorFilterPrivate * priv)
+{
+  int allocate_in_invoke;
+
+  allocate_in_invoke = priv->fw->allocate_in_invoke;
+  if (allocate_in_invoke == TRUE && priv->fw->allocateInInvoke) {
+    if (priv->fw->allocateInInvoke (&priv->privateData) == 0) {
+      allocate_in_invoke = TRUE;
+    } else {
+      allocate_in_invoke = FALSE;
+    }
+  }
+
+  return allocate_in_invoke;
+}
 
 /**
  * @brief Printout the comparison results of two tensors.

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -57,6 +57,14 @@ gst_tensor_filter_compare_tensors (GstTensorsInfo * info1,
     GstTensorsInfo * info2);
 
 /**
+ * @brief check if the allocate_in_invoke is valid for the framework
+ * @param[in] priv Struct containing the properties of the object
+ * @return TRUE if valid, FALSE on error
+ */
+extern gboolean
+gst_tensor_filter_allocate_in_invoke (GstTensorFilterPrivate * priv);
+
+/**
  * @brief Installs all the properties for tensor_filter
  * @param[in] gobject_class Glib object class whose properties will be set
  */


### PR DESCRIPTION
NNStreamer extensions for tensor filter update their functions based on the model file
However, this behavior is not thread-safe.
Updated for extensions to not update their functions (for destroyNotify and allocate_in_invoke)

For allocate_in_invoke, tensor_filter needs to know based on the model if the allocate_in_invoke is supported or not
So added another interface in GstTensorFilterFramework - allocateInInvoke

~destroyNotify interface is also updated. private_data for the subplugin is passed embedded in the data field so that
based on the private data, appropriate model specific destroy function for custom filter can be called~

V2:
Added allocate_in_invoke to be set properly in single API implementation of tensor_filter
Also added some minor updates in comment
Added minor bugfix in python extension

PART-2
Python updates in extensions framework functions
This results in non-thread-safe behavior
This PR modifies the corresponding implementation

PART-3
As extensions are supposed to be thread-safe, using class static variables without locks is not stable
Move class static variables to class local object variables for python, tensorflow and caffe2
Also update corresponding usages.

Resolves : #2034

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>