### PR TITLE
[common] Added proper GstCaps framerate comparison

### DIFF
--- a/gst/nnstreamer/tensor_common.c
+++ b/gst/nnstreamer/tensor_common.c
@@ -616,8 +616,12 @@ gst_tensor_config_is_equal (const GstTensorConfig * c1,
   g_return_val_if_fail (c1 != NULL, FALSE);
   g_return_val_if_fail (c2 != NULL, FALSE);
 
-  /** @todo 1/2 == 2/4 Don't say they are different! */
-  if (c1->rate_n != c2->rate_n || c1->rate_d != c2->rate_d) {
+  if (c1->rate_d == 0 || c2->rate_d == 0) {
+    return FALSE;
+  }
+
+  if (gst_util_fraction_compare (c1->rate_n, c1->rate_d, c2->rate_n,
+          c2->rate_d) != 0) {
     return FALSE;
   }
 
@@ -742,7 +746,12 @@ gst_tensors_config_is_equal (const GstTensorsConfig * c1,
   g_return_val_if_fail (c1 != NULL, FALSE);
   g_return_val_if_fail (c2 != NULL, FALSE);
 
-  if (c1->rate_n != c2->rate_n || c1->rate_d != c2->rate_d) {
+  if (c1->rate_d == 0 || c2->rate_d == 0) {
+    return FALSE;
+  }
+
+  if (gst_util_fraction_compare (c1->rate_n, c1->rate_d, c2->rate_n,
+          c2->rate_d) != 0) {
     return FALSE;
   }
 

--- a/tests/common/unittest_common.cc
+++ b/tests/common/unittest_common.cc
@@ -430,6 +430,23 @@ fill_tensors_info_for_test (GstTensorsInfo * info1, GstTensorsInfo * info2)
 }
 
 /**
+ * @brief Internal function to update tensors info.
+ */
+static void
+fill_tensors_config_for_test (GstTensorsConfig * conf1, GstTensorsConfig * conf2)
+{
+  g_assert (conf1 != NULL && conf2 != NULL);
+
+  gst_tensors_config_init (conf1);
+  gst_tensors_config_init (conf2);
+
+  conf1->rate_n = conf2->rate_n = 1;
+  conf1->rate_d = conf2->rate_d = 2;
+
+  fill_tensors_info_for_test (&conf1->info, &conf2->info);
+}
+
+/**
  * @brief Test for same tensors info.
  */
 TEST (common_tensor_info, equal_01_p)
@@ -498,6 +515,86 @@ TEST (common_tensor_info, equal_05_n)
   info2.info[1].dimension[0] = 10;
 
   EXPECT_FALSE (gst_tensors_info_is_equal (&info1, &info2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_01_p)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+
+  EXPECT_TRUE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_02_p)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+  conf1.rate_n *= 2;
+  conf1.rate_d *= 2;
+
+  EXPECT_TRUE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_03_p)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+  conf1.rate_n *= 0;
+  conf2.rate_n *= 0;
+
+  EXPECT_TRUE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_04_n)
+{
+  GstTensorsConfig conf1, conf2;
+
+  gst_tensors_config_init (&conf1);
+  gst_tensors_config_init (&conf2);
+
+  EXPECT_FALSE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_05_n)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+  conf1.rate_n *= 2;
+  conf1.rate_d *= 4;
+
+  EXPECT_FALSE (gst_tensors_config_is_equal (&conf1, &conf2));
+}
+
+/**
+ * @brief Test for same tensors config.
+ */
+TEST (common_tensors_config, equal_06_n)
+{
+  GstTensorsConfig conf1, conf2;
+
+  fill_tensors_config_for_test (&conf1, &conf2);
+  conf1.rate_d *= 0;
+
+  EXPECT_FALSE (gst_tensors_config_is_equal (&conf1, &conf2));
 }
 
 /**


### PR DESCRIPTION
Added proper comparison of GstCaps framerate (1/2 == 2/4)
Added corresponding unittest cases

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>