### PR TITLE
[tflite/bug] Set accelerator bug solve

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -510,13 +510,12 @@ TFLiteInterpreter::moveInternals (TFLiteInterpreter& interp)
  * @note	the model of _model_path will be loaded simultaneously
  * @return	Nothing
  */
-TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators):
-  use_nnapi(false), accelerator(ACCL_AUTO)
+TFLiteCore::TFLiteCore (const char * _model_path, const char * accelerators)
 {
   interpreter.setModelPath (_model_path);
 
+  setAccelerator (accelerators);
   if (accelerators != NULL) {
-    setAccelerator (accelerators);
     g_message ("nnapi = %d, accl = %s", use_nnapi, get_accl_hw_str(accelerator));
   }
 }

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -80,95 +80,93 @@ gstTest "--gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} !
 
 # Test the backend setting done with tensorflow-lite
 # This also performs tests for generic backend configuration parsing
-if [ -f /etc/tizen-platform.conf ] || [[ ! -z $(cat /etc/motd | grep Tizen) ]]; then
-    function run_pipeline() {
-        gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} accelerator=$1 ! filesink location=tensorfilter.out.log 2>info
-    }
+function run_pipeline() {
+    gst-launch-1.0 --gst-plugin-path=${PATH_TO_PLUGIN} filesrc location=${PATH_TO_IMAGE} ! pngdec ! videoscale ! imagefreeze ! videoconvert ! video/x-raw,format=RGB,framerate=0/1 ! tensor_converter ! tensor_filter framework=tensorflow-lite model=${PATH_TO_MODEL} accelerator=$1 ! filesink location=tensorfilter.out.log 2>info
+}
 
-    # Property reading test for nnapi
-    run_pipeline true:cpu,npu,gpu
-    cat info | grep "nnapi = 1, accl = cpu"
-    testResult $? 2-1 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:cpu,npu,gpu
+cat info | grep "nnapi = 1, accl = cpu"
+testResult $? 2-1 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!cpu
-    cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-2 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!cpu
+cat info | grep "nnapi = 1, accl = auto"
+testResult $? 2-2 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!npu,gpu
-    cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-3 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!npu,gpu
+cat info | grep "nnapi = 1, accl = gpu"
+testResult $? 2-3 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!npu,gpu,abcd
-    cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-4 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!npu,gpu,abcd
+cat info | grep "nnapi = 1, accl = gpu"
+testResult $? 2-4 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!npu,!abcd,gpu
-    cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-5 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!npu,!abcd,gpu
+cat info | grep "nnapi = 1, accl = gpu"
+testResult $? 2-5 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:auto
-    cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-6 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:auto
+cat info | grep "nnapi = 1, accl = auto"
+testResult $? 2-6 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:default,cpu
-    cat info | grep "nnapi = 1, accl = default"
-    testResult $? 2-7 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:default,cpu
+cat info | grep "nnapi = 1, accl = default"
+testResult $? 2-7 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!cpu,default
-    cat info | grep "nnapi = 1, accl = default"
-    testResult $? 2-8 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!cpu,default
+cat info | grep "nnapi = 1, accl = default"
+testResult $? 2-8 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!default
-    cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-9 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!default
+cat info | grep "nnapi = 1, accl = auto"
+testResult $? 2-9 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:npu.srcn
-    cat info | grep "nnapi = 1, accl = npu"
-    testResult $? 2-10 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:npu.srcn
+cat info | grep "nnapi = 1, accl = npu"
+testResult $? 2-10 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline false:abcd
-    cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-11 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline false:abcd
+cat info | grep "nnapi = 0, accl = none"
+testResult $? 2-11 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline false
-    cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-12 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline false
+cat info | grep "nnapi = 0, accl = none"
+testResult $? 2-12 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:
-    cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-13 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:
+cat info | grep "nnapi = 1, accl = auto"
+testResult $? 2-13 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true
-    cat info | grep "nnapi = 1, accl = auto"
-    testResult $? 2-14 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true
+cat info | grep "nnapi = 1, accl = auto"
+testResult $? 2-14 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline auto
-    cat info | grep "nnapi = 0, accl = none"
-    testResult $? 2-15 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline auto
+cat info | grep "nnapi = 0, accl = none"
+testResult $? 2-15 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:!npu,abcd,gpu
-    cat info | grep "nnapi = 1, accl = gpu"
-    testResult $? 2-16 "NNAPI activation test" 0 1
+# Property reading test for nnapi
+run_pipeline true:!npu,abcd,gpu
+cat info | grep "nnapi = 1, accl = gpu"
+testResult $? 2-16 "NNAPI activation test" 0 1
 
-    # Property reading test for nnapi
-    run_pipeline true:cpu.neon,cpu
-    cat info | grep "nnapi = 1, accl = cpu.neon"
-    testResult $? 2-17 "NNAPI activation test" 0 1
-fi
+# Property reading test for nnapi
+run_pipeline true:cpu.neon,cpu
+cat info | grep "nnapi = 1, accl = cpu.neon"
+testResult $? 2-17 "NNAPI activation test" 0 1
 
 report


### PR DESCRIPTION
Bug: Not setting accelerator ignored the use_nnapi configuration - this is resolved
Enable setting accelerator unittest non-tizen platforms as well

See also #1849 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>