### PR TITLE
[Ext/Filter/TFLite] Enable a TensorFilter's property, verify_model_path 

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -249,10 +249,6 @@ TFLiteInterpreter::loadModel (bool use_nnapi)
   gint64 start_time = g_get_real_time ();
 #endif
 
-  if (!g_file_test (model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of model_path (%s) is not valid (not regular)\n", model_path);
-    return -1;
-  }
   model = tflite::FlatBufferModel::BuildFromFile (model_path);
   if (!model) {
     g_critical ("Failed to mmap model\n");
@@ -696,6 +692,12 @@ TFLiteCore::reloadModel (const char * _model_path)
 {
   int err;
 
+  if (!g_file_test (_model_path, G_FILE_TEST_IS_REGULAR)) {
+    g_critical ("The path of model file(s), %s, to reload is invalid.",
+        _model_path);
+    return -EINVAL;
+  }
+
   interpreter_sub.lock ();
   interpreter_sub.setModelPath (_model_path);
 
@@ -988,7 +990,7 @@ static GstTensorFilterFramework NNS_support_tensorflow_lite = {
   .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
   .allocate_in_invoke = FALSE,
   .run_without_model = FALSE,
-  .verify_model_path = FALSE,
+  .verify_model_path = TRUE,
   .invoke_NN = tflite_invoke,
   .getInputDimension = tflite_getInputDim,
   .getOutputDimension = tflite_getOutputDim,

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -500,8 +500,11 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
       g_assert (model_files);
       gst_tensor_filter_parse_modelpaths_string (prop, model_files);
 
-      /* reload model if FW has been already opened */
-      /* TODO: need to define the behaviur according to priv->fw->verify_model_path */
+      /**
+       * Reload model if FW has been already opened;
+       * In the case of reloading model files, each priv->fw (tensor filter for each nnfw)
+       * has responsibility for the verification of the path regardless of priv->fw->verify_model_path.
+       */
       if (priv->prop.fw_opened && priv->is_updatable) {
         if (priv->fw && priv->fw->reloadModel) {
           if (priv->fw->reloadModel (&priv->prop, &priv->privateData) != 0) {


### PR DESCRIPTION
This PR defines the behaviour of reloading model files when the GstTensorFilter's property, verify_model_path, is set to TRUE and enables it on the tensor filter for TensorFlow Lite.

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also: https://github.com/nnsuite/nnstreamer/pull/1999
CC: @dongju-chae 

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped