### PR TITLE
[Tests/FilterExtCommon] hotfix: Fix build errors, dangling-else

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc
@@ -309,8 +309,9 @@ TEST (nnstreamer_EXT_NICK_NAME_basic_functions, invoke)
   /** should never crash */
   ret = sp->invoke_NN (&prop, &data, &input, &output);
   /** should be successful for single input/output case */
-  if (num_inputs == 1 && num_outputs == 1)
+  if (num_inputs == 1 && num_outputs == 1) {
     EXPECT_EQ (ret, 0);
+  }
 
   g_free (input.data);
   g_free (output.data);


### PR DESCRIPTION
This PR fixes build errors in the source code generated from unittest_tizen_template.c.

```bash
error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=dangling-else]
```

Even if #2014 also fixes those build errors, I think that it is better to merge this simple hotfix than to wait for merging #2014.

Signed-off-by: Wook Song <wook16.song@samsung.com>

See also: #2014

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [*]Skipped
2. Run test: [*]Passed [ ]Failed [*]Skipped