### PR TITLE
[Tests/FilterExtCommon] Fix test case failure @open sesame 1/16 15:47

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -56,7 +56,7 @@ gchar ** get_model_files ()
 {
   gchar *model_file, *model_filepath;
   gchar *model_path;
-  const gchar *model_filenames = "MODEL_FILE";
+  const gchar *model_filenames = "@MODEL_FILE@";
   const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar **model_files, **model_files_iterator;
   gchar *dirname;


### PR DESCRIPTION
This patch fixes failure in the test cases generated from unittest_tizen_template.cc.in. This is a bug of [1]

[1] cbb65b01278b39789e69c6de888b3e0e78b3e5db

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped


Signed-off-by: Wook Song <wook16.song@samsung.com>