### PR TITLE
New Filter Subplugin Interface Draft: C++ support

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.hh
@@ -28,6 +28,13 @@
  * @note This is experimental. The API and Class definition is NOT stable.
  *       If you want to write an OpenCV custom filter for nnstreamer, this is a good choice.
  *
+ * @details
+ *    This is a subplugin for C++ custom filters.
+ *    If you want to write a wrapper for neural network frameworks
+ *    or a hardware adaptor in C++, this is not for you.
+ *    If you want to attach a single C++ class/object as a filter
+ *    (a.k.a. custom filter) to a pipeline, this is what you want.
+ *
  * To Packagers:
  *
  * This is to be exposed with "nnstreamer-c++-dev"

--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -376,7 +376,11 @@ typedef struct _GstTensorFilterFramework
         * @param[in] private_data A subplugin may save its internal private data here.
         * @return 0 if supported. -errno if not supported.
         */
-    };
+    }
+#ifdef __NO_ANONYMOUS_NESTED_STRUCT
+        v0
+#endif
+    ;
 
     /**
      * @brief Tensor_Filter Subplugin definition Version 1
@@ -448,7 +452,12 @@ typedef struct _GstTensorFilterFramework
        * @param[in/out] data user sata for the supported handlers (can be NULL)
        * @return 0 if OK. non-zero if error. -ENOENT if operation is not supported. -EINVAL if operation is supported but provided arguments are invalid.
        */
-    };
+      void *subplugin_data; /**< A subplugin may store its own private global data here as well. Do not store data of each instance here, it is shared across all instances of a subplugin. */
+    }
+#ifdef __NO_ANONYMOUS_NESTED_STRUCT
+        v1
+#endif
+    ;
   };
 } GstTensorFilterFramework;
 

--- a/gst/nnstreamer/tensor_filter/meson.build
+++ b/gst/nnstreamer/tensor_filter/meson.build
@@ -8,3 +8,7 @@ tensor_filter_sources = [
 foreach s : tensor_filter_sources
   nnstreamer_sources += join_paths(meson.current_source_dir(), s)
 endforeach
+
+if get_option('enable-filter-cpp-class')
+  nnstreamer_sources += join_paths(meson.current_source_dir(), 'tensor_filter_support_cc.cc')
+endif

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.cc
@@ -1,0 +1,246 @@
+/**
+ * GStreamer Tensor_filter, C++ Subplugin Support. (this is not a subplugin)
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file	tensor_filter_support_cc.cc
+ * @date	22 Jan 2020
+ * @brief	Base class for tensor_filter subplugins of C++ classes.
+ * @see		http://github.com/nnsuite/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * @details
+ *    This is not a subplugin, but a helper for C++ subplugins.
+ *    If you want to write a wrapper for neural network frameworks
+ *    or a hardware adaptor in C++, this is what you want.
+ *    If you want to attach a single C++ class/object as a filter
+ *    (a.k.a. custom filter) to a pipeline, use tensor_filter_cpp
+ */
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+#include <type_traits>
+#endif
+
+#define __NO_ANONYMOUS_NESTED_STRUCT
+#include <nnstreamer_plugin_api_filter.h>
+#undef __NO_ANONYMOUS_NESTED_STRUCT
+
+#include "tensor_filter_support_cc.hh"
+
+namespace nnstreamer {
+
+/******************************************************
+ ** Class methods of tensor_filter_subplugin (base)  **
+ ******************************************************/
+
+#define _SANITY_CHECK (0xFACE217714DEADE7ULL)
+
+/**
+ * @brief C tensor-filter wrapper callback function, "open"
+ */
+int tensor_filter_subplugin::cpp_open (const GstTensorFilterProperties * prop,
+    void **private_data)
+{
+  const GstTensorFilterFramework * tfsp = nnstreamer_filter_find (prop->fwname);
+
+  assert (tfsp);
+  assert (tfsp->version == GST_TENSOR_FILTER_FRAMEWORK_V1);
+
+  /* 1. Fetch stored empty object from subplugin api (subplugin_data) */
+  tensor_filter_subplugin *sp = (tensor_filter_subplugin *) tfsp->v1.subplugin_data;
+  assert (sp->sanity == _SANITY_CHECK); /** tfsp is using me! */
+
+  /* 2. Spawn another empty object and configure the empty object */
+  tensor_filter_subplugin &obj = sp->getEmptyInstance();
+  obj.configure_instance (prop);
+
+  /* 3. Mark that this is not a representative (found by nnstreamer_filter_find) empty object */
+  obj.fwdesc.v1.subplugin_data = nullptr;
+
+  /* 4. Save the object as *private_data */
+  *private_data = &obj;
+
+  return 0;
+}
+
+#define start_up(t, p) \
+  tensor_filter_subplugin *t = (tensor_filter_subplugin *) p; \
+  assert (t); \
+  assert (t->sanity == _SANITY_CHECK); \
+  assert (t->fwdesc.v1.subplugin_data == nullptr);
+
+/**
+ * @brief C tensor-filter wrapper callback function, "close"
+ */
+void tensor_filter_subplugin::cpp_close (const GstTensorFilterProperties * prop,
+    void **private_data)
+{
+  start_up (obj, *private_data);
+
+  *private_data = nullptr;
+  delete obj;
+}
+
+/**
+ * @brief C V1 tensor-filter wrapper callback function, "invoke"
+ */
+int tensor_filter_subplugin::cpp_invoke (const GstTensorFilterProperties *prop,
+    void *private_data, const GstTensorMemory *input,
+    GstTensorMemory *output)
+{
+  start_up (obj, private_data);
+  return obj->invoke (*input, *output);
+}
+
+/**
+ * @brief C V1 tensor-filter wrapper callback function, "getFrameworkInfo"
+ */
+int tensor_filter_subplugin::cpp_getFrameworkInfo (const GstTensorFilterProperties * prop,
+    void *private_data, GstTensorFilterFrameworkInfo *fw_info)
+{
+  start_up (obj, private_data);
+  return obj->getFrameworkInfo (*fw_info);
+}
+
+/**
+ * @brief C V1 tensor-filter wrapper callback function, "getModelInfo"
+ */
+int tensor_filter_subplugin::cpp_getModelInfo (const GstTensorFilterProperties * prop,
+    void *private_data, model_info_ops ops,
+    GstTensorsInfo *in_info, GstTensorsInfo *out_info)
+{
+  start_up (obj, private_data);
+  return obj->getModelInfo (ops, *in_info, *out_info);
+}
+
+/**
+ * @brief C V1 tensor-filter wrapper callback function, "eventHandler"
+ */
+int tensor_filter_subplugin::cpp_eventHandler (const GstTensorFilterProperties * prop,
+    void *private_data, event_ops ops, GstTensorFilterFrameworkEventData *data)
+{
+  start_up (obj, private_data);
+  return obj->eventHandler (ops, *data);
+}
+
+/**
+ * @brief The template for fwdesc, the C wrapper (V1) struct.
+ */
+const GstTensorFilterFramework tensor_filter_subplugin::fwdesc_template = {
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V1,
+  .open = cpp_open,
+  .close = cpp_close,
+  {
+    .v1 = {
+      .invoke = cpp_invoke,
+      .getFrameworkInfo = cpp_getFrameworkInfo,
+      .getModelInfo = cpp_getModelInfo,
+      .eventHandler = cpp_eventHandler,
+      .subplugin_data = nullptr,
+    }
+  }
+};
+
+/**
+ * @brief Register the subplugin "derived" class.
+ * @detail A derived class MUST register itself with this function in order
+ *         to be available for nnstreamer pipelines, i.e., at its init().
+ *         The derived class type should be the template typename.
+ * @retval Returns an "emptyInstnace" of the derived class. It is recommended
+ *         to keep the object and feed to the unregister function.
+ */
+template<typename T>
+T * tensor_filter_subplugin::register_subplugin ()
+{
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+  /** The given class T should be derived from tensor_filter_subplugin */
+  assert ((std::is_base_of<tensor_filter_subplugin, T>::value));
+#endif
+
+  T *emptyInstance = T::T();
+
+  assert (emptyInstance);
+
+  memcpy (&emptyInstance->fwdesc, &fwdesc_template, sizeof (fwdesc_template));
+  emptyInstance->fwdesc.subplugin_data = emptyInstance;
+
+  nnstreamer_filter_probe (&emptyInstance->fwdesc);
+
+  return emptyInstance;
+}
+
+/**
+ * @brief Unregister the registered "derived" class.
+ * @detail The registered derived class may unregister itself if it can
+ *         guarantee that the class won't be used anymore; i.e., at its exit().
+ *         The derived class type should be the template typename.
+ * @param [in] emptyInstance An emptyInstance that mey be "delete"d by this
+ *             function. It may be created by getEmptyInstance() or the one
+ *             created by register_subplugin(); It is recommended to keep
+ *             the object created by register_subplugin() and feed it to
+ *             unregister_subplugin().
+ */
+template<typename T>
+void tensor_filter_subplugin::unregister_subplugin (T * emptyInstance)
+{
+  GstTensorFilterFrameworkInfo info;
+#if __cplusplus < 201103L
+#warn C++11 is required for safe execution
+#else
+  /** The given class T should be derived from tensor_filter_subplugin */
+  assert((std::is_base_of<tensor_filter_subplugin, T>::value));
+#endif
+  assert (emptyInstance);
+
+  emptyInstance->getFrameworkInfo (&info);
+  nnstreamer_filter_exit (info.name);
+
+  delete emptyInstance;
+}
+
+/**
+ * @brief Base constructor. The object represents a non-functional empty anchor
+ */
+tensor_filter_subplugin::tensor_filter_subplugin ():
+    sanity(_SANITY_CHECK)
+{
+  memcpy (&fwdesc, &fwdesc_template, sizeof (fwdesc_template));
+}
+
+/**
+ * @brief Base destructor. The object represents a single GST element instance in a pipeline
+ */
+tensor_filter_subplugin::~tensor_filter_subplugin ()
+{
+  /* Nothing to do */
+}
+
+/**
+ * @brief Base eventHandler, which does nothing!
+ */
+int tensor_filter_subplugin::eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data)
+{
+  return 0;
+}
+
+} /* namespace nnstreamer */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.hh
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_support_cc.hh
@@ -1,0 +1,126 @@
+/**
+ * GStreamer Tensor_filter, C++ Subplugin Support. (this is not a subplugin)
+ * Copyright (C) 2020 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file	tensor_filter_support_cc.h
+ * @date	15 Jan 2020
+ * @brief	Base class for tensor_filter subplugins of C++ classes.
+ * @see		http://github.com/nnsuite/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs except for NYI items
+ *
+ * @details
+ *    This is not a subplugin, but a helper for C++ subplugins.
+ *    If you want to write a wrapper for neural network frameworks
+ *    or a hardware adaptor in C++, this is what you want.
+ *    If you want to attach a single C++ class/object as a filter
+ *    (a.k.a. custom filter) to a pipeline, use tensor_filter_cpp
+ *
+ * To Packagers:
+ *
+ * This is to be exposed with "nnstreamer-c++-dev"
+ */
+#ifndef __NNS_TENSOR_FILTER_CPP_SUBPLUGIN_SUPPORT_H__
+#define __NNS_TENSOR_FILTER_CPP_SUBPLUGIN_SUPPORT_H__
+#ifdef __cplusplus
+
+#include <stdint.h>
+#include <nnstreamer_plugin_api_filter.h>
+
+namespace nnstreamer {
+/**
+ * @brief The base class for C++ subplugins. Derive this to write one.
+ *
+ * @detail The subplugin writers (derived class writer) are supposed to
+ *        write virtual functions for their subplugins. They may
+ *        add their own data structures as well in the derived class.
+ *         Unlike C-version, constructing an object will automatically
+ *        register(probe) the subplugin for nnstreamer.
+ *         Optional virtual functions (non pure virtual functions) may
+ *        be kept un-overriden if you don't support such.
+ *         For getInput/Output and setInput, return -EINVAL if you don't
+ *        support it.
+ *
+ *         We support tensor_filter_subplugin V1 only. (NNStreamer 1.5.1 or higher)
+ **/
+class tensor_filter_subplugin {
+  private: /** Derived classes should NEVER access these */
+    const uint64_t sanity; /**< Checks if dlopened obejct is really tensor_filter_subplugin */
+
+    static const GstTensorFilterFramework fwdesc_template; /**< Template for fwdesc. Each subclass or object may have different subplugin_data while the C callbacks are identical. Thus, we copy C callbacks from this template to fwdesc and let each subplugin start customizing based on fwdesc, not on fwdesc_template */
+
+    /** tensor_filter/C wrapper functions */
+    static int cpp_open (const GstTensorFilterProperties * prop, void **private_data); /**< C wrapper func, open */
+    static void cpp_close (const GstTensorFilterProperties * prop, void **private_data); /**< C wrapper func, close */
+    static int cpp_invoke (const GstTensorFilterProperties *prop, void *private_data, const GstTensorMemory *input, GstTensorMemory *output); /**< C V1 wrapper func, invoke */
+    static int cpp_getFrameworkInfo (const GstTensorFilterProperties * prop, void *private_data, GstTensorFilterFrameworkInfo *fw_info); /**< C V1 wrapper func, getFrameworkInfo */
+    static int cpp_getModelInfo (const GstTensorFilterProperties * prop, void *private_data, model_info_ops ops, GstTensorsInfo *in_info, GstTensorsInfo *out_info); /**< C V1 wrapper func, getModelInfo */
+    static int cpp_eventHandler (const GstTensorFilterProperties * prop, void *private_data, event_ops ops, GstTensorFilterFrameworkEventData *data); /**< C V1 wrapper func, eventHandler */
+
+    GstTensorFilterFramework fwdesc; /**< Represents C/V1 wrapper for the derived class and its objects. Derived should not access this anyway; the base class will handle this with the C wrapper functions, base static-functions, and base constructors/destructors. */
+
+  protected: /** Derived classes should call these at init/exit */
+    template<typename T>
+    static T * register_subplugin ();
+        /**< Register this subplugin class (not object) (usually at so-init)
+          * @retval: an empty instance for unregister_subplugin */
+
+    template<typename T>
+    static void unregister_subplugin (T * emptyInstance);
+        /**< Unregister this subplugin class (not object) (usually at so-exit) */
+
+  public:
+    /*************************************************************
+     ** These should be filled/implemented by subplugin authors **
+     *************************************************************/
+    tensor_filter_subplugin ();
+        /**< Creates a non-functional "empty" object
+             Subplugin (derived class) should make a constructor with same role and input arguments!
+          */
+
+    virtual tensor_filter_subplugin & getEmptyInstance () = 0;
+        /**< Return a newly created "empty" object of the derived class. */
+
+    virtual void configure_instance (const GstTensorFilterProperties *prop) = 0;
+        /**< Configure a non-functional "empty" object as a
+             functional "filled" object ready to be invoked */
+
+    virtual ~tensor_filter_subplugin (); /**< called by Close */
+
+    virtual int invoke (const GstTensorMemory &input, GstTensorMemory &output) = 0;
+        /**< Mandatory virtual method.  Invoke NN */
+
+    virtual int getFrameworkInfo (GstTensorFilterFrameworkInfo &info) = 0;
+        /**< Mandatory virtual method.
+          * An empty instance created by derived() should support this with
+          * its default info value.
+          * "name" property of info should NEVER be changed.
+          */
+
+    virtual int getModelInfo (model_info_ops ops, GstTensorsInfo &in_info, GstTensorsInfo &out_info) = 0;
+        /**< Mandatory virtual method.
+          *  For a given opened model (an instance of the derived class),
+          * provide input/output dimensions.
+          *  At least one of the two possible ops should be available.
+          *  Return -ENOENT if an operation is not available */
+
+    virtual int eventHandler (event_ops ops, GstTensorFilterFrameworkEventData &data);
+        /**< Optional. If not implemented, no event is handled */
+};
+
+} /* namespace nnstreamer */
+
+#endif /* __cplusplus */
+#endif /* __NNS_TENSOR_FILTER_CPP_SUBPLUGIN_SUPPORT_H__ */

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,7 +20,8 @@ option('restricted-elements', type: 'string', value: '')
 option('enable-tflite-nnapi-delegation', type: 'boolean', value: false) # true to enable tensorflow-lite to delegate nnapi interpretation to nnfw backend in tizen
 option('enable-nnfw-runtime', type: 'boolean', value: false) # true to enable nnfw tensor filter element
 option('nnfw-runtime-prioritize', type: 'boolean', value: false) # true to set higher priority for nnfw for tflite extension files in auto mode
-option('enable-cppfilter', type: 'boolean', value: true)
+option('enable-cppfilter', type: 'boolean', value: true) # Allows C++ custom filters
+option('enable-filter-cpp-class', type: 'boolean', value: false) # Allows to accept C++ classes as filter subplugin implementation.
 option('enable-tizen-sensor', type: 'boolean', value: false)
 option('enable-edgetpu', type: 'boolean', value: false)
 option('enable-armnn', type: 'boolean', value: false)


### PR DESCRIPTION
With this, developers can write a C++ class to create
a tensor_filter subplugin without writing the duplicated
C codes.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

Changes in V2:
- Redesigned the whole classes
- Applied the recent changes of #2072
Changes in V3:
- Re-redesigned the whole class.
- Build tested without subplugins

TODOS in later PRs:
- Refactor a few subplugins as pure C++ classes and test/update this class.
- Add packaging info
- Add more inline doxygen comments.


With this PR completed in the future, we can remove all the duplicated C code in C++ subplugins.