### PR TITLE
[Meson] Disable external filters for pytorch, caffe2, tf-lite by default 

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,9 @@ override_dh_auto_clean:
 
 override_dh_auto_configure:
 	mkdir -p build
-	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include -Dinstall-example=true -Denable-tensorflow=$(enable_tf) -Denable-capi=true -Denable-tizen=false build
+	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
+	-Dinstall-example=true -Denable-tensorflow=$(enable_tf) -Denable-tensorflow-lite=true -Denable-pytorch=true -Denable-caffe2=true \
+	-Denable-capi=true -Denable-tizen=false build
 
 override_dh_auto_build:
 	ninja -C build

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,10 @@
 option('enable-test', type: 'boolean', value: true)
 option('enable-orc', type: 'boolean', value: true) # default true, use orc when found orc library
 option('install-test', type: 'boolean', value: false)
-option('enable-tensorflow-lite', type: 'boolean', value: true)
-option('enable-tensorflow', type: 'boolean', value: true)
-option('enable-caffe2', type: 'boolean', value: true)
-option('enable-pytorch', type: 'boolean', value: true)
+option('enable-tensorflow-lite', type: 'boolean', value: false)
+option('enable-tensorflow', type: 'boolean', value: false)
+option('enable-caffe2', type: 'boolean', value: false)
+option('enable-pytorch', type: 'boolean', value: false)
 option('enable-pytorch-use-gpu', type: 'boolean', value: false) # default value, can be specified at run time
 option('enable-movidius-ncsdk2', type: 'boolean', value: false)
 option('install-example', type: 'boolean', value: false)

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -3,8 +3,11 @@
 %define		gstlibdir	%{_libdir}/%{gstpostfix}
 %define		nnstexampledir	/usr/lib/nnstreamer/bin
 %define		tensorflow_support	0
+%define		tensorflow_lite_support	1
 %define		armnn_support 0
 %define		python_support 1
+%define		pytorch_support 0
+%define		caffe2_support 0
 
 %ifnarch %arm aarch64
 %define armnn_support 0
@@ -55,8 +58,10 @@ BuildRequires:	python-numpy-devel
 %endif
 # Testcase requires bmp2png, which requires libpng
 BuildRequires:  pkgconfig(libpng)
+%if 0%{?tensorflow_lite_support}
 # for tensorflow-lite
 BuildRequires: tensorflow-lite-devel
+%endif
 # custom_example_opencv filter requires opencv-devel
 BuildRequires: opencv-devel
 # For './testAll.sh' time limit.
@@ -142,12 +147,15 @@ Thus, the user needs to check the version of Tensorflow with the
 Tensorflow used for building this package.
 %endif
 
+# for tensorflow-lite
+%if 0%{?tensorflow_lite_support}
 %package tensorflow-lite
 Summary:	NNStreamer TensorFlow Lite Support
 Requires:	nnstreamer = %{version}-%{release}
 # tensorflow-lite provides .a file and it's embedded into the subplugin. No dep to tflite.
 %description tensorflow-lite
 NNStreamer's tensor_fliter subplugin of TensorFlow Lite.
+%endif
 
 %if 0%{?python_support}
 %package -n nnstreamer-python2
@@ -287,6 +295,26 @@ You may enable this package to use Google Edge TPU with NNStreamer and Tizen ML 
 %else
 %define enable_tf -Denable-tensorflow=false
 %endif
+# Support tensorflow-lite
+%if 0%{?tensorflow_lite_support}
+%define enable_tf_lite -Denable-tensorflow-lite=true
+%else
+%define enable_tf_lite -Denable-tensorflow-lite=false
+%endif
+
+# Support pytorch
+%if 0%{?pytorch_support}
+%define enable_pytorch -Denable-pytorch=true
+%else
+%define enable_pytorch -Denable-pytorch=false
+%endif
+
+# Support caffe2
+%if 0%{?caffe2_support}
+%define enable_caffe2 -Denable-caffe2=true
+%else
+%define enable_caffe2 -Denable_caffe2=false
+%endif
 
 # Support ArmNN
 %if 0%{?armnn_support}
@@ -334,7 +362,7 @@ mkdir -p build
 meson --buildtype=plain --prefix=%{_prefix} --sysconfdir=%{_sysconfdir} --libdir=%{_libdir} \
 	--bindir=%{nnstexampledir} --includedir=%{_includedir} -Dinstall-example=true \
 	%{enable_api} %{enable_tizen} %{element_restriction} -Denable-env-var=false -Denable-symbolic-link=false \
-	-Denable-pytorch=false -Denable-caffe2=false %{enable_tf} %{enable_python} \
+	%{enable_tf_lite} %{enable_tf} %{enable_pytorch} %{enable_caffe2} %{enable_python} \
 	%{enable_nnfw_runtime} %{enable_mvncsdk2} %{enable_armnn} %{enable_edgetpu} \
 	build
 
@@ -455,10 +483,12 @@ cp -r result %{buildroot}%{_datadir}/nnstreamer/unittest/
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow.so
 %endif
 
+%if 0%{?tensorflow_lite_support}
 %files tensorflow-lite
 %manifest nnstreamer.manifest
 %defattr(-,root,root,-)
 %{_prefix}/lib/nnstreamer/filters/libnnstreamer_filter_tensorflow-lite.so
+%endif
 
 %if 0%{?python_support}
 %files -n nnstreamer-python2


### PR DESCRIPTION
This PR disables by default the tensor filters to support external neural network frameworks such as pytorch, caffe2, and tensorflow-lite in the meson_options.txt file. According to this change, the .spec and rules files are also modified as well.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>