### PR TITLE
[Meson] Make 'enable-edgetpu' depend on 'enable-tensorflow-lite'

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -284,24 +284,28 @@ if get_option('enable-cppfilter')
 endif
 
 if get_option('enable-edgetpu')
-  edgetpu_dep = dependency('edgetpu', required: false)
-  if not edgetpu_dep.found()
-    # Ubuntu edgetpu package does not have pkgconfig file
-    edgetpu_dep = cc.find_library('edgetpu')
+  if get_option('enable-tensorflow-lite')
+    edgetpu_dep = dependency('edgetpu', required: false)
+    if not edgetpu_dep.found()
+      # Ubuntu edgetpu package does not have pkgconfig file
+      edgetpu_dep = cc.find_library('edgetpu')
+    endif
+    filter_sub_edgetpu_sources = ['tensor_filter_edgetpu.cc']
+
+    nnstreamer_filter_edgetpu_sources = []
+    foreach s : filter_sub_edgetpu_sources
+      nnstreamer_filter_edgetpu_sources += join_paths(meson.current_source_dir(), s)
+    endforeach
+
+    shared_library('nnstreamer_filter_edgetpu',
+      nnstreamer_filter_edgetpu_sources,
+      dependencies: [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, tflite_dep],
+      install: true,
+      install_dir: filter_subplugin_install_dir
+    )
+  else
+    error ('enable-tensorflow-lite should be set as \'true\' to build the tensor filter for Edge TPU.')
   endif
-  filter_sub_edgetpu_sources = ['tensor_filter_edgetpu.cc']
-
-  nnstreamer_filter_edgetpu_sources = []
-  foreach s : filter_sub_edgetpu_sources
-    nnstreamer_filter_edgetpu_sources += join_paths(meson.current_source_dir(), s)
-  endforeach
-
-  shared_library('nnstreamer_filter_edgetpu',
-    nnstreamer_filter_edgetpu_sources,
-    dependencies: [glib_dep, gst_dep, nnstreamer_dep, edgetpu_dep, tflite_dep],
-    install: true,
-    install_dir: filter_subplugin_install_dir
-  )
 endif
 
 if get_option('enable-openvino')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -138,7 +138,7 @@ if get_option('enable-nnfw-runtime')
   subdir('tizen_nnfw_runtime')
 endif
 
-if get_option('enable-edgetpu')
+if get_option('enable-tensorflow-lite') and get_option('enable-edgetpu')
   subdir('nnstreamer_filter_edgetpu')
 endif
 


### PR DESCRIPTION
In order to handle the case that 'enable-edgetpu' is set to 'true', meson requires a variable, 'tflite dep', which is a declaration of a dependency on TensorFlow-Lite. Therefore, the 'enable-edgetpu' option
alone cannot properly set the feature. This patch fixes this issue.

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>