### PR TITLE
[Test] input memory to invoke filter-plugins

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -215,10 +215,12 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, get_dimension)
   /** python subplugin modifies methods based on model file */
   if (sp->getInputDimension && sp->getOutputDimension) {
     /** get input/output dimension successfully */
+    gst_tensors_info_init (&res);
     ret = sp->getInputDimension (&prop, &data, &res);
     gst_tensors_info_free (&res);
     EXPECT_EQ (ret, 0);
 
+    gst_tensors_info_init (&res);
     ret = sp->getOutputDimension (&prop, &data, &res);
     gst_tensors_info_free (&res);
     EXPECT_EQ (ret, 0);
@@ -236,7 +238,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke_fail_n)
 {
   int ret;
   void *data = NULL;
-  GstTensorMemory input, output;
+  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { 0, };
   gchar **model_files;
 
   model_files = get_model_files ();
@@ -253,27 +256,27 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke_fail_n)
   EXPECT_NE (sp, (void *) NULL);
 
   /** invoke without open */
-  ret = sp->invoke_NN (&prop, &data, &input, &output);
+  ret = sp->invoke_NN (&prop, &data, input, output);
   EXPECT_NE (ret, 0);
 
   ret = sp->open (&prop, &data);
   EXPECT_EQ (ret, 0);
 
-  input.type = output.type = _NNS_FLOAT32;
-  input.size = output.size = 1 * gst_tensor_get_element_size (output.type);
-  input.data = g_malloc (input.size);
-  output.data = g_malloc (output.size);
+  input[0].type = output[0].type = _NNS_FLOAT32;
+  input[0].size = output[0].size = 1 * gst_tensor_get_element_size (output[0].type);
+  input[0].data = g_malloc (input[0].size);
+  output[0].data = g_malloc (output[0].size);
 
   /** invoke unsuccessful */
   ret = sp->invoke_NN (&prop, &data, NULL, NULL);
   EXPECT_NE (ret, 0);
-  ret = sp->invoke_NN (&prop, &data, &input, NULL);
+  ret = sp->invoke_NN (&prop, &data, input, NULL);
   EXPECT_NE (ret, 0);
-  ret = sp->invoke_NN (&prop, &data, NULL, &output);
+  ret = sp->invoke_NN (&prop, &data, NULL, output);
   EXPECT_NE (ret, 0);
 
-  g_free (input.data);
-  g_free (output.data);
+  g_free (input[0].data);
+  g_free (output[0].data);
 
   sp->close (&prop, &data);
   g_strfreev (model_files);
@@ -286,10 +289,11 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
 {
   int ret;
   void *data = NULL;
-  GstTensorMemory input, output;
+  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { 0, };
   gchar **model_files;
-  GstTensorsInfo res;
-  int num_inputs, num_outputs;
+  GstTensorsInfo input_info, output_info;
+  guint i;
 
   model_files = get_model_files ();
   ASSERT_TRUE (model_files != nullptr);
@@ -311,51 +315,54 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
       (sp->setInputDimension));
 
   /** Decide the size for input and output */
+  gst_tensors_info_init (&input_info);
+  gst_tensors_info_init (&output_info);
+
   if (sp->getInputDimension && sp->getOutputDimension) {
-    gst_tensors_info_init (&res);
-    ret = sp->getOutputDimension (&prop, &data, &res);
+    ret = sp->getInputDimension (&prop, &data, &input_info);
     EXPECT_EQ (ret, 0);
-    output.size = gst_tensor_info_get_size (&res.info[0]);
-    output.type = res.info[0].type;
-    num_outputs = res.num_tensors;
-    gst_tensors_info_free (&res);
 
-    gst_tensors_info_init (&res);
-    ret = sp->getInputDimension (&prop, &data, &res);
+    ret = sp->getOutputDimension (&prop, &data, &output_info);
     EXPECT_EQ (ret, 0);
-    input.size = gst_tensor_info_get_size (&res.info[0]);
-    input.type = res.info[0].type;
-    num_inputs = res.num_tensors;
-    gst_tensors_info_free (&res);
   } else {
-    res.num_tensors = 1;
-    res.info[0].type = _NNS_FLOAT32;
-    res.info[0].dimension[0] = 10;
-    res.info[0].dimension[1] = 1;
-    res.info[0].dimension[2] = 1;
-    res.info[0].dimension[3] = 1;
-
-    input.size = gst_tensor_info_get_size (&res.info[0]);
-    input.type = res.info[0].type;
-    num_inputs = res.num_tensors;
-    output.size = gst_tensor_info_get_size (&res.info[0]);
-    output.type = res.info[0].type;
-    num_outputs = res.num_tensors;
+    input_info.num_tensors = output_info.num_tensors = 1;
+    input_info.info[0].type = output_info.info[0].type = _NNS_FLOAT32;
+    input_info.info[0].dimension[0] = output_info.info[0].dimension[0] = 10;
+    input_info.info[0].dimension[1] = output_info.info[0].dimension[1] = 1;
+    input_info.info[0].dimension[2] = output_info.info[0].dimension[2] = 1;
+    input_info.info[0].dimension[3] = output_info.info[0].dimension[3] = 1;
   }
 
-  input.data = g_malloc (input.size);
-  output.data = g_malloc (output.size);
+  for (i = 0; i < input_info.num_tensors; ++i) {
+    input[i].size = gst_tensor_info_get_size (&input_info.info[i]);
+    input[i].type = input_info.info[i].type;
+    input[i].data = g_malloc (input[i].size);
+  }
+
+  for (i = 0; i < output_info.num_tensors; ++i) {
+    output[i].size = gst_tensor_info_get_size (&output_info.info[i]);
+    output[i].type = output_info.info[i].type;
+    output[i].data = g_malloc (output[i].size);
+  }
 
   /** should never crash */
-  ret = sp->invoke_NN (&prop, &data, &input, &output);
+  ret = sp->invoke_NN (&prop, &data, input, output);
   /** should be successful for single input/output case */
-  if (sp->getInputDimension && sp->getOutputDimension && num_inputs == 1
-      && num_outputs == 1) {
+  if (sp->getInputDimension && sp->getOutputDimension &&
+      input_info.num_tensors > 0 && output_info.num_tensors > 0) {
     EXPECT_EQ (ret, 0);
   }
 
-  g_free (input.data);
-  g_free (output.data);
+  for (i = 0; i < input_info.num_tensors; ++i) {
+    g_free (input[i].data);
+  }
+
+  for (i = 0; i < output_info.num_tensors; ++i) {
+    g_free (output[i].data);
+  }
+
+  gst_tensors_info_free (&input_info);
+  gst_tensors_info_free (&output_info);
 
   sp->close (&prop, &data);
   g_strfreev (model_files);


### PR DESCRIPTION
Set max array for input and output tensor-memory to prevent out-of-index exception.

Invoke-callback requires the array of tensor memories.
Now this does not make an error, but later if we try to generate another testcase with multi-tensors, it needs to set the array of tensor data.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
