### PR TITLE
[Split] Fix a build warning incurred by a may-be-uninitialized variable

### DIFF
--- a/gst/nnstreamer/tensor_split/gsttensorsplit.c
+++ b/gst/nnstreamer/tensor_split/gsttensorsplit.c
@@ -643,14 +643,17 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
     }
     case PROP_TENSORSEG:
     {
-      if (split->tensorseg && split->tensorseg->len > 0) {
+      if ((split->tensorseg) && (split->tensorseg->len > 0)) {
         tensor_dim *dim = NULL;
+        gchar *strv = NULL;
         int i, j;
-        gchar **strings;
-        gchar *p, *strv;
+
 
         for (i = 0; i < split->tensorseg->len; i++) {
           GPtrArray *arr = g_ptr_array_new ();
+          gchar *p = NULL;
+          gchar **strings;
+
           dim = g_array_index (split->tensorseg, tensor_dim *, i);
           for (j = 0; j < NNS_TENSOR_RANK_LIMIT; j++) {
             g_ptr_array_add (arr, g_strdup_printf ("%i", (*dim)[j]));
@@ -673,7 +676,8 @@ gst_tensor_split_get_property (GObject * object, guint prop_id,
             strv = p;
           }
         }
-        g_value_take_string (value, strv);
+        /* the second parameter, strv (i.e., gchar *v_string), is nullable */
+        g_value_take_string (value, strv ? strv : g_strdup (""));
       } else {
         g_value_set_string (value, "");
       }


### PR DESCRIPTION
While build with GBS using the latest base and unified repository, the compiler complains about a variable that is used without initialization. Even though it looks a false-positive, this PR eliminates this build warning.

```bash
[   63s] FAILED: gst/nnstreamer/73d9e45@@nnstreamer@sha/gsttensorsplit.c.o 
[   63s] cc -Igst/nnstreamer/73d9e45@@nnstreamer@sha -Igst/nnstreamer -I../gst/nnstreamer -Igst/nnstreamer/tensor_transform -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/gstreamer-1.0 -I/usr/include/orc-0.4 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Werror -std=gnu89 '-DVERSION="1.3.0"' -D__TIZEN__=1 -Wredundant-decls -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Waddress -Wno-multichar -Wvla -Wpointer-arith -Wmissing-declarations -Wmissing-include-dirs -Wmissing-prototypes -Wnested-externs -Waggregate-return -Wold-style-definition -Wdeclaration-after-statement '-DNNSTREAMER_CONF_FILE="/etc/nnstreamer.ini"' -DHAVE_ORC=1 -DENABLE_TENSORFLOW_LITE=1 -O2 -g2 -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector -Wformat-security -fmessage-length=0 -Wl,--as-needed -feliminate-unused-debug-types --param=ssp-buffer-size=4 -fdiagnostics-color=never -m64 -march=nehalem -msse4.2 -mfpmath=sse -fasynchronous-unwind-tables -fno-omit-frame-pointer -g -fprofile-arcs -ftest-coverage -fPIC -pthread -MD -MQ 'gst/nnstreamer/73d9e45@@nnstreamer@sha/gsttensorsplit.c.o' -MF 'gst/nnstreamer/73d9e45@@nnstreamer@sha/gsttensorsplit.c.o.d' -o 'gst/nnstreamer/73d9e45@@nnstreamer@sha/gsttensorsplit.c.o' -c /home/abuild/rpmbuild/BUILD/nnstreamer-1.3.0/gst/nnstreamer/tensor_split/gsttensorsplit.c
[   63s] /home/abuild/rpmbuild/BUILD/nnstreamer-1.3.0/gst/nnstreamer/tensor_split/gsttensorsplit.c: In function 'gst_tensor_split_get_property':
[   63s] /home/abuild/rpmbuild/BUILD/nnstreamer-1.3.0/gst/nnstreamer/tensor_split/gsttensorsplit.c:676:9: error: 'strv' may be used uninitialized in this function [-Werror=maybe-uninitialized]
[   63s]   676 |         g_value_take_string (value, strv);
[   63s]       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   63s] cc1: all warnings being treated as errors

```

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>