### PR TITLE
[CodeClean] build option for python and conf file in android

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,7 @@ override_dh_auto_configure:
 	mkdir -p build
 	meson --buildtype=plain --prefix=/usr --sysconfdir=/etc --libdir=lib/$(DEB_HOST_MULTIARCH) --bindir=lib/nnstreamer/bin --includedir=include \
 	-Dinstall-example=true -Denable-tensorflow=$(enable_tf) -Denable-tensorflow-lite=true -Denable-pytorch=true -Denable-caffe2=true \
-	-Denable-capi=true -Denable-tizen=false build
+	-Denable-python=true -Denable-capi=true -Denable-tizen=false build
 
 override_dh_auto_build:
 	ninja -C build

--- a/gst/nnstreamer/nnstreamer_conf.c
+++ b/gst/nnstreamer/nnstreamer_conf.c
@@ -317,7 +317,7 @@ nnsconf_loadconf (gboolean force_reload)
 #ifndef __TIZEN__
   /** if it's not Tizen, configuration from env-var has a higher priority */
   conf.conffile = _strdup_getenv (NNSTREAMER_ENVVAR_CONF_FILE);
-  if (!g_file_test (conf.conffile, G_FILE_TEST_IS_REGULAR)) {
+  if (conf.conffile && !g_file_test (conf.conffile, G_FILE_TEST_IS_REGULAR)) {
     g_free (conf.conffile);
     conf.conffile = NULL;
   }
@@ -350,14 +350,6 @@ nnsconf_loadconf (gboolean force_reload)
     }
   }
 
-  if (conf.conffile == NULL) {
-    /**
-     * Failed to get the configuration.
-     * Note that Android API does not use the configuration.
-     */
-    g_warning ("Failed to load the configuration, no config file found.");
-  }
-
   if (conf.conffile) {
     key_file = g_key_file_new ();
     g_assert (key_file != NULL);
@@ -387,6 +379,12 @@ nnsconf_loadconf (gboolean force_reload)
     }
 
     g_key_file_free (key_file);
+  } else {
+    /**
+     * Failed to get the configuration.
+     * Note that Android API does not use the configuration.
+     */
+    g_warning ("Failed to load the configuration, no config file found.");
   }
 
   for (t = 0; t < NNSCONF_PATH_END; t++) {

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,7 +13,7 @@ option('disable-audio-support', type: 'boolean', value: false)
 option('enable-env-var', type: 'boolean', value: true)
 option('enable-symbolic-link', type: 'boolean', value: true)
 option('enable-capi', type: 'boolean', value: false)
-option('enable-python', type: 'boolean', value: true)
+option('enable-python', type: 'boolean', value: false)
 option('enable-tizen', type: 'boolean', value: false)
 option('enable-element-restriction', type: 'boolean', value: false) # true to restrict gst-elements in api
 option('restricted-elements', type: 'string', value: '')


### PR DESCRIPTION
1. Check null string before validating the conf file.
2. Disable default build option of python.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
