### PR TITLE
[Tests/Filter/MvNCSDK2] Add failure test cases 

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -395,6 +395,9 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
     LD_LIBRARY_PATH=./tests/nnstreamer_filter_edgetpu:. ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu --gst-plugin-path=. --gtest_output="xml:unittest_edgetpu.xml"
     popd
 %endif #ifarch 64
+    pushd build
+    LD_LIBRARY_PATH=./tests/nnstreamer_filter_mvncsdk2:. ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2 --gst-plugin-path=. --gtest_output="xml:unittest_mvncsdk2.xml"
+    popd
     pushd tests
     ssat -n --summary summary.txt
     popd

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.cc
@@ -80,7 +80,7 @@ NCSDKTensorFilterTestHelper::init (model_t model)
     this->mGraphHandle = nullptr;
   }
   this->mModelPath = nullptr;
-  this->mFailStage =fail_stage_t::NONE;
+  this->mFailStage = fail_stage_t::NONE;
 
   switch (model) {
     default:

--- a/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
+++ b/tests/nnstreamer_filter_mvncsdk2/NCSDKTensorFilterTestHelper.hh
@@ -46,6 +46,27 @@ typedef enum _model {
   DEFAULT_MODEL = GOOGLE_LENET,
 } model_t;
 
+typedef enum _fail_stage_t {
+  NONE,
+  WRONG_SDK_VER,
+  FAIL_GLBL_GET_OPT,
+  FAIL_DEV_CREATE,
+  FAIL_DEV_OPEN,
+  FAIL_DEV_CLOSE,
+  FAIL_GRAPH_CREATE,
+  FAIL_GRAPH_ALLOC,
+  FAIL_GRAPH_Q_INFER,
+  FAIL_GRAPH_GET_INPUT_TENSOR_DESC,
+  FAIL_GRAPH_GET_OUTPUT_TENSOR_DESC,
+  FAIL_FIFO_CREATE_INPUT,
+  FAIL_FIFO_CREATE_OUTPUT,
+  FAIL_FIFO_ALLOC_INPUT,
+  FAIL_FIFO_ALLOC_OUTPUT,
+  FAIL_FIFO_WRT_ELEM,
+  FAIL_FIFO_RD_ELEM,
+  FAIL_FIFO_RM_ELEM,
+} fail_stage_t;
+
 typedef uint32_t ncsdk_ver_t[NC_VERSION_MAX_SIZE];
 
 class NCSDKTensorFilterTestHelper
@@ -61,6 +82,9 @@ public:
   ~NCSDKTensorFilterTestHelper ();
   void init (model_t model);
   void release ();
+  // Set/Get fail-stage
+  void setFailStage (const fail_stage_t stage);
+  const fail_stage_t getFailStage ();
 
   // Mock methods that simulate NCSDK2 APIs
   // Mock Global APIs
@@ -120,6 +144,7 @@ private:
   const void *mGraphBuf;
   uint32_t mLenGraphBuf;
   ncsdk_ver_t mVer;
+  fail_stage_t mFailStage;
   gchar *mModelPath;
   model_t mModel;
 };

--- a/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
+++ b/tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2.cc
@@ -90,6 +90,85 @@ TEST (pipeline_mvncsdk2_filter, launch_normal)
   NCSDKTensorFilterTestHelper::getInstance ().release ();
 }
 
+#define TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(idx, fail_stage) \
+    TEST (pipeline_mvncsdk2_filter, launch_normal_ ##idx##_n) { \
+      const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH"); \
+      gchar *pipeline; \
+      gchar *test_model; \
+      GstElement *gstpipe; \
+      GError *err = NULL; \
+      int status = 0; \
+      \
+      NCSDKTensorFilterTestHelper::getInstance ().init (GOOGLE_LENET); \
+      NCSDKTensorFilterTestHelper::getInstance () \
+          .setFailStage (fail_stage); \
+      \
+      if (root_path == NULL) { \
+        root_path = ".."; \
+      } \
+      test_model = g_build_filename (root_path, "tests", "test_models", \
+          "models", "google_lenet_ncsdk_caffe_1.graph", NULL); \
+      \
+      pipeline = g_strdup_printf ("videotestsrc ! videoconvert ! videoscale ! videorate ! video/x-raw,format=BGR,width=224,height=224 " \
+          "! tensor_converter ! tensor_transform mode=arithmetic option=typecast:float32,add:-104.0069877 " \
+          "! tensor_filter framework=movidius-ncsdk2 model=\"%s\" ! fakesink", \
+          test_model); \
+      gstpipe = gst_parse_launch (pipeline, &err); \
+      if (gstpipe) { \
+        GstStateChangeReturn ret; \
+        bool test = false; \
+        \
+        ret = gst_element_set_state (gstpipe, GST_STATE_PLAYING); \
+        \
+        g_usleep (1 * G_USEC_PER_SEC); \
+        if ((ret == GST_STATE_CHANGE_ASYNC) || \
+            (ret == GST_STATE_CHANGE_SUCCESS)) { \
+          test = true;\
+        } \
+        EXPECT_NE (test, true); \
+        EXPECT_EQ (ret, GST_STATE_CHANGE_FAILURE); \
+        \
+        gst_object_unref (gstpipe); \
+      } else { \
+        status = -1; \
+        g_printerr ("Failed to launch the pipeline, %s : %s\n", pipeline, \
+            (err) ? err->message : "unknown reason"); \
+        g_clear_error (&err); \
+      } \
+      EXPECT_EQ (status, 0); \
+      g_free (test_model); \
+      g_free (pipeline); \
+      \
+      NCSDKTensorFilterTestHelper::getInstance ().release (); \
+    };\
+
+
+/** @brief Testing failure cases (in the case of wrong SDK version) */
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(0, fail_stage_t::WRONG_SDK_VER);
+
+/** @brief Testing failure cases (in the case of fialure in getting version information) */
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(1, fail_stage_t::FAIL_GLBL_GET_OPT);
+
+/** @brief Testing failure cases (in the case of fialure in handling device handles) */
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(2, fail_stage_t::FAIL_DEV_CREATE);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(3, fail_stage_t::FAIL_DEV_OPEN);
+
+/** @brief Testing failure cases (in the case of fialure in handling graph handles) */
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(4, fail_stage_t::FAIL_GRAPH_CREATE);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(5, fail_stage_t::FAIL_GRAPH_ALLOC);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(6,
+    fail_stage_t::FAIL_GRAPH_GET_INPUT_TENSOR_DESC);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(7,
+    fail_stage_t::FAIL_GRAPH_GET_OUTPUT_TENSOR_DESC);
+
+/** @brief Testing failure cases (in the case of fialure in handling FIFO handles) */
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(8, fail_stage_t::FAIL_FIFO_CREATE_INPUT);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(9, fail_stage_t::FAIL_FIFO_CREATE_OUTPUT);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(10, fail_stage_t::FAIL_FIFO_ALLOC_INPUT);
+TEST_PIPELINE_LAUNCH_NORMAL_FAILURE(11, fail_stage_t::FAIL_FIFO_ALLOC_OUTPUT);
+
+/** @todo: Failure in invoke () incurs assertion so that the whole tests would be stopped. */
+
 /**
  * @brief Main function for unit test.
  */


### PR DESCRIPTION
This patch adds failure test cases, which are based on the normal pipeline launch test case. Note that the current line coverage of tensor_filter_movidius_ncsdk2.c is 87.2%.

Signed-off-by: Wook Song <wook16.song@samsung.com>