### PR TITLE
[tensor_filter] Support data layout for tensor @open sesame 02/04 16:27

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -92,6 +92,35 @@ typedef enum
 } accl_hw;
 
 /**
+ * @brief Internal tensor layout format for other/tensor
+ *
+ * The layout is needed by some of the subplugins to appropriately  process the
+ * data based on the axis of the channel in the data. Layout information will be
+ * currently utilized by only some of the sublpugins (SNAP, NNFW), and should be
+ * provided to use some of the subplugins (SNAP).
+ *
+ * Tensor layout is stored locally in the tensor filter element, and not shared
+ * with other elements in the pipeline. Thus, tensor layout is not part of the
+ * capabilities of the element, and does not take part in the caps negotiation.
+ *
+ * NONE layout implies that the layout of the data is neither NHWC nor NCHW. '
+ * However, ANY layout implies that the layout of the provided data is not
+ * relevant.
+ *
+ * @note Providing tensor layout can also decide acceleration to be supported
+ * as not all the accelerators might support all the layouts (NYI).
+ */
+typedef enum _nns_tensor_layout
+{
+  _NNS_LAYOUT_ANY = 0,     /**< does not care about the data layout */
+  _NNS_LAYOUT_NHWC,        /**< NHWC: channel last layout */
+  _NNS_LAYOUT_NCHW,        /**< NCHW: channel first layout */
+  _NNS_LAYOUT_NONE,        /**< NONE: none of the above defined layouts */
+} tensor_layout;
+
+typedef tensor_layout tensors_layout[NNS_TENSOR_SIZE_LIMIT];
+
+/**
  * @brief GstTensorFilter's properties for NN framework (internal data structure)
  *
  * Because custom filters of tensor_filter may need to access internal data
@@ -106,9 +135,11 @@ typedef struct _GstTensorFilterProperties
 
   int input_configured; /**< TRUE if input tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo input_meta; /**< configured input tensor info */
+  tensors_layout input_layout; /**< data layout info provided as a property to tensor_filter for the input, defaults to _NNS_LAYOUT_ANY for all the tensors */
 
   int output_configured; /**< TRUE if output tensor is configured. Use int instead of gboolean because this is refered by custom plugins. */
   GstTensorsInfo output_meta; /**< configured output tensor info */
+  tensors_layout output_layout; /**< data layout info provided as a property to tensor_filter for the output, defaults to _NNS_LAYOUT_ANY for all the tensors */
 
   const char *custom_properties; /**< sub-plugin specific custom property values in string */
   const char *accl_str; /**< accelerator configuration passed in as parameter */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -810,39 +810,49 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
       break;
     }
     case PROP_INPUTLAYOUT:
-      g_assert (!prop->input_configured && value);
-      /* Once configured, it cannot be changed in runtime */
-      {
-        guint num_layouts;
+    {
+      /** TODO: allow updating the data layout after fw has been opened */
+      guint num_layouts;
 
-        num_layouts = gst_tensors_parse_layouts_string (prop->input_layout,
-            g_value_get_string (value));
-
-        if (prop->input_meta.num_tensors > 0 &&
-            prop->input_meta.num_tensors != num_layouts) {
-          g_warning ("Invalid input-layout, given param does not fit.");
-        }
-
-        prop->input_meta.num_tensors = num_layouts;
+      if (priv->prop.fw_opened == TRUE) {
+        g_warning
+            ("Updating data layout is not supported after opened framework.");
+        break;
       }
+
+      num_layouts = gst_tensors_parse_layouts_string (prop->input_layout,
+          g_value_get_string (value));
+
+      if (prop->input_meta.num_tensors > 0 &&
+          prop->input_meta.num_tensors != num_layouts) {
+        g_warning ("Invalid input-layout, given param does not fit.");
+      }
+
+      prop->input_meta.num_tensors = num_layouts;
       break;
+    }
     case PROP_OUTPUTLAYOUT:
-      g_assert (!prop->output_configured && value);
-      /* Once configured, it cannot be changed in runtime */
-      {
-        guint num_layouts;
+    {
+      /** TODO: allow updating the data layout after fw has been opened */
+      guint num_layouts;
 
-        num_layouts = gst_tensors_parse_layouts_string (prop->output_layout,
-            g_value_get_string (value));
-
-        if (prop->output_meta.num_tensors > 0 &&
-            prop->output_meta.num_tensors != num_layouts) {
-          g_warning ("Invalid output-layout, given param does not fit.");
-        }
-
-        prop->output_meta.num_tensors = num_layouts;
+      if (priv->prop.fw_opened == TRUE) {
+        g_warning
+            ("Updating data layout is not supported after opened framework.");
+        break;
       }
+
+      num_layouts = gst_tensors_parse_layouts_string (prop->output_layout,
+          g_value_get_string (value));
+
+      if (prop->output_meta.num_tensors > 0 &&
+          prop->output_meta.num_tensors != num_layouts) {
+        g_warning ("Invalid output-layout, given param does not fit.");
+      }
+
+      prop->output_meta.num_tensors = num_layouts;
       break;
+    }
     default:
       return FALSE;
   }


### PR DESCRIPTION
Data layout added for tensor_filter in GstTensorFilterProperties 
Four data layouts are supported
- ANY - unknown does not matter
- NHWC - referred as channels last
- NCHW - referred as channels first
- none - doesnt fit with above options 
These data layouts can be different for each other/tensor in other/tensors 
Layout is taken input as a string, and then parsed for each tensor 
This layout is stored in tensor_filter element itself to be used by its subplugins, and not passed to other elements in the pipeline
Added corresponding unittests as well

This is not the final solution but a temporary solution to provide data layouts to tensor filters. Better solution is being tracked at #2051.

Related Issue: #1986 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor 

cc @jaeyun-jung 