### PR TITLE
[Fix] add type checking for gst value in tensor_converter.c

### DIFF
--- a/gst/nnstreamer/tensor_converter/tensor_converter.c
+++ b/gst/nnstreamer/tensor_converter/tensor_converter.c
@@ -1244,7 +1244,8 @@ gst_tensor_converter_get_possible_media_caps (GstTensorConverter * self)
                   break;
               }
 
-              if (gst_value_list_get_size (&supported_formats) > 0) {
+              if (G_VALUE_TYPE (&supported_formats) == GST_TYPE_LIST &&
+                  gst_value_list_get_size (&supported_formats) > 0) {
                 gst_structure_set_value (st, "format", &supported_formats);
               }
               g_value_unset (&supported_formats);


### PR DESCRIPTION
This PR adds type checking for the gst value, `supported_formats`.
When an unsupported colorspace is used, `gst_value_list_get_size()` has
generated unnecessary warnings.

Refer to the below for the original problem.
```
make[1]: Entering directory '/home/dchae/PR/nnstreamer-private-plugins'
cd tests && ssat -n && cd ..

(gst-launch-1.0:4388): GStreamer-CRITICAL **: gst_value_list_get_size: assertion 'GST_VALUE_HOLDS_LIST (value)' failed

(gst-launch-1.0:4402): GStreamer-CRITICAL **: gst_value_list_get_size: assertion 'GST_VALUE_HOLDS_LIST (value)' failed

(gst-launch-1.0:4418): GStreamer-CRITICAL **: gst_value_list_get_size: assertion 'GST_VALUE_HOLDS_LIST (value)' failed

```

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>
