### PR TITLE
[tensor_filter] Unused variable bug resolve

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter.c
@@ -791,6 +791,12 @@ gst_tensor_filter_fixate_caps (GstBaseTransform * trans,
   silent_debug_caps (caps, "caps");
   silent_debug_caps (othercaps, "othercaps");
 
+  /** Removes no-used-variable warning for priv in when DBG is set */
+  if (priv->fw == NULL) {
+    gst_caps_unref (othercaps);
+    return NULL;
+  }
+
   /**
    * To get the out-caps, GstTensorFilter has to parse tensor info from NN model.
    */


### PR DESCRIPTION
Resolve bug related to unused variable
If DBG is defined, this error is raised as the variable is only used
for check silent property when DBG is not defined

Self evaluation:
Build test: [x]Passed [ ]Failed [ ]Skipped
Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>