### PR TITLE
[subplugins] Refactor subplugin interface

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_armnn.cc
@@ -698,15 +698,7 @@ armnn_getOutputDim (const GstTensorFilterProperties * prop,
 static gchar filter_subplugin_armnn[] = "armnn";
 
 static GstTensorFilterFramework NNS_support_armnn = {
-  .name = filter_subplugin_armnn,
-  .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = armnn_invoke,
-  .getInputDimension = armnn_getInputDim,
-  .getOutputDimension = armnn_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = armnn_open,
   .close = armnn_close,
 };
@@ -715,6 +707,15 @@ static GstTensorFilterFramework NNS_support_armnn = {
 void
 init_filter_armnn (void)
 {
+  NNS_support_armnn.name = filter_subplugin_armnn;
+  NNS_support_armnn.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
+  NNS_support_armnn.allocate_in_invoke = FALSE;
+  NNS_support_armnn.run_without_model = FALSE;
+  NNS_support_armnn.verify_model_path = FALSE;
+  NNS_support_armnn.invoke_NN = armnn_invoke;
+  NNS_support_armnn.getInputDimension = armnn_getInputDim;
+  NNS_support_armnn.getOutputDimension = armnn_getOutputDim;
+
   nnstreamer_filter_probe (&NNS_support_armnn);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -559,7 +559,7 @@ caffe2_getOutputDim (const GstTensorFilterProperties * prop,
  * @param[in] data The data element.
  */
 static void
-caffe2_destroyNotify (void *data)
+caffe2_destroyNotify (void **private_data, void *data)
 {
   /* do nothing */
 }
@@ -567,24 +567,25 @@ caffe2_destroyNotify (void *data)
 static gchar filter_subplugin_caffe2[] = "caffe2";
 
 static GstTensorFilterFramework NNS_support_caffe2 = {
-  .name = filter_subplugin_caffe2,
-  .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = TRUE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = caffe2_run,
-  .getInputDimension = caffe2_getInputDim,
-  .getOutputDimension = caffe2_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = caffe2_open,
   .close = caffe2_close,
-  .destroyNotify = caffe2_destroyNotify,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_caffe2 (void)
 {
+  NNS_support_caffe2.name = filter_subplugin_caffe2;
+  NNS_support_caffe2.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
+  NNS_support_caffe2.allocate_in_invoke = TRUE;
+  NNS_support_caffe2.run_without_model = FALSE;
+  NNS_support_caffe2.verify_model_path = FALSE;
+  NNS_support_caffe2.invoke_NN = caffe2_run;
+  NNS_support_caffe2.getInputDimension = caffe2_getInputDim;
+  NNS_support_caffe2.getOutputDimension = caffe2_getOutputDim;
+  NNS_support_caffe2.destroyNotify = caffe2_destroyNotify;
+
   nnstreamer_filter_probe (&NNS_support_caffe2);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_edgetpu.cc
@@ -373,25 +373,24 @@ edgetpu_getOutputDim (const GstTensorFilterProperties *prop, void **private_data
 static gchar filter_subplugin_edgetpu[] = "edgetpu";
 
 static GstTensorFilterFramework NNS_support_edgetpu = {
-  .name = filter_subplugin_edgetpu,
-  .allow_in_place = FALSE,
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = edgetpu_invoke,
-  .getInputDimension = edgetpu_getInputDim,
-  .getOutputDimension = edgetpu_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = edgetpu_open,
   .close = edgetpu_close,
-  .destroyNotify = NULL,
-  .reloadModel = NULL,
 };
 
 /**@brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_edgetpu (void)
 {
+  NNS_support_edgetpu.name = filter_subplugin_edgetpu;
+  NNS_support_edgetpu.allow_in_place = FALSE;
+  NNS_support_edgetpu.allocate_in_invoke = FALSE;
+  NNS_support_edgetpu.run_without_model = FALSE;
+  NNS_support_edgetpu.verify_model_path = FALSE;
+  NNS_support_edgetpu.invoke_NN = edgetpu_invoke;
+  NNS_support_edgetpu.getInputDimension = edgetpu_getInputDim;
+  NNS_support_edgetpu.getOutputDimension = edgetpu_getOutputDim;
+
   nnstreamer_filter_probe (&NNS_support_edgetpu);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -412,13 +412,7 @@ _mvncsdk2_getOutputDim (const GstTensorFilterProperties * prop,
 static gchar filter_subplugin_movidius_ncsdk2[] = "movidius-ncsdk2";
 
 static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
-  .name = filter_subplugin_movidius_ncsdk2,
-  .allow_in_place = FALSE,
-  .allocate_in_invoke = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = _mvncsdk2_invoke,
-  .getInputDimension = _mvncsdk2_getInputDim,
-  .getOutputDimension = _mvncsdk2_getOutputDim,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = _mvncsdk2_open,
   .close = _mvncsdk2_close,
 };
@@ -427,6 +421,14 @@ static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
 void
 init_filter_mvncsdk2 (void)
 {
+  NNS_support_movidius_ncsdk2.name = filter_subplugin_movidius_ncsdk2;
+  NNS_support_movidius_ncsdk2.allow_in_place = FALSE;
+  NNS_support_movidius_ncsdk2.allocate_in_invoke = FALSE;
+  NNS_support_movidius_ncsdk2.verify_model_path = FALSE;
+  NNS_support_movidius_ncsdk2.invoke_NN = _mvncsdk2_invoke;
+  NNS_support_movidius_ncsdk2.getInputDimension = _mvncsdk2_getInputDim;
+  NNS_support_movidius_ncsdk2.getOutputDimension = _mvncsdk2_getOutputDim;
+
   nnstreamer_filter_probe (&NNS_support_movidius_ncsdk2);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_nnfw.c
@@ -649,15 +649,7 @@ nnfw_invoke (const GstTensorFilterProperties * prop,
 static gchar filter_subplugin_nnfw[] = "nnfw";
 
 static GstTensorFilterFramework NNS_support_nnfw = {
-  .name = filter_subplugin_nnfw,
-  .allow_in_place = FALSE,
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = nnfw_invoke,
-  .getInputDimension = nnfw_getInputDim,
-  .getOutputDimension = nnfw_getOutputDim,
-  .setInputDimension = nnfw_setInputDim,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = nnfw_open,
   .close = nnfw_close,
 };
@@ -666,6 +658,16 @@ static GstTensorFilterFramework NNS_support_nnfw = {
 void
 init_filter_nnfw (void)
 {
+  NNS_support_nnfw.name = filter_subplugin_nnfw;
+  NNS_support_nnfw.allow_in_place = FALSE;
+  NNS_support_nnfw.allocate_in_invoke = FALSE;
+  NNS_support_nnfw.run_without_model = FALSE;
+  NNS_support_nnfw.verify_model_path = FALSE;
+  NNS_support_nnfw.invoke_NN = nnfw_invoke;
+  NNS_support_nnfw.getInputDimension = nnfw_getInputDim;
+  NNS_support_nnfw.getOutputDimension = nnfw_getOutputDim;
+  NNS_support_nnfw.setInputDimension = nnfw_setInputDim;
+
   nnstreamer_filter_probe (&NNS_support_nnfw);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.cc
@@ -620,15 +620,7 @@ ov_open (const GstTensorFilterProperties * prop, void **private_data)
 static gchar filter_subplugin_openvino[] = "openvino";
 
 static GstTensorFilterFramework NNS_support_openvino = {
-  .name = filter_subplugin_openvino,
-  .allow_in_place = FALSE,
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = ov_invoke,
-  .getInputDimension = ov_getInputDim,
-  .getOutputDimension = ov_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = ov_open,
   .close = ov_close,
 };
@@ -639,6 +631,15 @@ static GstTensorFilterFramework NNS_support_openvino = {
 void
 init_filter_openvino (void)
 {
+  NNS_support_openvino.name = filter_subplugin_openvino;
+  NNS_support_openvino.allow_in_place = FALSE;
+  NNS_support_openvino.allocate_in_invoke = FALSE;
+  NNS_support_openvino.run_without_model = FALSE;
+  NNS_support_openvino.verify_model_path = FALSE;
+  NNS_support_openvino.invoke_NN = ov_invoke;
+  NNS_support_openvino.getInputDimension = ov_getInputDim;
+  NNS_support_openvino.getOutputDimension = ov_getOutputDim;
+
   nnstreamer_filter_probe (&NNS_support_openvino);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -738,7 +738,7 @@ py_run (const GstTensorFilterProperties * prop, void **private_data,
  * @param[in] data The data element.
  */
 static void
-py_destroyNotify (void *data)
+py_destroyNotify (void **private_data, void *data)
 {
   std::map <void*, PyArrayObject*>::iterator it;
   it = PYCore::outputArrayMap.find(data);
@@ -904,25 +904,29 @@ static gchar filter_subplugin_python[] = "python2";
 #endif
 
 static GstTensorFilterFramework NNS_support_python = {
-  .name = filter_subplugin_python,
-  .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = TRUE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = py_run,
-  /** dimension-related callbacks are dynamically assigned */
-  .getInputDimension = py_getInputDim,
-  .getOutputDimension = py_getOutputDim,
-  .setInputDimension = py_setInputDim,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = py_open,
   .close = py_close,
-  .destroyNotify = py_destroyNotify,
+  {
+  }
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_py (void)
 {
+  NNS_support_python.name = filter_subplugin_python;
+  NNS_support_python.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
+  NNS_support_python.allocate_in_invoke = TRUE;
+  NNS_support_python.run_without_model = FALSE;
+  NNS_support_python.verify_model_path = FALSE;
+  NNS_support_python.invoke_NN = py_run;
+  /** dimension-related callbacks are dynamically updated */
+  NNS_support_python.getInputDimension = py_getInputDim;
+  NNS_support_python.getOutputDimension = py_getOutputDim;
+  NNS_support_python.setInputDimension = py_setInputDim;
+  NNS_support_python.destroyNotify = py_destroyNotify;
+
   nnstreamer_filter_probe (&NNS_support_python);
   filter_framework = &NNS_support_python;
   /** Python should be initialized and finalized only once */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_pytorch.cc
@@ -670,26 +670,25 @@ torch_checkAvailability (accl_hw hw)
 static gchar filter_subplugin_pytorch[] = "pytorch";
 
 static GstTensorFilterFramework NNS_support_pytorch = {
-  .name = filter_subplugin_pytorch,
-  .allow_in_place = FALSE,
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = torch_invoke,
-  .getInputDimension = torch_getInputDim,
-  .getOutputDimension = torch_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = torch_open,
   .close = torch_close,
-  .destroyNotify = NULL,
-  .reloadModel = NULL,
-  .checkAvailability = torch_checkAvailability,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_torch (void)
 {
+  NNS_support_pytorch.name = filter_subplugin_pytorch;
+  NNS_support_pytorch.allow_in_place = FALSE;
+  NNS_support_pytorch.allocate_in_invoke = FALSE;
+  NNS_support_pytorch.run_without_model = FALSE;
+  NNS_support_pytorch.verify_model_path = FALSE;
+  NNS_support_pytorch.invoke_NN = torch_invoke;
+  NNS_support_pytorch.getInputDimension = torch_getInputDim;
+  NNS_support_pytorch.getOutputDimension = torch_getOutputDim;
+  NNS_support_pytorch.checkAvailability = torch_checkAvailability;
+
   nnstreamer_filter_probe (&NNS_support_pytorch);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -717,7 +717,7 @@ tf_getOutputDim (const GstTensorFilterProperties * prop, void **private_data,
  * @param[in] data The data element.
  */
 static void
-tf_destroyNotify (void *data)
+tf_destroyNotify (void **private_data, void *data)
 {
   TF_DeleteTensor ( (TFCore::outputTensorMap.find (data))->second);
   TFCore::outputTensorMap.erase (data);
@@ -726,24 +726,25 @@ tf_destroyNotify (void *data)
 static gchar filter_subplugin_tensorflow[] = "tensorflow";
 
 static GstTensorFilterFramework NNS_support_tensorflow = {
-  .name = filter_subplugin_tensorflow,
-  .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = TRUE,
-  .run_without_model = FALSE,
-  .verify_model_path = FALSE,
-  .invoke_NN = tf_run,
-  .getInputDimension = tf_getInputDim,
-  .getOutputDimension = tf_getOutputDim,
-  .setInputDimension = NULL,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = tf_open,
   .close = tf_close,
-  .destroyNotify = tf_destroyNotify,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_tf (void)
 {
+  NNS_support_tensorflow.name = filter_subplugin_tensorflow;
+  NNS_support_tensorflow.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
+  NNS_support_tensorflow.allocate_in_invoke = TRUE;
+  NNS_support_tensorflow.run_without_model = FALSE;
+  NNS_support_tensorflow.verify_model_path = FALSE;
+  NNS_support_tensorflow.invoke_NN = tf_run;
+  NNS_support_tensorflow.getInputDimension = tf_getInputDim;
+  NNS_support_tensorflow.getOutputDimension = tf_getOutputDim;
+  NNS_support_tensorflow.destroyNotify = tf_destroyNotify;
+
   nnstreamer_filter_probe (&NNS_support_tensorflow);
 }
 

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -985,26 +985,26 @@ tflite_checkAvailability (accl_hw hw)
 static gchar filter_subplugin_tensorflow_lite[] = "tensorflow-lite";
 
 static GstTensorFilterFramework NNS_support_tensorflow_lite = {
-  .name = filter_subplugin_tensorflow_lite,
-  .allow_in_place = FALSE,      /** @todo: support this to optimize performance later. */
-  .allocate_in_invoke = FALSE,
-  .run_without_model = FALSE,
-  .verify_model_path = TRUE,
-  .invoke_NN = tflite_invoke,
-  .getInputDimension = tflite_getInputDim,
-  .getOutputDimension = tflite_getOutputDim,
-  .setInputDimension = tflite_setInputDim,
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = tflite_open,
   .close = tflite_close,
-  .destroyNotify = NULL,
-  .reloadModel = tflite_reloadModel,
-  .checkAvailability = tflite_checkAvailability,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */
 void
 init_filter_tflite (void)
 {
+  NNS_support_tensorflow_lite.name = filter_subplugin_tensorflow_lite,
+  NNS_support_tensorflow_lite.allow_in_place = FALSE;      /** @todo: support this to optimize performance later. */
+  NNS_support_tensorflow_lite.allocate_in_invoke = FALSE;
+  NNS_support_tensorflow_lite.run_without_model = FALSE;
+  NNS_support_tensorflow_lite.verify_model_path = TRUE;
+  NNS_support_tensorflow_lite.invoke_NN = tflite_invoke;
+  NNS_support_tensorflow_lite.getInputDimension = tflite_getInputDim;
+  NNS_support_tensorflow_lite.getOutputDimension = tflite_getOutputDim;
+  NNS_support_tensorflow_lite.setInputDimension = tflite_setInputDim;
+  NNS_support_tensorflow_lite.reloadModel = tflite_reloadModel;
+  NNS_support_tensorflow_lite.checkAvailability = tflite_checkAvailability;
   nnstreamer_filter_probe (&NNS_support_tensorflow_lite);
 }
 

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom_easy.c
@@ -165,6 +165,7 @@ custom_close (const GstTensorFilterProperties * prop, void **private_data)
 
 static char name_str[] = "custom-easy";
 static GstTensorFilterFramework NNS_support_custom_easy = {
+  .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .name = name_str,
   .allow_in_place = FALSE,      /* custom cannot support in-place. */
   .allocate_in_invoke = FALSE,  /* we allocate output buffers for you. */


### PR DESCRIPTION
Refactor subplugin interface
Add new interface for the subplugins along with the old interface
Added version number to check if old subplugin interface is used or the new one

Both the interfaces are added as a union,
This will allow for staggered changes rather a big change to be made at once

Related Issue: #2045 

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>