### PR TITLE
Coverity/1123747/1123767/1123869: Stack Size Limit

### DIFF
--- a/tests/tizen_capi/unittest_tizen_sensor.cc
+++ b/tests/tizen_capi/unittest_tizen_sensor.cc
@@ -104,6 +104,8 @@ typedef struct {
   int negative;
 } verify_data;
 
+static verify_data data; /* Too big for stack. Use this global var */
+
 /**
  * @brief Test if the sensor-reading matches the golden values.
  */
@@ -163,7 +165,6 @@ TEST (tizensensor_as_source, virtual_sensor_flow_03)
   ml_pipeline_h handle;
   ml_pipeline_sink_h s_handle;
   ml_pipeline_state_e state;
-  verify_data data;
 
   status = sensor_get_default_sensor (SENSOR_LIGHT, &sensor);
   EXPECT_EQ (status, 0);
@@ -254,7 +255,6 @@ TEST (tizensensor_as_source, virtual_sensor_flow_04)
   ml_pipeline_h handle;
   ml_pipeline_sink_h s_handle;
   ml_pipeline_state_e state;
-  verify_data data;
 
   sensor_get_sensor_list (SENSOR_LIGHT, &sensor_list, &count);
   EXPECT_EQ (count, 3);
@@ -347,7 +347,6 @@ TEST (tizensensor_as_source, virtual_sensor_flow_05_n)
   ml_pipeline_h handle;
   ml_pipeline_sink_h s_handle;
   ml_pipeline_state_e state;
-  verify_data data;
 
   sensor_get_sensor_list (SENSOR_LIGHT, &sensor_list, &count);
   EXPECT_EQ (count, 3);


### PR DESCRIPTION
Coverity says not to use stack variable larger than 10kB.
Move verify_data data to global so that it does not
consume the stack.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

