### PR TITLE
[coverity] single-shot API coverity fix

### DIFF
--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -382,9 +382,9 @@ ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
 
     if (tensors_info && !ml_tensors_info_is_equal (tensors_info, info)) {
       /* given input info is not matched with configured */
+      ml_tensors_info_destroy (info);
       if (is_input) {
         /* try to update tensors info */
-        ml_tensors_info_destroy (info);
         if (ml_single_update_info (single, tensors_info, &info) != ML_ERROR_NONE)
           goto done;
       } else {
@@ -393,6 +393,7 @@ ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
     }
 
     ml_tensors_info_clone (dest, info);
+    ml_tensors_info_destroy (info);
   } else if (tensors_info) {
     ml_single_set_inout_tensors_info (filter_obj, is_input, tensors_info);
     ml_tensors_info_clone (dest, tensors_info);
@@ -401,7 +402,6 @@ ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
   is_valid = ml_tensors_info_is_valid (dest);
 
 done:
-  ml_tensors_info_destroy (info);
   return is_valid;
 }
 

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -353,6 +353,7 @@ static gboolean
 ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
     ml_tensors_info_s * tensors_info)
 {
+  int status;
   ml_single *single_h;
   ml_tensors_info_h info = NULL;
   ml_tensors_info_s *dest;
@@ -395,7 +396,9 @@ ml_single_set_info_in_handle (ml_single_h single, gboolean is_input,
     ml_tensors_info_clone (dest, info);
     ml_tensors_info_destroy (info);
   } else if (tensors_info) {
-    ml_single_set_inout_tensors_info (filter_obj, is_input, tensors_info);
+    status = ml_single_set_inout_tensors_info (filter_obj, is_input, tensors_info);
+    if (status != ML_ERROR_NONE)
+      goto done;
     ml_tensors_info_clone (dest, tensors_info);
   }
 


### PR DESCRIPTION
Added coverity fix of checking return value
In ml_single_set_info_in_handle: Value returned from a function is not checked for errors before being used (CWE-252)
    
Fix coverity issue CWE-416
Issue: In ml_single_set_info_in_handle: A pointer to freed memory is dereferenced, used as a function argument, or otherwise used
    
Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>