### PR TITLE
[Coverity] 1123652/1123668 : Handle thrown exception

### DIFF
--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -3734,15 +3734,23 @@ TEST (nnstreamer_capi_singleshot, set_input_info_success_02)
 int
 main (int argc, char **argv)
 {
-  int result;
+  int result = -1;
 
-  testing::InitGoogleTest (&argc, argv);
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
 
   /* ignore tizen feature status while running the testcases */
   set_feature_state (1);
 
-  result = RUN_ALL_TESTS ();
-
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+  
   set_feature_state (-1);
 
   return result;


### PR DESCRIPTION
Fix to catch exception from GTest
Coverity CID  1123652, 1123668 : Error handling Issues (UNCAUGHT_EXCEPT)
tests/tizen_capi/unittest_tizen_capi.cc

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>

