### PR TITLE
[Coverity] 1123913, 1123863 and potential error : Handle thrown exception

### DIFF
--- a/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
+++ b/tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc
@@ -468,12 +468,19 @@ TEST (nnstreamer_filter_armnn, invoke_01)
 int
 main (int argc, char **argv)
 {
-  int result;
+  int result = -1;
 
-  testing::InitGoogleTest (&argc, argv);
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
 
-  result = RUN_ALL_TESTS ();
-
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
+  
   return result;
 }
-

--- a/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
+++ b/tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc
@@ -132,12 +132,21 @@ TEST (edgetpu_tflite_direct, error_02_n)
  */
 int main (int argc, char **argv)
 {
-  int result;
+  int result = -1;
 
-  testing::InitGoogleTest (&argc, argv);
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
 
   gst_init (&argc, &argv);
-  result = RUN_ALL_TESTS ();
+
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
 
   return result;
 }

--- a/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
+++ b/tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc
@@ -1281,15 +1281,21 @@ TEST (nnstreamer_nnfw_mlapi, multimodel_02_p)
 int
 main (int argc, char **argv)
 {
-  int result;
+  int result = -1;
 
-  testing::InitGoogleTest (&argc, argv);
-
+  try {
+    testing::InitGoogleTest (&argc, argv);
+  } catch (...) {
+    g_warning ("catch 'testing::internal::<unnamed>::ClassUniqueToAlwaysTrue'");
+  }
   /* ignore tizen feature status while running the testcases */
   set_feature_state (1);
 
-  result = RUN_ALL_TESTS ();
-
+  try {
+    result = RUN_ALL_TESTS ();
+  } catch (...) {
+    g_warning ("catch `testing::internal::GoogleTestFailureException`");
+  }
   set_feature_state (-1);
 
   return result;


### PR DESCRIPTION
Fix to catch exception from GTest
Coverity CID : 1123913, 1123863 and potential error code
 - tests/tizen_nnfw_runtime/unittest_tizen_nnfw_runtime_raw.cc (coverity issue)
 - tests/nnstreamer_filter_armnn/unittest_filter_armnn.cc (potential error code)
 - tests/nnstreamer_filter_edgetpu/unittest_edgetpu.cc (potential error code)

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>