### PR TITLE
Support accelerator backends for tensor filter extensions

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -228,39 +228,31 @@ if have_python3
   )
 endif
 
-if get_option('enable-movidius-ncsdk2')
-  # Explicitly checks mvnc.h in the ncsdk2 directory
-  nns_mvncsdk2_dep = cc.find_library('mvnc', required: false)
-  if not nns_mvncsdk2_dep.found()
-    warning('Failed to find \'libmvnc.so\' despite setting enable-movidius-ncsdk2. This option be ignored.')
-  elif not cc.check_header('mvnc2/mvnc.h')
-    warning('Failed to find \'mvnc2/mvnc.h\' despite setting enable-movidius-ncsdk2. This option be ignored.')
-  else
-    filter_sub_mvncsdk2_sources = [
-      'tensor_filter_movidius_ncsdk2.c'
-    ]
+if have_movidius_ncsdk2
+  filter_sub_mvncsdk2_sources = [
+    'tensor_filter_movidius_ncsdk2.c'
+  ]
 
-    nnstreamer_filter_mvncsdk2_sources = []
-    foreach s : filter_sub_mvncsdk2_sources
-      nnstreamer_filter_mvncsdk2_sources += join_paths(meson.current_source_dir(), s)
-    endforeach
+  nnstreamer_filter_mvncsdk2_sources = []
+  foreach s : filter_sub_mvncsdk2_sources
+    nnstreamer_filter_mvncsdk2_sources += join_paths(meson.current_source_dir(), s)
+  endforeach
 
-    nnstreamer_filter_mvncsdk2_deps = [glib_dep, gst_dep, nnstreamer_dep, nns_mvncsdk2_dep]
+  nnstreamer_filter_mvncsdk2_deps = [glib_dep, gst_dep, nnstreamer_dep, nns_mvncsdk2_dep]
 
-    shared_library('nnstreamer_filter_movidius-ncsdk2',
-      nnstreamer_filter_mvncsdk2_sources,
-      dependencies: nnstreamer_filter_mvncsdk2_deps,
-      install: true,
-      install_dir: filter_subplugin_install_dir
-    )
+  shared_library('nnstreamer_filter_movidius-ncsdk2',
+    nnstreamer_filter_mvncsdk2_sources,
+    dependencies: nnstreamer_filter_mvncsdk2_deps,
+    install: true,
+    install_dir: filter_subplugin_install_dir
+  )
 
-    static_library('nnstreamer_filter_movidius-ncsdk2',
-      nnstreamer_filter_mvncsdk2_sources,
-      dependencies: nnstreamer_filter_mvncsdk2_deps,
-      install: true,
-      install_dir: nnstreamer_libdir
-    )
-  endif
+  static_library('nnstreamer_filter_movidius-ncsdk2',
+    nnstreamer_filter_mvncsdk2_sources,
+    dependencies: nnstreamer_filter_mvncsdk2_deps,
+    install: true,
+    install_dir: nnstreamer_libdir
+  )
 endif
 
 if get_option('enable-cppfilter')

--- a/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_caffe2.cc
@@ -42,6 +42,12 @@
 #define DBG FALSE
 #endif
 
+static const gchar *caffe2_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  NULL
+};
+
 using namespace caffe2;
 
 /**
@@ -563,6 +569,20 @@ caffe2_destroyNotify (void **private_data, void *data)
   /* do nothing */
 }
 
+/**
+ * @brief The optional callback for GstTensorFilterFramework
+ * @param[in] hw backend accelerator hardware
+ * @return 0 if supported. -errno if not supported.
+ */
+static int
+caffe2_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (caffe2_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_caffe2[] = "caffe2";
 
 static GstTensorFilterFramework NNS_support_caffe2 = {
@@ -584,6 +604,7 @@ init_filter_caffe2 (void)
   NNS_support_caffe2.getInputDimension = caffe2_getInputDim;
   NNS_support_caffe2.getOutputDimension = caffe2_getOutputDim;
   NNS_support_caffe2.destroyNotify = caffe2_destroyNotify;
+  NNS_support_caffe2.checkAvailability = caffe2_checkAvailability;
 
   nnstreamer_filter_probe (&NNS_support_caffe2);
 }

--- a/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_movidius_ncsdk2.c
@@ -35,6 +35,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+static const gchar *mvncsdk2_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  ACCL_NPU_STR,
+  ACCL_NPU_MOVIDIUS_STR,
+  NULL
+};
+
 void init_filter_mvncsdk2 (void) __attribute__ ((constructor));
 void fini_filter_mvncsdk2 (void) __attribute__ ((destructor));
 
@@ -381,7 +389,6 @@ _mvncsdk2_getInputDim (const GstTensorFilterProperties * prop,
  * @param prop : property of tensor_filter instance
  * @param private_data : tensorflow lite plugin's private data
  * @param[out] info : The dimesions and types of output tensors
- * @todo : fill this function
  */
 static int
 _mvncsdk2_getOutputDim (const GstTensorFilterProperties * prop,
@@ -409,12 +416,27 @@ _mvncsdk2_getOutputDim (const GstTensorFilterProperties * prop,
   return 0;
 }
 
+/**
+ * @brief The optional callback for GstTensorFilterFramework
+ * @param[in] hw backend accelerator hardware
+ * @return 0 if supported. -errno if not supported.
+ */
+static int
+_mvncsdk2_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (mvncsdk2_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_movidius_ncsdk2[] = "movidius-ncsdk2";
 
 static GstTensorFilterFramework NNS_support_movidius_ncsdk2 = {
   .version = GST_TENSOR_FILTER_FRAMEWORK_V0,
   .open = _mvncsdk2_open,
   .close = _mvncsdk2_close,
+  .checkAvailability = _mvncsdk2_checkAvailability,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */

--- a/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_openvino.hh
@@ -47,6 +47,7 @@
 
 const gchar *openvino_accl_support[] = {
   ACCL_CPU_STR,
+  ACCL_NPU_STR,
   ACCL_NPU_MOVIDIUS_STR,
   NULL
 };

--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow.cc
@@ -45,6 +45,12 @@
 #define DBG FALSE
 #endif
 
+static const gchar *tf_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  NULL
+};
+
 /**
  * @brief	Internal data structure for tensorflow
  */
@@ -737,6 +743,19 @@ tf_destroyNotify (void **private_data, void *data)
   }
 }
 
+/**
+ * @brief Check support of the backend
+ * @param[in] hw backend to check support of
+ */
+static int
+tf_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (tf_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_tensorflow[] = "tensorflow";
 
 static GstTensorFilterFramework NNS_support_tensorflow = {
@@ -758,6 +777,7 @@ init_filter_tf (void)
   NNS_support_tensorflow.getInputDimension = tf_getInputDim;
   NNS_support_tensorflow.getOutputDimension = tf_getOutputDim;
   NNS_support_tensorflow.destroyNotify = tf_destroyNotify;
+  NNS_support_tensorflow.checkAvailability = tf_checkAvailability;
 
   nnstreamer_filter_probe (&NNS_support_tensorflow);
 }

--- a/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_custom.c
@@ -37,6 +37,12 @@
 void init_filter_custom (void) __attribute__ ((constructor));
 void fini_filter_custom (void) __attribute__ ((destructor));
 
+static const gchar *custom_accl_support[] = {
+  ACCL_AUTO_STR,
+  ACCL_DEFAULT_STR,
+  NULL
+};
+
 /**
  * @brief internal_data
  */
@@ -266,6 +272,18 @@ custom_allocateInInvoke (void **private_data)
   return -EINVAL;
 }
 
+/**
+ * @brief Check support of the backend
+ */
+static int
+custom_checkAvailability (accl_hw hw)
+{
+  if (g_strv_contains (custom_accl_support, get_accl_hw_str (hw)))
+    return 0;
+
+  return -ENOENT;
+}
+
 static gchar filter_subplugin_custom[] = "custom";
 
 static GstTensorFilterFramework NNS_support_custom = {
@@ -283,6 +301,7 @@ static GstTensorFilterFramework NNS_support_custom = {
   .close = custom_close,
   .destroyNotify = custom_destroyNotify,        /* if custom filter model supports allocate_in_invoke, this will be set from custom filter. */
   .allocateInInvoke = custom_allocateInInvoke,
+  .checkAvailability = custom_checkAvailability,
 };
 
 /** @brief Initialize this object for tensor_filter subplugin runtime register */

--- a/meson.build
+++ b/meson.build
@@ -250,6 +250,21 @@ if get_option('enable-armnn')
   add_project_arguments('-DENABLE_ARMNN=1', language: ['c', 'cpp'])
 endif
 
+# Movidius NCSDK2
+have_movidius_ncsdk2 = false
+if get_option('enable-movidius-ncsdk2')
+  # Explicitly checks mvnc.h in the ncsdk2 directory
+  nns_mvncsdk2_dep = cc.find_library('mvnc', required: false)
+  if not nns_mvncsdk2_dep.found()
+    warning('Failed to find \'libmvnc.so\' despite setting enable-movidius-ncsdk2. This option be ignored.')
+  elif not cc.check_header('mvnc2/mvnc.h')
+    warning('Failed to find \'mvnc2/mvnc.h\' despite setting enable-movidius-ncsdk2. This option be ignored.')
+  else
+    have_movidius_ncsdk2 = true
+    add_project_arguments('-DENABLE_MOVIDIUS_NCSDK2=1', language: ['c', 'cpp'])
+  endif
+endif
+
 # Set configuration to install .ini
 nnstreamer_install_conf = configuration_data()
 nnstreamer_install_conf.merge_from(nnstreamer_conf)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -156,7 +156,7 @@ if get_option('enable-tensorflow-lite') and get_option('enable-edgetpu')
   subdir('nnstreamer_filter_edgetpu')
 endif
 
-if get_option('enable-movidius-ncsdk2')
+if have_movidius_ncsdk2
   subdir('nnstreamer_filter_mvncsdk2')
 endif
 

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1462,6 +1462,50 @@ TEST (nnstreamer_capi_util, availability_fail_04_n)
 }
 #endif /** ENABLE_NNFW_RUNTIME */
 
+#ifdef ENABLE_MOVIDIUS_NCSDK2
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_05)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_NPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_05_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_MVNC, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+#endif /** ENABLE_MOVIDIUS_NCSDK2 */
+
 /**
  * @brief Test NNStreamer Utility for checking tensors info handle
  */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1414,6 +1414,54 @@ TEST (nnstreamer_capi_util, availability_fail_03_n)
   EXPECT_EQ (result, false);
 }
 
+#ifdef ENABLE_NNFW_RUNTIME
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_04)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_04_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU_SR, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_NNFW, ML_NNFW_HW_NPU_MOVIDIUS, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+#endif /** ENABLE_NNFW_RUNTIME */
+
 /**
  * @brief Test NNStreamer Utility for checking tensors info handle
  */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1317,7 +1317,7 @@ TEST (nnstreamer_capi_util, availability_01)
 /**
  * @brief Test NNStreamer Utility for checking availability of Tensorflow-lite backend
  */
-TEST (nnstreamer_capi_util, availability_fail_n)
+TEST (nnstreamer_capi_util, availability_fail_01_n)
 {
   bool result;
   int status;
@@ -1343,6 +1343,42 @@ TEST (nnstreamer_capi_util, availability_fail_n)
   EXPECT_EQ (result, false);
 }
 #endif /* ENABLE_TENSORFLOW_LITE */
+
+#ifdef ENABLE_TENSORFLOW
+/**
+ * @brief Test NNStreamer Utility for checking availability of Tensorflow backend
+ */
+TEST (nnstreamer_capi_util, availability_02)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of Tensorflow backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_02_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_TENSORFLOW, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+#endif /** ENABLE_TENSORFLOW */
 
 /**
  * @brief Test NNStreamer Utility for checking tensors info handle

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1506,6 +1506,54 @@ TEST (nnstreamer_capi_util, availability_fail_05_n)
 }
 #endif /** ENABLE_MOVIDIUS_NCSDK2 */
 
+#ifdef ENABLE_ARMNN
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_06)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_CPU_NEON, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_06_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_NPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_ARMNN, ML_NNFW_HW_NPU_EDGE_TPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+#endif /** ENABLE_ARMNN */
+
 /**
  * @brief Test NNStreamer Utility for checking tensors info handle
  */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -1381,6 +1381,40 @@ TEST (nnstreamer_capi_util, availability_fail_02_n)
 #endif /** ENABLE_TENSORFLOW */
 
 /**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_03)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_ANY, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_AUTO, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, true);
+}
+
+/**
+ * @brief Test NNStreamer Utility for checking availability of custom backend
+ */
+TEST (nnstreamer_capi_util, availability_fail_03_n)
+{
+  bool result;
+  int status;
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_CPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+
+  status = ml_check_nnfw_availability (ML_NNFW_TYPE_CUSTOM_FILTER, ML_NNFW_HW_GPU, &result);
+  EXPECT_EQ (status, ML_ERROR_NONE);
+  EXPECT_EQ (result, false);
+}
+
+/**
  * @brief Test NNStreamer Utility for checking tensors info handle
  */
 TEST (nnstreamer_capi_util, tensors_info)


### PR DESCRIPTION
- Updated the list of HWs supported with openvino. Providing "true:npu" should also work along with "true:npu.movidius". Providing specific movidius accelerator works. However, just providing a generic npu should also default to movidius.
- Added list of supported accelerators as backend for caffe2
- Added list of supported backend accelerators for python extension of tensor filter
- Added supported list of hardware for tensorflow's tensor filter's extension. Added corresponding unit-tests using single API
- Added supported accelerators for custom filters and its unit-tests with single API
- Added unit-tests for nnfw supported accelerators with single API
- Added supported accelerators for ncsdk2 extension and corresponding unit-tests with single API
- Added supported accelerators for armnn and added corresponding unit tests with single API. Tested set accelerators on the device with Caffe model on the device

Resolves: #1849 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>