### PR TITLE
[Doc] Fix broken links for SSAT in documentation.

### DIFF
--- a/Documentation/component-description.md
+++ b/Documentation/component-description.md
@@ -115,7 +115,7 @@ Note that test elements in /tests/ are not elements for applications. They exist
   - Android WIP: JCenter Repository & Daily Build Release
   - macOS WIP: Daily Build Release
 - [Test cases](../tests/): Mandatory unit test cases required to pass for each PR.
-  - Used [SSAT](https://github.com/nnsuite/SSAT).
+  - Used [SSAT](https://github.com/myungjoo/SSAT).
   - Each element and feature is required to register its testcases at [test case directory](../tests/)
 - Examples: Example GStreamer applications using NNStreamer and example sub-plugins for NNStreamer. The binaries from this directory is not supposed to be packaged with the main binary package.
   - [Example GStreamer applications](https://github.com/nnsuite/nnstreamer-example)

--- a/Documentation/how-to-use-testcases.md
+++ b/Documentation/how-to-use-testcases.md
@@ -10,7 +10,7 @@ $ cd build
 $ ninja test
 ```
 
-For all gst-launch-based test cases ([SSAT](https://github.com/nnsuite/SSAT), mostly golden testing)
+For all gst-launch-based test cases ([SSAT](https://github.com/myungjoo/SSAT), mostly golden testing)
 ```
 $ cd tests
 $ ssat


### PR DESCRIPTION
This PR fixes broken links for `SSAT` in documentation.
`nnsuite/SSAT` is no longer available.

It resolves #2094 

Signed-off-by: Dongju Chae <dongju.chae@samsung.com>