### PR TITLE
LF/AI: Add required documents

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,23 @@
+# Definitions of Roles
+
+## Maintainer
+
+- May override to merge a pull-request or push/revert commits.
+- Decides policies and architecture.
+- Designate reviewers and their dedicated subdirectories.
+
+## Reviewer
+
+- May reject a pull-request, which prohibits merging.
+- May vote for an approval.
+- May merge a pull-request if it has enough number of approval-votes from reviewers or maintainers (2 or more).
+- The ability (vote/reject/merge) may be limited to a few subdirectories.
+- The list of reviewers and their subdirectories is at [.github/CODEOWNERS].
+
+## Committer
+
+- Anyone who has sent a pull-request, which is accepted and merged with the full procedures.
+
+## Note
+
+We allow anyone to sent a pull-request, to provide a code-review (although not being able to vote or reject), or to write an issue as long as they do no harm or break [CODE_OF_CONDUCT.md]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,16 @@
+## Versioning
+
+- Major.Minor.Patch
+- Major: updated if we have big changes in the architecture or APIs
+- Minor: release of a new version (even number) with moderate changes, usually with a new subplugin/plugin or APIs.
+    - Odd number: developmental version, preparing for next even-minor-number release.
+    - Even number: release version.
+- Patch: release of fixes and small changes whenever necessary or enough time has been passed since the last release.
+
+## Binary Release (Deployment)
+
+- Tizen
+- Ubuntu
+- Yocto/OpenEmbedded
+- Android
+- macOS


### PR DESCRIPTION
LF/AI requires to add MAINTAINERS.md and RELESES.md
This is to comply with the propsal of
https://github.com/lfai/proposing-projects/pull/9

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

