### PR TITLE
[Coverity] Fix resource leak

### DIFF
--- a/tests/nnstreamer_filter_openvino/unittest_openvino.cc
+++ b/tests/nnstreamer_filter_openvino/unittest_openvino.cc
@@ -98,6 +98,9 @@ TEST (tensor_filter_openvino, open_and_close_0)
   gchar *test_model;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -116,8 +119,6 @@ TEST (tensor_filter_openvino, open_and_close_0)
     };
 
     prop->model_files = model_files;
-
-    ASSERT_TRUE (fw && fw->open && fw->close);
 
     ret = fw->open (prop, &private_data);
 #ifdef __OPENVINO_CPU_EXT__
@@ -147,8 +148,6 @@ TEST (tensor_filter_openvino, open_and_close_0)
     prop->num_models = 2;
     prop->model_files = model_files;
 
-    ASSERT_TRUE (fw && fw->open && fw->close);
-
     ret = fw->open (prop, &private_data);
 #ifdef __OPENVINO_CPU_EXT__
     EXPECT_EQ (ret, 0);
@@ -174,8 +173,6 @@ TEST (tensor_filter_openvino, open_and_close_0)
     prop->num_models = 1;
     prop->model_files = model_files;
 
-    ASSERT_TRUE (fw && fw->open && fw->close);
-
     ret = fw->open (prop, &private_data);
 
 #ifdef __OPENVINO_CPU_EXT__
@@ -200,8 +197,6 @@ TEST (tensor_filter_openvino, open_and_close_0)
 
     prop->num_models = 1;
     prop->model_files = model_files;
-
-    ASSERT_TRUE (fw && fw->open && fw->close);
 
     ret = fw->open (prop, &private_data);
 
@@ -234,6 +229,9 @@ TEST (tensor_filter_openvino, open_and_close_1)
   gchar *test_model_xml;
   gchar *test_model_bin;
   gint ret;
+
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
@@ -272,8 +270,6 @@ TEST (tensor_filter_openvino, open_and_close_1)
 
     prop->model_files = model_files;
 
-    ASSERT_TRUE (fw && fw->open && fw->close);
-
     ret = fw->open (prop, &private_data);
 #ifdef __OPENVINO_CPU_EXT__
     EXPECT_EQ (ret, 0);
@@ -306,6 +302,9 @@ TEST (tensor_filter_openvino, open_and_close_2)
   gchar *test_model_bin;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -336,8 +335,6 @@ TEST (tensor_filter_openvino, open_and_close_2)
 
     prop->model_files = model_files;
 
-    ASSERT_TRUE (fw && fw->open && fw->close);
-
     ret = fw->open (prop, &private_data);
 #ifdef __OPENVINO_CPU_EXT__
     EXPECT_EQ (ret, 0);
@@ -367,6 +364,9 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
   gchar *test_model;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -385,8 +385,6 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
   prop->model_files = model_files;
   prop->num_models = 1;
   prop->accl_str = "true:cpu";
-
-  ASSERT_TRUE (fw && fw->open && fw->close);
 
   ret = fw->open (prop, &private_data);
   EXPECT_NE (ret, TensorFilterOpenvino::RetSuccess);
@@ -413,8 +411,6 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
 
     prop->num_models = 2;
     prop->model_files = model_files;
-
-    ASSERT_TRUE (fw && fw->open && fw->close);
 
     ret = fw->open (prop, &private_data);
     EXPECT_NE (ret, TensorFilterOpenvino::RetSuccess);
@@ -444,8 +440,6 @@ TEST (tensor_filter_openvino, open_and_close_0_n)
     prop->num_models = 2;
     prop->model_files = model_files;
 
-    ASSERT_TRUE (fw && fw->open && fw->close);
-
     ret = fw->open (prop, &private_data);
     EXPECT_NE (ret, TensorFilterOpenvino::RetSuccess);
     EXPECT_EQ (ret, TensorFilterOpenvino::RetEInval);
@@ -472,6 +466,9 @@ TEST (tensor_filter_openvino, open_and_close_1_n)
   gchar *test_model;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -489,8 +486,6 @@ TEST (tensor_filter_openvino, open_and_close_1_n)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close);
 
   ret = fw->open (prop, &private_data);
   EXPECT_NE (ret, TensorFilterOpenvino::RetSuccess);
@@ -540,6 +535,9 @@ TEST (tensor_filter_openvino, open_and_close_2_n)
   gchar *test_model;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -557,8 +555,6 @@ TEST (tensor_filter_openvino, open_and_close_2_n)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close);
 
   ret = fw->open (prop, &private_data);
   EXPECT_NE (ret, TensorFilterOpenvino::RetSuccess);
@@ -597,6 +593,9 @@ TEST (tensor_filter_openvino, getTensorDim_0)
   gchar *test_model;
   gint ret;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -615,8 +614,6 @@ TEST (tensor_filter_openvino, getTensorDim_0)
     };
 
     prop->model_files = model_files;
-
-    ASSERT_TRUE (fw && fw->open && fw->close);
 
     ret = fw->open (prop, &private_data);
 #ifdef __OPENVINO_CPU_EXT__

--- a/tests/nnstreamer_plugins/unittest_plugins.cc
+++ b/tests/nnstreamer_plugins/unittest_plugins.cc
@@ -2958,6 +2958,9 @@ TEST (test_tensor_filter, reopen_tflite_02_p)
 
   const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
+  
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close);
 
   /* supposed to run test in build directory */
   if (root_path == NULL)
@@ -2978,8 +2981,6 @@ TEST (test_tensor_filter, reopen_tflite_02_p)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close);
 
   /* open tf-lite model */
   EXPECT_TRUE (fw->open (prop, &private_data) == 0);
@@ -3106,6 +3107,9 @@ TEST (test_tensor_filter, reload_tflite_model_not_found_n)
   const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -3126,8 +3130,6 @@ TEST (test_tensor_filter, reload_tflite_model_not_found_n)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
 
   /* open tf-lite model */
   EXPECT_TRUE (fw->open (prop, &private_data) == 0);
@@ -3168,6 +3170,9 @@ TEST (test_tensor_filter, reload_tflite_model_wrong_dims_n)
   const gchar *root_path = g_getenv ("NNSTREAMER_BUILD_ROOT_PATH");
   gchar *test_model;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -3188,8 +3193,6 @@ TEST (test_tensor_filter, reload_tflite_model_wrong_dims_n)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
 
   /* open tf-lite model */
   EXPECT_TRUE (fw->open (prop, &private_data) == 0);
@@ -3223,6 +3226,9 @@ TEST (test_tensor_filter, reload_tflite_same_model_not_found_n)
   gchar *test_model;
   gchar *test_model_renamed;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -3246,9 +3252,7 @@ TEST (test_tensor_filter, reload_tflite_same_model_not_found_n)
   prop->model_files = model_files;
   prop->num_models = 1;
 
-  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
-
-  /* open tf-lite model */
+    /* open tf-lite model */
   EXPECT_TRUE (fw->open (prop, &private_data) == 0);
 
   /* reload tf-lite model again */
@@ -3286,6 +3290,9 @@ TEST (test_tensor_filter, reload_tflite_same_model_wrong_dims_n)
   gchar *test_model_backup;
   gchar *test_model_renamed;
 
+  /* Check if mandatory methods are contained */
+  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
+
   /* supposed to run test in build directory */
   if (root_path == NULL)
     root_path = "..";
@@ -3310,8 +3317,6 @@ TEST (test_tensor_filter, reload_tflite_same_model_wrong_dims_n)
   prop->fwname = fw_name;
   prop->model_files = model_files;
   prop->num_models = 1;
-
-  ASSERT_TRUE (fw && fw->open && fw->close && fw->reloadModel);
 
   /* open tf-lite model */
   EXPECT_TRUE (fw->open (prop, &private_data) == 0);


### PR DESCRIPTION
Fix coverity issues and potential error caused by resource leak.
Error occurred when assert test  was used after other memories were allocated.
The assert test performs immediately after the frame work was obtained.
 - CID: 1123780, 1123859, 113952, 1123963
 - tests/nnstreamer_filter_openvino/unittest_openvino.cc

Signed-off-by: gichan-jang <gichan2.jang@samsung.com>
