### PR TITLE
[Wait for #2119] Support models with signed 8-bit integer I/O

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -320,6 +320,7 @@ TFLiteInterpreter::getTensorType (TfLiteType tfType)
     case kTfLiteInt32:
       return _NNS_INT32;
     case kTfLiteBool:
+    case kTfLiteInt8:
       return _NNS_INT8;
     case kTfLiteInt64:
       return _NNS_INT64;


### PR DESCRIPTION
TensorFlow Lite models whose I/O is of type `kTfLiteInt8` are rejected,
requiring an I/O wrapper (`Quantize` operators). As signed 8-bit
integers are preferred in TensorFlow's quantization specifications [1],
this patch alleviates the need for an I/O wrapper to run strictly
`kTfLiteInt8`-type models.

Resolves: #2105 

[1] https://www.tensorflow.org/lite/performance/quantization_spec