### PR TITLE
[Coverity] Fix unitialized pointer field CID: 1123873

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -90,7 +90,7 @@ G_END_DECLS
 /**
  * @brief Class constructor
  */
-tensor_filter_cpp::tensor_filter_cpp(const char *name): validity(0xdeafdead), name(g_strdup(name)), ref_count(0)
+tensor_filter_cpp::tensor_filter_cpp(const char *name): validity(0xdeafdead), name(g_strdup(name)), ref_count(0), prop(NULL)
 {
 }
 


### PR DESCRIPTION
Fix Coverity issues caused by unitialized pointer field in tensor_filter_cpp.cc

Signed-off-by: Yongjoo Ahn <yongjoo1.ahn@samsung.com>