### PR TITLE
[unittest/build] Fix location of unittests binaries

### DIFF
--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -43,7 +43,7 @@ elif [ -d "${input}" ]; then
   do
     run_entry $entry
     ret=$?
-    if [ $ret -ne 0]; then
+    if [ $ret -ne 0 ]; then
       break
     fi
   done

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,20 +33,10 @@ if libpng_dep.found()
 endif
 
 # ssat repo_dynamic
-executable('unittest_repo',
-  join_paths('nnstreamer_repo_dynamicity', 'tensor_repo_dynamic_test.c'),
-  dependencies: [nnstreamer_dep, gst_dep, glib_dep],
-  install: get_option('install-test'),
-  install_dir: unittest_install_dir
-)
+subdir('nnstreamer_repo_dynamicity')
 
 # filter_reload
-executable('unittest_filter_reload',
-  join_paths('nnstreamer_filter_reload', 'tensor_filter_reload_test.c'),
-  dependencies: [nnstreamer_dep, gst_dep, glib_dep],
-  install: get_option('install-test'),
-  install_dir: unittest_install_dir
-)
+subdir('nnstreamer_filter_reload')
 
 # gtest
 gtest_dep = dependency('gtest', required: false)

--- a/tests/nnstreamer_filter_reload/meson.build
+++ b/tests/nnstreamer_filter_reload/meson.build
@@ -1,0 +1,6 @@
+executable('unittest_filter_reload',
+  'tensor_filter_reload_test.c',
+  dependencies: [nnstreamer_dep, gst_dep, glib_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)

--- a/tests/nnstreamer_filter_reload/runTest.sh
+++ b/tests/nnstreamer_filter_reload/runTest.sh
@@ -31,10 +31,10 @@ else
     TESTBINDIR="../../build/tests"
 fi
 
-${TESTBINDIR}/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL1}
+${TESTBINDIR}/nnstreamer_filter_reload/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL1}
 testResult $? 1 "reload tflite model case 1 (same model)" 0 1
 
-${TESTBINDIR}/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL2}
+${TESTBINDIR}/nnstreamer_filter_reload/unittest_filter_reload --input_img=${PATH_TO_INPUT} --first_model=${PATH_TO_MODEL1} --second_model=${PATH_TO_MODEL2}
 testResult $? 2 "reload tflite model case 2 (diff model)" 0 1
 
 report

--- a/tests/nnstreamer_repo_dynamicity/meson.build
+++ b/tests/nnstreamer_repo_dynamicity/meson.build
@@ -1,0 +1,6 @@
+executable('unittest_repo',
+  'tensor_repo_dynamic_test.c',
+  dependencies: [nnstreamer_dep, gst_dep, glib_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -37,7 +37,7 @@ else
     TESTBINDIR="../../build/tests"
 fi
 
-${TESTBINDIR}/unittest_repo --gst-plugin-path=../../build
+${TESTBINDIR}/nnstreamer_repo_dynamicity/unittest_repo --gst-plugin-path=../../build
 
 callCompareTest testsequence_1.golden tensorsequence01_1.log 1-1 "Compare 1-1" 1 0
 callCompareTest testsequence_2.golden tensorsequence01_2.log 1-2 "Compare 1-2" 1 0


### PR DESCRIPTION
Many unittest binaries are built and located in build/tests
All these binaries located in build/tests (not in recursive folders) are
run all at once with nnstreamer.spec by running all the files in build/tests (line 388)

However, some of these binaries are not supposed to run directly (they requires extra params),
and are properly run and tested with their shell scripts run with ssat (repo and reload unittests)

This PR moves the repo and reload unittest generated binaries into appropriate subfolders
to avoid running these binaries directly and avoid unnecessary warnings

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>