### PR TITLE
Tizen/CAPI: Workaround to support VIVANTE

### DIFF
--- a/api/capi/include/nnstreamer-capi-private.h
+++ b/api/capi/include/nnstreamer-capi-private.h
@@ -347,14 +347,15 @@ int ml_initialize_gstreamer (void);
 /**
  * @brief Validates the nnfw model file.
  * @since_tizen 5.5
- * @param[in] model The path of model file.
+ * @param[in] model List of model file paths.
+ * @param[in] num_models The number of model files. There are a few frameworks that require multiple model files for a single model.
  * @param[in/out] nnfw The type of NNFW.
  * @return @c 0 on success. Otherwise a negative error value.
  * @retval #ML_ERROR_NONE Successful
  * @retval #ML_ERROR_NOT_SUPPORTED Not supported.
  * @retval #ML_ERROR_INVALID_PARAMETER Given parameter is invalid.
  */
-int ml_validate_model_file (const char *model, ml_nnfw_type_e * nnfw);
+int ml_validate_model_file (char **model, unsigned int num_models, ml_nnfw_type_e * nnfw);
 
 /**
  * @brief Checks the availability of the plugin.

--- a/api/capi/src/nnstreamer-capi-single.c
+++ b/api/capi/src/nnstreamer-capi-single.c
@@ -560,17 +560,15 @@ ml_single_open_custom (ml_single_h * single, ml_single_preset * info)
    */
   if (info->models) {
     gchar **list_models;
-    guint m, num_models;
+    guint num_models;
 
     list_models = g_strsplit (info->models, ",", -1);
     num_models = g_strv_length (list_models);
 
-    for (m = 0; m < num_models; ++m) {
-      status = ml_validate_model_file (list_models[m], &nnfw);
-      if (status != ML_ERROR_NONE) {
-        g_strfreev (list_models);
-        return status;
-      }
+    status = ml_validate_model_file (list_models, num_models, &nnfw);
+    if (status != ML_ERROR_NONE) {
+      g_strfreev (list_models);
+      return status;
     }
 
     g_strfreev (list_models);


### PR DESCRIPTION
We need to rewrite this change to make it more general.

This fixes:
1. if there are multiple files for a model, we need to check the
whole list at once, not indivisually.
2. add VIVANTE detection and verification methods.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

