### PR TITLE
[filter] Support probing for tensor filter subplugins version 1 @open sesame 03/02 03:40

### DIFF
--- a/gst/nnstreamer/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/nnstreamer_plugin_api_filter.h
@@ -445,6 +445,8 @@ typedef struct _GstTensorFilterFramework
  * @brief Filter's sub-plugin should call this function to register itself.
  * @param[in] tfsp Tensor-Filter Sub-Plugin to be registered.
  * @return TRUE if registered. FALSE is failed or duplicated.
+ *
+ * @note Do not change the subplugins callbacks after probing the filter.
  */
 extern int
 nnstreamer_filter_probe (GstTensorFilterFramework * tfsp);

--- a/tests/nnstreamer_sink/unittest_sink.cc
+++ b/tests/nnstreamer_sink/unittest_sink.cc
@@ -3510,6 +3510,7 @@ TEST (tensor_stream_test, custom_filter_passthrough)
   GstTensorFilterFramework *fw = g_new0 (GstTensorFilterFramework, 1);
 
   ASSERT_TRUE (fw != NULL);
+  fw->version = GST_TENSOR_FILTER_FRAMEWORK_V0;
   fw->name = g_strdup ("custom-passthrough");
   fw->run_without_model = TRUE;
   fw->invoke_NN = test_custom_invoke;


### PR DESCRIPTION
Support probing for tensor filter subplugins framework of version 1
Various ToDos' have been added which will be supported soon.

Related Issue: #2116

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
