### PR TITLE
[CAPI] change the return value of info/data destroy function - @open sesame 03/02 12:16

### DIFF
--- a/api/capi/src/nnstreamer-capi-util.c
+++ b/api/capi/src/nnstreamer-capi-util.c
@@ -85,12 +85,12 @@ ml_tensors_info_destroy (ml_tensors_info_h info)
 {
   ml_tensors_info_s *tensors_info;
 
+  if (!info)
+    return ML_ERROR_NONE;
+
   check_feature_state ();
 
   tensors_info = (ml_tensors_info_s *) info;
-
-  if (!tensors_info)
-    return ML_ERROR_INVALID_PARAMETER;
 
   ml_tensors_info_free (tensors_info);
   g_free (tensors_info);
@@ -538,10 +538,10 @@ ml_tensors_data_destroy (ml_tensors_data_h data)
   ml_tensors_data_s *_data;
   guint i;
 
-  check_feature_state ();
-
   if (!data)
-    return ML_ERROR_INVALID_PARAMETER;
+    return ML_ERROR_NONE;
+
+  check_feature_state ();
 
   _data = (ml_tensors_data_s *) data;
 


### PR DESCRIPTION
Currently, when `info/data destroy()` called with the input `NULL`, it returns `ML_ERROR_INVALID_PARAMETER`. IMO, however, it should be done without any kind of error.

Signed-off-by: HyoungJoo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped