### PR TITLE
Hotfix: prepare GStreamer 1.16

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -1299,12 +1299,12 @@ gst_nnstreamer_tizen_sensor_init (GstPlugin * plugin)
 }
 
 #ifndef PACKAGE
-#define PACKAGE "nnstreamer"
+#define PACKAGE "nnstreamer_tizen_sensor"
 #endif
 
 GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
     GST_VERSION_MINOR,
-    nnstreamer_tizensensor,
+    nnstreamer_tizen_sensor,
     "nnstreamer Tizen sensor framework extension",
     gst_nnstreamer_tizen_sensor_init, VERSION, "LGPL", "nnstreamer",
     "https://github.com/nnsuite/nnstreamer");


### PR DESCRIPTION
From GStreamer 1.16, package name and plugin name should be
matched; otherwise, gstreamer will blacklist the plugin.

This fixes blacklisting issue with GStreamer 1.16 and
Tizen-sensor-framework plugin.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

