### PR TITLE
[filter] Support get and set properties @open sesame 03/07 05:10

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.h
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.h
@@ -29,6 +29,12 @@
 #include <nnstreamer_plugin_api.h>
 #include <nnstreamer_plugin_api_filter.h>
 
+/** Check tensor_filter framework version */
+#define GST_TF_FW_VN(fw, vn) \
+    (fw && checkGstTensorFilterFrameworkVersion (fw->version, vn))
+#define GST_TF_FW_V0(fw) GST_TF_FW_VN (fw, 0)
+#define GST_TF_FW_V1(fw) GST_TF_FW_VN (fw, 1)
+
 /**
  * @brief Structure definition for common tensor-filter properties.
  */
@@ -36,6 +42,7 @@ typedef struct _GstTensorFilterPrivate
 {
   void *privateData; /**< NNFW plugin's private data is stored here */
   GstTensorFilterProperties prop; /**< NNFW plugin's properties */
+  GstTensorFilterFrameworkInfo info; /**< NNFW framework info */
   const GstTensorFilterFramework *fw; /**< The implementation core of the NNFW. NULL if not configured */
 
   /* internal properties for tensor-filter */

--- a/tests/tizen_capi/unittest_tizen_capi.cc
+++ b/tests/tizen_capi/unittest_tizen_capi.cc
@@ -217,7 +217,6 @@ TEST (nnstreamer_capi_playstop, dummy_01)
   EXPECT_EQ (status, ML_ERROR_NONE);
 }
 
-
 /**
  * @brief Test NNStreamer pipeline construct & destruct
  */
@@ -3158,16 +3157,6 @@ TEST (nnstreamer_capi_singleshot, property_01_p)
   EXPECT_EQ (status, ML_ERROR_NONE);
 
   EXPECT_STREQ (prop_value, "false");
-  g_free (prop_value);
-
-  /* set layout (tf-lite does not require the layout) */
-  status = ml_single_set_property (single, "inputlayout", "NHWC");
-  EXPECT_EQ (status, ML_ERROR_NONE);
-
-  status = ml_single_get_property (single, "inputlayout", &prop_value);
-  EXPECT_EQ (status, ML_ERROR_NONE);
-
-  EXPECT_STREQ (prop_value, "NHWC");
   g_free (prop_value);
 
   /* get input info */


### PR DESCRIPTION
Support get and set properties for GstTensorFilterFramework V1.
Updated GstTensorFilterFramework to include the number of accelerators supported along with its list.
Added TODO where updating of the framework is to be added if the set is called after the framework is opened or input/output is already configured.

Note: All the added TODO with the property update will be handled in a separate PR as per #2114

See also: #2116

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>