### PR TITLE
[meson] Add dependency of gtest

### DIFF
--- a/tests/cpp_methods/meson.build
+++ b/tests/cpp_methods/meson.build
@@ -1,18 +1,16 @@
-if get_option('enable-cppfilter')
-  cppfilter_test_lib = library('cppfilter_test',
-    join_paths(meson.current_source_dir(), 'cppfilter_test.cc'),
-    dependencies: [nnstreamer_cpp_dep],
-    install: get_option('install-test'),
-    install_dir: unittest_install_dir
-  )
+cppfilter_test_lib = library('cppfilter_test',
+  join_paths(meson.current_source_dir(), 'cppfilter_test.cc'),
+  dependencies: [nnstreamer_cpp_dep],
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)
 
-  unittest_cppfilter = executable('unittest_cppfilter',
-    join_paths(meson.current_source_dir(), 'unittest_cpp_methods.cc'),
-    dependencies: [gtest_dep, unittest_util_dep, nnstreamer_cpp_dep],
-    link_with: cppfilter_test_lib,
-    install: get_option('install-test'),
-    install_dir: unittest_install_dir
-  )
+unittest_cppfilter = executable('unittest_cppfilter',
+  join_paths(meson.current_source_dir(), 'unittest_cpp_methods.cc'),
+  dependencies: [gtest_dep, unittest_util_dep, nnstreamer_cpp_dep],
+  link_with: cppfilter_test_lib,
+  install: get_option('install-test'),
+  install_dir: unittest_install_dir
+)
 
-  test('unittest_cppfilter', unittest_cppfilter, args: ['--gst-plugin-path=../..'])
-endif
+test('unittest_cppfilter', unittest_cppfilter, args: ['--gst-plugin-path=../..'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -150,8 +150,7 @@ if have_movidius_ncsdk2
   subdir('nnstreamer_filter_mvncsdk2')
 endif
 
-
-if get_option('enable-cppfilter')
+if get_option('enable-cppfilter') and gtest_dep.found()
   subdir('cpp_methods')
 endif
 

--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -1,3 +1,7 @@
+if not gtest_dep.found()
+    error('Cannot find gtest library')
+endif
+
 tizen_apptest_deps = [
   gtest_dep,
   glib_dep


### PR DESCRIPTION
Some of the unit-tests depend on gtest
However, their dependency is not checked leading to build failure with incorrect messages
Added dependency check of gtest before building those unittests

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped


Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>