### PR TITLE
[tflite] optimize invoke critical path

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -99,11 +99,13 @@ private:
 
   GstTensorsInfo inputTensorMeta;  /**< The tensor info of input tensors */
   GstTensorsInfo outputTensorMeta;  /**< The tensor info of output tensors */
+  std::vector <TfLiteTensor *> input_tensor_ptr;
+  std::vector <TfLiteTensor *> output_tensor_ptr;
 
   tensor_type getTensorType (TfLiteType tfType);
   int getTensorDim (int tensor_idx, tensor_dim dim);
   int setTensorProp (const std::vector<int> &tensor_idx_list,
-      GstTensorsInfo * tensorMeta);
+      GstTensorsInfo * tensorMeta, std::vector <TfLiteTensor *>& tensor_ptrs);
 };
 
 /**
@@ -181,36 +183,24 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
   gint64 start_time = g_get_real_time ();
 #endif
 
-  std::vector <int> tensors_idx;
-  int tensor_idx;
-  TfLiteTensor *tensor_ptr;
   TfLiteStatus status;
   bool size_mismatch = FALSE;
 
-  for (unsigned int i = 0; i < outputTensorMeta.num_tensors; ++i) {
-    tensor_idx = interpreter->outputs ()[i];
-    tensor_ptr = interpreter->tensor (tensor_idx);
-
-    if (tensor_ptr->bytes != output[i].size)
+  for (unsigned int i = 0; i < input_tensor_ptr.size (); i++) {
+    if (input_tensor_ptr[i]->bytes != input[i].size)
       size_mismatch = TRUE;
-    tensor_ptr->data.raw = (char *) output[i].data;
-    tensors_idx.push_back (tensor_idx);
+    input_tensor_ptr[i]->data.raw = (char *) input[i].data;
   }
-
-  for (unsigned int i = 0; i < inputTensorMeta.num_tensors; ++i) {
-    tensor_idx = interpreter->inputs ()[i];
-    tensor_ptr = interpreter->tensor (tensor_idx);
-
-    if (tensor_ptr->bytes != input[i].size)
+  for (unsigned int i = 0; i < output_tensor_ptr.size (); i++) {
+    if (output_tensor_ptr[i]->bytes != output[i].size)
       size_mismatch = TRUE;
-    tensor_ptr->data.raw = (char *) input[i].data;
-    tensors_idx.push_back (tensor_idx);
+    output_tensor_ptr[i]->data.raw = (char *) output[i].data;
   }
 
   if (!size_mismatch) {
 #ifdef ENABLE_TFLITE_NNAPI_DELEGATE
     if (use_nnapi)
-      status = nnfw_delegate->Invoke (interpreter.get());
+      status = nnfw_delegate->Invoke (interpreter.get ());
     else
 #endif
       status = interpreter->Invoke ();
@@ -219,9 +209,11 @@ TFLiteInterpreter::invoke (const GstTensorMemory * input,
   }
 
   /** if it is not `nullptr`, tensorflow makes `free()` the memory itself. */
-  int tensorSize = tensors_idx.size ();
-  for (int i = 0; i < tensorSize; ++i) {
-    interpreter->tensor (tensors_idx[i])->data.raw = nullptr;
+  for (unsigned int i = 0; i < input_tensor_ptr.size (); ++i) {
+    input_tensor_ptr[i]->data.raw = nullptr;
+  }
+  for (unsigned int i = 0; i < output_tensor_ptr.size (); ++i) {
+    output_tensor_ptr[i]->data.raw = nullptr;
   }
 
 #if (DBG)
@@ -380,10 +372,12 @@ TFLiteInterpreter::getTensorDim (int tensor_idx, tensor_dim dim)
  */
 int
 TFLiteInterpreter::setTensorProp (const std::vector<int> &tensor_idx_list,
-    GstTensorsInfo * tensorMeta)
+    GstTensorsInfo * tensorMeta, std::vector <TfLiteTensor *>& tensor_ptrs)
 {
   tensorMeta->num_tensors = tensor_idx_list.size ();
 
+  tensor_ptrs.clear ();
+  tensor_ptrs.reserve (tensorMeta->num_tensors);
   for (unsigned int i = 0; i < tensorMeta->num_tensors; ++i) {
     if (getTensorDim (tensor_idx_list[i], tensorMeta->info[i].dimension)) {
       g_critical ("failed to get the dimension of input tensors");
@@ -391,6 +385,7 @@ TFLiteInterpreter::setTensorProp (const std::vector<int> &tensor_idx_list,
     }
     tensorMeta->info[i].type =
         getTensorType (interpreter->tensor (tensor_idx_list[i])->type);
+    tensor_ptrs.push_back (interpreter->tensor (tensor_idx_list[i]));
 
 #if (DBG)
     gchar *dim_str =
@@ -410,7 +405,7 @@ TFLiteInterpreter::setTensorProp (const std::vector<int> &tensor_idx_list,
 int
 TFLiteInterpreter::setInputTensorProp ()
 {
-  return setTensorProp (interpreter->inputs (), &inputTensorMeta);
+  return setTensorProp (interpreter->inputs (), &inputTensorMeta, input_tensor_ptr);
 }
 
 /**
@@ -420,7 +415,7 @@ TFLiteInterpreter::setInputTensorProp ()
 int
 TFLiteInterpreter::setOutputTensorProp ()
 {
-  return setTensorProp (interpreter->outputs (), &outputTensorMeta);
+  return setTensorProp (interpreter->outputs (), &outputTensorMeta, output_tensor_ptr);
 }
 
 /**
@@ -510,6 +505,8 @@ TFLiteInterpreter::moveInternals (TFLiteInterpreter& interp)
 #ifdef ENABLE_TFLITE_NNAPI_DELEGATE
   nnfw_delegate = std::move (interp.nnfw_delegate);
 #endif
+  input_tensor_ptr.swap (interp.input_tensor_ptr);
+  output_tensor_ptr.swap (interp.output_tensor_ptr);
   setModelPath (interp.getModelPath ());
 }
 


### PR DESCRIPTION
Move unnecessary computations out of the critical path to maximize invoke performance for tensorflow-lite.

See also: #2134 

**Self evaluation:**
1. Build test: [x]Passed [ ]Failed [ ]Skipped
2. Run test: [x]Passed [ ]Failed [ ]Skipped

Signed-off-by: Parichay Kapoor <pk.kapoor@samsung.com>
