### PR TITLE
[Doc] invalid element name

### DIFF
--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.c
@@ -105,7 +105,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tensor_src_tizensensor_debug);
 #define GST_CAT_DEFAULT gst_tensor_src_tizensensor_debug
 
 /**
- * @brief tensor_src_iio properties.
+ * @brief tensor_src_tizensensor properties.
  */
 enum
 {

--- a/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
+++ b/ext/nnstreamer/tensor_source/tensor_src_tizensensor.h
@@ -106,7 +106,7 @@ struct _GstTensorSrcTIZENSENSORClass
 };
 
 /**
- * @brief Function to get type of tensor_src_iio.
+ * @brief Function to get type of tensor_src_tizensensor.
  */
 GType gst_tensor_src_tizensensor_get_type (void);
 


### PR DESCRIPTION
fix invalid element name in src-tizensensor source.

Signed-off-by: Jaeyun <jy1210.jung@samsung.com>
