### PR TITLE
[Clang/Subplugin/Infra] Exclude features.h when building with clang

### DIFF
--- a/gst/nnstreamer/nnstreamer_subplugin.c
+++ b/gst/nnstreamer/nnstreamer_subplugin.c
@@ -24,7 +24,9 @@
  */
 
 #include <dlfcn.h>
+#if !defined(__clang__) && (defined(__GNUC__) || defined(__GNUG__))
 #include <features.h>           /* Check libc version for dlclose-related workaround */
+#endif
 #include <glib.h>
 
 #include "nnstreamer_subplugin.h"


### PR DESCRIPTION
The header file, features.h, does not exist in the libc of clang. Therefore, features.h is excluded when building with clang to avoid a compilation error reltate to this header file.

Signed-off-by: Wook Song <wook16.song@samsung.com>

This PR fixes a sub-item in #2096 
See also https://github.com/nnsuite/nnstreamer/issues/2141#with-enable-orc-enable-env-var-and-enable-symbolic-link

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [ ]Skipped