### PR TITLE
[Meson/Filter/TFLite] Use has_type to check types tflite supports 

### DIFF
--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -104,28 +104,19 @@ if get_option('enable-tensorflow-lite')
     endif
   endif
 
-  TFLite_version = tflite_dep.version().split('.')
-  TFLite_major = TFLite_version[0].to_int()
-  TFLite_minor = TFLite_version[1].to_int()
-
   tflite_compile_args = []
-  if TFLite_major == 1
-    if TFLite_minor >= 10
-      tflite_compile_args += '-DTFLITE_INT16=1'
-      tflite_compile_args += '-DTFLITE_COMPLEX64=1'
-      message('data type [INT16] is added for TFLite')
-      message('data type [COMPLEX64] is added for TFLite')
-    endif
 
-    if TFLite_minor >= 13
-      tflite_compile_args += '-DTFLITE_INT8=1'
-      message('data type [INT8] is added for TFLite')
-    endif
-
-    if TFLite_minor >= 14
-      tflite_compile_args += '-DTFLITE_FLOAT16=1'
-      message('data type [FLOAT16] is added for TFLite')
-    endif
+  if cxx.has_type('kTfLiteInt8', prefix : '#include <tensorflow/contrib/lite/model.h>')
+    tflite_compile_args += '-DTFLITE_INT8=1'
+  endif
+  if cxx.has_type('kTfLiteInt16', prefix : '#include <tensorflow/contrib/lite/model.h>')
+    tflite_compile_args += '-DTFLITE_INT16=1'
+  endif
+  if cxx.has_type('kTfLiteFloat16', prefix : '#include <tensorflow/contrib/lite/model.h>')
+    tflite_compile_args += '-DTFLITE_FLOAT16=1'
+  endif
+  if cxx.has_type('kTfLiteComplex64', prefix : '#include <tensorflow/contrib/lite/model.h>')
+    tflite_compile_args += '-DTFLITE_COMPLEX64=1'
   endif
 
   tflite_extra_dep = declare_dependency(

--- a/ext/nnstreamer/tensor_filter/meson.build
+++ b/ext/nnstreamer/tensor_filter/meson.build
@@ -104,6 +104,36 @@ if get_option('enable-tensorflow-lite')
     endif
   endif
 
+  TFLite_version = tflite_dep.version().split('.')
+  TFLite_major = TFLite_version[0].to_int()
+  TFLite_minor = TFLite_version[1].to_int()
+
+  tflite_compile_args = []
+  if TFLite_major == 1
+    if TFLite_minor >= 10
+      tflite_compile_args += '-DTFLITE_INT16=1'
+      tflite_compile_args += '-DTFLITE_COMPLEX64=1'
+      message('data type [INT16] is added for TFLite')
+      message('data type [COMPLEX64] is added for TFLite')
+    endif
+
+    if TFLite_minor >= 13
+      tflite_compile_args += '-DTFLITE_INT8=1'
+      message('data type [INT8] is added for TFLite')
+    endif
+
+    if TFLite_minor >= 14
+      tflite_compile_args += '-DTFLITE_FLOAT16=1'
+      message('data type [FLOAT16] is added for TFLite')
+    endif
+  endif
+
+  tflite_extra_dep = declare_dependency(
+    compile_args : tflite_compile_args,
+  )
+
+  nnstreamer_filter_tflite_deps += tflite_extra_dep
+
   shared_library('nnstreamer_filter_tensorflow-lite',
     nnstreamer_filter_tflite_sources,
     dependencies: nnstreamer_filter_tflite_deps,

--- a/meson.build
+++ b/meson.build
@@ -170,29 +170,6 @@ if get_option('enable-tensorflow-lite')
   else
     error('Cannot find tensorflow-lite')
   endif
-
-  TFLite_version = tflite_dep.version().split('.')
-  TFLite_major = TFLite_version[0].to_int()
-  TFLite_minor = TFLite_version[1].to_int()
-
-  if TFLite_major == 1
-    if TFLite_minor >= 10
-      add_project_arguments('-DTFLITE_INT16=1', language: ['c', 'cpp'])
-      add_project_arguments('-DTFLITE_COMPLEX64=1', language: ['c', 'cpp'])
-      message('data type [INT16] is added for TFLite')
-      message('data type [COMPLEX64] is added for TFLite')
-    endif
-
-    if TFLite_minor >= 13
-      add_project_arguments('-DTFLITE_INT8=1', language: ['c', 'cpp'])
-      message('data type [INT8] is added for TFLite')
-    endif
-
-    if TFLite_minor >= 14
-      add_project_arguments('-DTFLITE_FLOAT16=1', language: ['c', 'cpp'])
-      message('data type [FLOAT16] is added for TFLite')
-    endif
-  endif
 endif
 
 # PyTorch


### PR DESCRIPTION
This PR mainly concerns checking which data types the installed TensorFlow Lite supports at build time. In detail, the following commits are included:

- [Meson/TFLite] Check version in ext/nns/filter/meson.build 
  - Move a specific code for the tensor filter extension for tflite from meson.build in the source root to the tensor filter extension directory
- [Meson/Filter/TFLite] Use has_type to check types tflite supports 
  - Instead of checking which data types the installed TensorFlow Lite
supports via hardcoded version information, this patch uses has_type,
which is a function of the compiler object in meson, to check that.

See also: #2139, #2120
cc: @helloahn

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped

Signed-off-by: Wook Song <wook16.song@samsung.com>