### PR TITLE
[Filter/C++] Add workround for a warning related to format-nonliteral @open sesame 03/16 12:00

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_cpp.cc
@@ -182,6 +182,7 @@ int tensor_filter_cpp::invoke (const GstTensorFilterProperties *prop, void **pri
 /**
  * @brief Printout only once for a given error
  */
+__attribute__((format(printf, 3, 4)))
 static void g_printerr_once (const char *file, int line, const char *fmt,
     ...)
 {


### PR DESCRIPTION
This patch adds a workround for the warning issued by clang when wrapping a function which takes format-literal-string arguments.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Resolves: https://github.com/nnsuite/nnstreamer/issues/2141#with-enable-cppfilter

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped