### PR TITLE
[Tests] Fix build failures incurred by typo and sed on macOS

### DIFF
--- a/tests/nnstreamer_filter_extensions_common/meson.build
+++ b/tests/nnstreamer_filter_extensions_common/meson.build
@@ -61,9 +61,9 @@ foreach ext : extensions
     input : ext_test_template,
     output : ext_test_path_each,
     command : [copy, '-f', '@INPUT@', '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_name_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_abbrv_option, '@OUTPUT@', \
-      '&&', 'sed', '-i', sed_ext_mf_option, '@OUTPUT@']
+      '&&', 'sed', '-i\'.cc\'', sed_ext_name_option, '@OUTPUT@', \
+      '&&', 'sed', '-i\'.cc\'', sed_ext_abbrv_option, '@OUTPUT@', \
+      '&&', 'sed', '-i\'.cc\'', sed_ext_mf_option, '@OUTPUT@']
   )
 
   exec = executable(

--- a/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
+++ b/tests/nnstreamer_filter_extensions_common/unittest_tizen_template.cc.in
@@ -370,8 +370,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke_fail_n)
 {
   int ret;
   void *data = NULL;
-  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { 0, };
-  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { {0}, };
+  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { {0}, };
   gchar **model_files;
 
   model_files = get_model_files ();
@@ -422,8 +422,8 @@ TEST (nnstreamer_@EXT_ABBRV@_basic_functions, invoke)
   int ret;
   int ret_get_in, ret_get_out, ret_set_in;
   void *data = NULL;
-  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { 0, };
-  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { 0, };
+  GstTensorMemory input[NNS_TENSOR_SIZE_LIMIT] = { {0}, };
+  GstTensorMemory output[NNS_TENSOR_SIZE_LIMIT] = { {0}, };
   gchar **model_files;
   GstTensorsInfo input_info, output_info;
   guint i;

--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -194,7 +194,7 @@ main (int argc, char *argv[])
     {"second_model", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING, &second_model_path,
       "The path of second model file",
       "e.g., models/mobilenet_v2_1.0_224_quant.tflite"},
-    {"silent", 's', G_OPTION_FLAG_NONE, G_OPTION_FLAG_NONE, &silent,
+    {"silent", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE, &silent,
       "Hide debug message", "TRUE (default)"},
     {NULL}
   };


### PR DESCRIPTION
This patch fixes build failures when the 'enable-test' option is set 'true' on macOS. The following errors are fixed:
- Corrected typo (G_OPTION_FLAG_NONE -> G_OPTION_ARG_NONE)
- Fixed an error caused by the behaviour difference of 'sed' between Linux
  and macOS
- Eliminated a warning related to 'missing-braces' complained by clang++

Signed-off-by: Wook Song <wook16.song@samsung.com>

Resolves: https://github.com/nnsuite/nnstreamer/issues/2141#with-enable-test

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped