### PR TITLE
[Tests/Meson] Build tensor filter reload tests when tf-lite is enabled

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -35,8 +35,10 @@ endif
 # ssat repo_dynamic
 subdir('nnstreamer_repo_dynamicity')
 
-# filter_reload
-subdir('nnstreamer_filter_reload')
+# filter_reload (Currently, the reload test for tensor filter requires tflite)
+if get_option('enable-tensorflow-lite')
+  subdir('nnstreamer_filter_reload')
+endif
 
 # gtest
 gtest_dep = dependency('gtest', required: false)


### PR DESCRIPTION
The model reload test cases of tensor filter only works for the tensorflow lite filter and its models. Therefore, this patch adds a condition to check that the option for Tensorflow-Lite is enabled
before building those tests.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped