### PR TITLE
[TestCase] Count negative cases of SSAT results @open sesame 3/18 09:59

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -117,7 +117,7 @@ BuildRequires:  json-glib-devel
 
 # Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
 %if 0%{?unit_test}
-BuildRequires: ssat
+BuildRequires: ssat >= 1.1.0
 %endif
 
 # For ORC (Oil Runtime Compiler)
@@ -392,7 +392,7 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
     LD_LIBRARY_PATH=./tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64
     pushd tests
-    ssat -n --summary summary.txt
+    ssat -n --summary summary.txt -cn _n
     popd
 %endif #if unit_test
 

--- a/tools/development/count_test_cases.py
+++ b/tools/development/count_test_cases.py
@@ -44,12 +44,12 @@ def readSSAT(filename):
         with open(filename, "r") as f:
             r = f.readlines()
             for line in r:
-                res = re.match(r'passed=(\d+), failed=(\d+), ignored=(\d+)', line)
+                res = re.match(r'passed=(\d+), failed=(\d+), ignored=(\d+), negative=(\d+)', line)
                 if res:
-                    return (int(res.group(1)) + int(res.group(2)) + int(res.group(3)), int(res.group(1)), int(res.group(2)), int(res.group(3)))
+                    return (int(res.group(1)) + int(res.group(2)) + int(res.group(3)), int(res.group(1)), int(res.group(2)), int(res.group(3)), int(res.group(4)))
     except:
         print("No SSAT results.")
-    return (0, 0, 0, 0)
+    return (0, 0, 0, 0, 0)
 
 def main():
     if len(sys.argv) != 3:
@@ -76,13 +76,13 @@ def main():
                 ng = ng + n
     posg = pg + fg + ig - ng
 
-    (t, p, f, i) = readSSAT(sys.argv[2])
+    (t, p, f, i, n) = readSSAT(sys.argv[2])
 
     print("GTest (total " + str(tg) + " cases)")
     print("  Passed: " + str(pg) + " / Failed: " + str(fg) + " / Ignored: " + str(ig) + " | Positive: " + str(posg) + " / Negative: " + str(ng))
     print("SSAT (total " + str(t) + " cases)")
-    print("  Passed: " + str(p) + " / Failed: " + str(f) + " / Ignored: " + str(i))
-    print("Grand Total: " + str(pg + t) + " cases")
+    print("  Passed: " + str(p) + " / Failed: " + str(f) + " / Ignored: " + str(i) + " | Positive: " + str(t - n) + " / Negative: " + str(n))
+    print("Grand Total: " + str(pg + t) + " cases (negatives : " + str(ng + n) + ")")
     print("  Passed: " + str(pg+p) + " / Failed: " + str(fg + f) + " / Ignored: " + str(ig + i))
     return 0
 


### PR DESCRIPTION
Count negative cases of SSAT.
Print the sum of negative cases of Gtest and SSAT at the end.

This requires updates of SSAT (1.1.0)

Fixes #2150

With this commit, we get the following summary in the build log:
```
[  185s] GTest (total 349 cases)
[  185s]   Passed: 349 / Failed: 0 / Ignored: 0 | Positive: 251 / Negative: 98
[  185s] SSAT (total 520 cases)
[  185s]   Passed: 520 / Failed: 0 / Ignored: 0 | Positive: 508 / Negative: 12
[  185s] Grand Total: 869 cases (negatives : 110)
[  185s]   Passed: 869 / Failed: 0 / Ignored: 0
```

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

