### PR TITLE
[AHUB/430058] Fix unitialized local variable

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_tensorflow_lite.cc
@@ -432,7 +432,7 @@ TFLiteInterpreter::setOutputTensorProp ()
 int
 TFLiteInterpreter::setInputTensorsInfo (const GstTensorsInfo * info)
 {
-  TfLiteStatus status;
+  TfLiteStatus status = kTfLiteOk;
   const std::vector<int> &input_idx_list = interpreter->inputs();
 
   /** Cannot change the number of inputs */


### PR DESCRIPTION
WID:16576294 Uninitialized data is read from local variable 'status' at tensor_filter_tensorflow_lite.cc:474.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

