### PR TITLE
[AHUB/523198] Fix null pointer dereferencing

### DIFF
--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -788,7 +788,7 @@ gst_tensor_filter_common_set_property (GstTensorFilterPrivate * priv,
       if (fw) {
         /** Get framework info for v1 */
         if (GST_TF_FW_V1 (fw) &&
-            priv->fw->getFrameworkInfo (prop, NULL, &priv->info) < 0) {
+            fw->getFrameworkInfo (prop, NULL, &priv->info) < 0) {
           ml_logw ("Cannot get the given framework info, %s\n", fw_name);
           break;
         }


### PR DESCRIPTION
This fixes:
WID:16646516 After having been compared to NULL value at tensor_filter_common.c:773, pointer 'priv->fw' is dereferenced at tensor_filter_common.c:791.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

