### PR TITLE
[Coverity/1123909] Fix ALLOC-FREE-MISMATCH

### DIFF
--- a/tests/nnstreamer_source/unittest_src_iio.cc
+++ b/tests/nnstreamer_source/unittest_src_iio.cc
@@ -510,7 +510,7 @@ build_dev_dir_scan_elements (iio_dev_dir_struct * iio_dev,
   num_bytes++;
 
   data_size = num_bytes * iio_dev->num_scan_elements / skip;
-  scan_el_data = (char *) malloc (data_size);
+  scan_el_data = (char *) g_malloc0 (data_size);
   if (scan_el_data == NULL) {
     return -1;
   }
@@ -583,7 +583,7 @@ build_dev_dir_scan_elements (iio_dev_dir_struct * iio_dev,
     }
   }
 
-  gchar *copied_scan_el_data = (gchar *) malloc (data_size * BUF_LENGTH);
+  gchar *copied_scan_el_data = (gchar *) g_malloc (data_size * BUF_LENGTH);
   if (copied_scan_el_data == NULL) {
     g_free (scan_el_data);
     return -1;


### PR DESCRIPTION
Coverity complains about malloc-gfree pair. Then, pacify it by
using g_malloc-gfree pair.

Fixes: CID 1123909 (#1 of 1): Incorrect deallocator used (ALLOC_FREE_MISMATCH)
12. free: Calling g_free frees scan_el_data using g_free but it should have been freed using free.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

