### PR TITLE
[LFAI-4] Switch to SPDX short-form identifiers

### DIFF
--- a/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
+++ b/nnstreamer_example/custom_example_LSTM/dummy_LSTM.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter LSTM Example, "dummyLSTM"
  * Copyright (C) 2018 Jijoong Moon <jijoong.moon@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file	dummy_LSTM.c
  * @date	28 Nov 2018

--- a/nnstreamer_example/custom_example_RNN/dummy_RNN.c
+++ b/nnstreamer_example/custom_example_RNN/dummy_RNN.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter RNN Example, "dummyRNN"
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file	dummy_RNN.c
  * @date	02 Nov 2018

--- a/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
+++ b/nnstreamer_example/custom_example_average/nnstreamer_customfilter_example_average.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter Example 4. Average
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnstreamer_customfilter_example_average.c
  * @date  02 Jul 2018

--- a/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_average.cc
+++ b/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_average.cc
@@ -2,7 +2,7 @@
  * NNStreamer OpenCV Custom Filter Example: Average
  * Copyright (C) 2018 Sangjung Woo <sangjung.woo@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnstreamer_customfilter_opencv_average.cc
  * @date  25 Oct 2018

--- a/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
+++ b/nnstreamer_example/custom_example_opencv/nnstreamer_customfilter_opencv_scaler.cc
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2018 Sangjung Woo <sangjung.woo@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnstreamer_customfilter_opencv_scaler.cc
  * @date  22 Oct 2018

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter Example 1. Pass-Through
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file	nnstreamer_customfilter_example_passthrough.c
  * @date	11 Jun 2018

--- a/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
+++ b/nnstreamer_example/custom_example_passthrough/nnstreamer_customfilter_example_passthrough_variable.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter Example 2. Pass-Through with Variable Dimensions
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file	nnstreamer_customfilter_example_passthrough_variable.c
  * @date	22 Jun 2018

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter Example 3. Scaler
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnstreamer_customfilter_example_scaler.c
  * @date  22 Jun 2018

--- a/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
+++ b/nnstreamer_example/custom_example_scaler/nnstreamer_customfilter_example_scaler_allocator.c
@@ -2,7 +2,7 @@
  * NNStreamer Custom Filter Example 3. Scaler - Allocator, to test "allocate_in_invoke" option
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnstreamer_customfilter_example_scaler_allocator.c
  * @date  22 Jun 2018

--- a/tests/nnstreamer_sink/nnscustom_drop_buffer.c
+++ b/tests/nnstreamer_sink/nnscustom_drop_buffer.c
@@ -2,7 +2,7 @@
  * NNStreamer custom filter to test buffer-drop
  * Copyright (C) 2018 Jaeyun Jung <jy1210.jung@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnscustom_drop_buffer.c
  * @date  25 Jan 2019

--- a/tests/nnstreamer_sink/nnscustom_framecounter.c
+++ b/tests/nnstreamer_sink/nnscustom_framecounter.c
@@ -3,7 +3,7 @@
  * NNStreamer Custom Filter for Multistream Synchronization Test
  * Copyright (C) 2018 MyungJoo Ham <myungjoo.ham@samsung.com>
  *
- * LICENSE: LGPL-2.1
+ * SPDX-License-Identifier: LGPL-2.1-only
  *
  * @file  nnscustom_framecounter.c
  * @date  08 Nov 2018

--- a/tools/development/nnstreamerCodeGenCustomFilter.py
+++ b/tools/development/nnstreamerCodeGenCustomFilter.py
@@ -43,7 +43,7 @@ common_head = """/**
 * NNStreamer Custom Filter, {name}, created by codegen
 * Copyright (C) 2019 Samsung Electronics
 *
-* LICENSE: LGPL-2.1
+* SPDX-License-Identifier: LGPL-2.1-only
 *
 * @file     nnstreamer_customfilter_{fname}.c
 * @date     {today}


### PR DESCRIPTION
Change "LICENSE: LGPL-2.1" to "SPDX-License-Identifier: LGPL-2.1-only"

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>
