### PR TITLE
[LFAI-5] Add Licenses to files with no license

### DIFF
--- a/.TAOS-CI/taos/auto-unittest.sh
+++ b/.TAOS-CI/taos/auto-unittest.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file auto-unittest.sh
 # @brief Auto-generate unit test result
 # @how to append this script to /etc/crontab

--- a/.TAOS-CI/taos/config/config-environment.sh
+++ b/.TAOS-CI/taos/config/config-environment.sh
@@ -3,6 +3,8 @@
 # Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file     config-environment.sh
 # @brief    The configuration file to maintain all scripts
 # @see      https://github.com/nnsuite/TAOS-CI

--- a/.TAOS-CI/taos/config/config-plugins-audit.sh
+++ b/.TAOS-CI/taos/config/config-plugins-audit.sh
@@ -3,6 +3,8 @@
 # Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file     config-plugins-audit.sh
 # @brief    Configuraiton file to maintain audit modules (after completing a build procedure)
 # @see      https://github.com/nnsuite/TAOS-CI

--- a/.TAOS-CI/taos/config/config-plugins-format.sh
+++ b/.TAOS-CI/taos/config/config-plugins-format.sh
@@ -3,6 +3,8 @@
 # Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file     config-plugins-format.sh
 # @brief    Configuration file to maintain format modules (before doing a build procedure)
 # @see      https://github.com/nnsuite/TAOS-CI

--- a/.TAOS-CI/taos/config/config-server-administrator.sh
+++ b/.TAOS-CI/taos/config/config-server-administrator.sh
@@ -3,6 +3,8 @@
 # Do not append a license statement in the configuration file for a differnet license-based repository.
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file config-server-administrator.sh
 # @brief configuration file to declare contents that a server administrator installed.
 # @see      https://github.com/nnsuite/TAOS-CI

--- a/api/android/build-android-lib.sh
+++ b/api/android/build-android-lib.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 # @file  build-android-lib.sh
 # @brief A script to build NNStreamer API library for Android
 #

--- a/packaging/run_unittests_binaries.sh
+++ b/packaging/run_unittests_binaries.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file run_unittests.sh
 ## @author Parichay Kapoor <pk.kapoor@gmail.com>
 ## @date Dec 20 2019

--- a/tests/codegen/runTest.sh
+++ b/tests/codegen/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Mar 06 2019

--- a/tests/gen24bBMP.py
+++ b/tests/gen24bBMP.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file gen24bBMP.py
 # @brief Generate 24bpp .bmp files for test cases

--- a/tests/nnstreamer_converter/generateGoldenTestResult.py
+++ b/tests/nnstreamer_converter/generateGoldenTestResult.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateGoldenTestResult.py
 # @brief Generate golden test results for test cases

--- a/tests/nnstreamer_converter/runTest.sh
+++ b/tests/nnstreamer_converter/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_decoder/generateGoldenTestResult.py
+++ b/tests/nnstreamer_decoder/generateGoldenTestResult.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateGoldenTestResult.py
 # @brief Generate golden test results for test cases

--- a/tests/nnstreamer_decoder/runTest.sh
+++ b/tests/nnstreamer_decoder/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_decoder_boundingbox/runTest.sh
+++ b/tests/nnstreamer_decoder_boundingbox/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_decoder_image_labeling/runTest.sh
+++ b/tests/nnstreamer_decoder_image_labeling/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_decoder_image_segment/runTest.sh
+++ b/tests/nnstreamer_decoder_image_segment/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author Yongjoo Ahn <yongjoo1.ahn@samsung.com>
 ## @date Feb 26 2020

--- a/tests/nnstreamer_decoder_pose/runTest.sh
+++ b/tests/nnstreamer_decoder_pose/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_demux/runTest.sh
+++ b/tests/nnstreamer_demux/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_filter_caffe2/checkLabel.py
+++ b/tests/nnstreamer_filter_caffe2/checkLabel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkLabel.py
 # @brief Check the result label of caffe2 model

--- a/tests/nnstreamer_filter_caffe2/runTest.sh
+++ b/tests/nnstreamer_filter_caffe2/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author HyoungJoo Ahn <hello.ahn@samsung.com>
 ## @date Jun 17 2019

--- a/tests/nnstreamer_filter_custom/checkScaledTensor.py
+++ b/tests/nnstreamer_filter_custom/checkScaledTensor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkScaledTensor.py
 # @brief Check if the scaled results are correct

--- a/tests/nnstreamer_filter_custom/runTest.sh
+++ b/tests/nnstreamer_filter_custom/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_filter_python/checkScaledTensor.py
+++ b/tests/nnstreamer_filter_python/checkScaledTensor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file   checkScaledTensor.py
 # @brief  Check if the scaled results are correct

--- a/tests/nnstreamer_filter_python/runTest.sh
+++ b/tests/nnstreamer_filter_python/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author Dongju Chae <dongju.chae@samsung.com>
 ## @date Apr 3 2019

--- a/tests/nnstreamer_filter_pytorch/checkLabel.py
+++ b/tests/nnstreamer_filter_pytorch/checkLabel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2019 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkLabel.py
 # @brief Check the result label of pytorch model

--- a/tests/nnstreamer_filter_pytorch/create_mnist_jit.py
+++ b/tests/nnstreamer_filter_pytorch/create_mnist_jit.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2019 Samsung Electronics
 # License: LGPL-2.1
 #

--- a/tests/nnstreamer_filter_pytorch/runTest.sh
+++ b/tests/nnstreamer_filter_pytorch/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author Parichay Kapoor <pk.kapoor@samsung.com>
 ## @date May 7th 2019

--- a/tests/nnstreamer_filter_reload/runTest.sh
+++ b/tests/nnstreamer_filter_reload/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author Dongju Chae <dongju.chae@samsung.com>
 ## @date Dec 19 2019

--- a/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
+++ b/tests/nnstreamer_filter_reload/tensor_filter_reload_test.c
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file    tensor_filter_reload_test.c
  * @data    19 Dec 2019
  * @brief   test case to test a filter's model reload

--- a/tests/nnstreamer_filter_tensorflow/checkLabel.py
+++ b/tests/nnstreamer_filter_tensorflow/checkLabel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkLabel.py
 # @brief Check the result label of tensorflow-lite model

--- a/tests/nnstreamer_filter_tensorflow/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author HyoungJoo Ahn <hello.ahn@samsung.com>
 ## @date Dec 17 2018

--- a/tests/nnstreamer_filter_tensorflow_lite/checkLabel.py
+++ b/tests/nnstreamer_filter_tensorflow_lite/checkLabel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkLabel.py
 # @brief Check the result label of tensorflow-lite model

--- a/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
+++ b/tests/nnstreamer_filter_tensorflow_lite/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_merge/generateTest.py
+++ b/tests/nnstreamer_merge/generateTest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateTest.py
 # @brief Generate golden test results for test cases

--- a/tests/nnstreamer_merge/runTest.sh
+++ b/tests/nnstreamer_merge/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_mux/runTest.sh
+++ b/tests/nnstreamer_mux/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_repo/runTest.sh
+++ b/tests/nnstreamer_repo/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_repo_dynamicity/runTest.sh
+++ b/tests/nnstreamer_repo_dynamicity/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
+++ b/tests/nnstreamer_repo_dynamicity/tensor_repo_dynamic_test.c
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file    tensor_repo_dynamic_test.c
  * @date    03 Dec 2018
  * @brief   test case to test tensor repo plugin dynamism

--- a/tests/nnstreamer_repo_lstm/generateTestCase.py
+++ b/tests/nnstreamer_repo_lstm/generateTestCase.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateTestCase.py
 # @brief Generate a sequence of video/x-raw frames & golden

--- a/tests/nnstreamer_repo_lstm/runTest.sh
+++ b/tests/nnstreamer_repo_lstm/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author Jijoong Moon <jijoong.moon@samsung.com>
 ## @date Nov 28 2018

--- a/tests/nnstreamer_repo_rnn/generateTestCase.py
+++ b/tests/nnstreamer_repo_rnn/generateTestCase.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
 # License: LGPL-2.1
 #

--- a/tests/nnstreamer_repo_rnn/runTest.sh
+++ b/tests/nnstreamer_repo_rnn/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @author Jijoong Moon <jijoong.moon@gmail.com>

--- a/tests/nnstreamer_split/runTest.sh
+++ b/tests/nnstreamer_split/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/test_models/models/passthrough.py
+++ b/tests/test_models/models/passthrough.py
@@ -1,6 +1,7 @@
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2019 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file    Passthrough.py
 # @brief   Python custom filter example: passthrough

--- a/tests/test_models/models/scaler.py
+++ b/tests/test_models/models/scaler.py
@@ -1,6 +1,7 @@
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2019 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file    Scaler.py
 # @brief   Python custom filter example: scaler

--- a/tests/tizen_capi/dummy_sensor.c
+++ b/tests/tizen_capi/dummy_sensor.c
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file	dummy_sensor.h
  * @date	28 Nov 2019
  * @brief	Dummy Tizen Sensor API support for unit tests.

--- a/tests/tizen_capi/dummy_sensor.h
+++ b/tests/tizen_capi/dummy_sensor.h
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file	dummy_sensor.h
  * @date	28 Nov 2019
  * @brief	Dummy Tizen Sensor API support for unit tests.

--- a/tests/tizen_capi/sensor.h
+++ b/tests/tizen_capi/sensor.h
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file	sensor.h
  * @date	28 Nov 2019
  * @brief	Tizen Sensor Framework Simulator

--- a/tests/transform_arithmetic/checkResult.py
+++ b/tests/transform_arithmetic/checkResult.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
 # License: LGPL-2.1
 #

--- a/tests/transform_arithmetic/runTest.sh
+++ b/tests/transform_arithmetic/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/transform_dimchg/checkResult.py
+++ b/tests/transform_dimchg/checkResult.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkResult.py
 # @brief Check if the tranform results are correct

--- a/tests/transform_dimchg/runTest.sh
+++ b/tests/transform_dimchg/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/transform_stand/checkResult.py
+++ b/tests/transform_stand/checkResult.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkResult.py
 # @brief Check if the tranform results are correct with typecast

--- a/tests/transform_stand/generateTest.py
+++ b/tests/transform_stand/generateTest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateTest.py
 # @brief Generate golden test results for test cases

--- a/tests/transform_stand/runTest.sh
+++ b/tests/transform_stand/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/transform_transpose/generateTest.py
+++ b/tests/transform_transpose/generateTest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file generateTest.py
 # @brief Generate golden test results for test cases

--- a/tests/transform_transpose/runTest.sh
+++ b/tests/transform_transpose/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/transform_typecast/checkResult.py
+++ b/tests/transform_typecast/checkResult.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # Copyright (C) 2018 Samsung Electronics
-# License: LGPL-2.1
 #
 # @file checkResult.py
 # @brief Check if the tranform results are correct with typecast

--- a/tests/transform_typecast/runTest.sh
+++ b/tests/transform_typecast/runTest.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 ##
+## SPDX-License-Identifier: LGPL-2.1-only
+##
 ## @file runTest.sh
 ## @author MyungJoo Ham <myungjoo.ham@gmail.com>
 ## @date Nov 01 2018

--- a/tests/unittest_util.c
+++ b/tests/unittest_util.c
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file        unittest_util.c
  * @date        15 Jan 2019
  * @brief       Unit test utility.

--- a/tests/unittest_util.h
+++ b/tests/unittest_util.h
@@ -1,4 +1,6 @@
 /**
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
  * @file        unittest_util.h
  * @date        15 Jan 2019
  * @brief       Unit test utility.

--- a/tests/unittestcoverage.py
+++ b/tests/unittestcoverage.py
@@ -1,20 +1,8 @@
 #!/usr/bin/env python2.7
 
 ##
-# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-only
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-##
 # @file unittestcoverage.py
 # @brief Calculate and show unit test coverate rate.
 # @author MyungJoo Ham <myungjoo.ham@samsung.com>

--- a/tools/development/count_test_cases.py
+++ b/tools/development/count_test_cases.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 ##
+# SPDX-License-Identifier: LGPL-2.1-only
+#
 # GTest / SSAT Test Result Aggregator
 # Copyright (c) 2019 Samsung Electronics
 #
-# You may use this under either LGPL 2.1+ or Apache-2.0.
-
 ##
 # @file   count_test_cases.py
 # @brief  A unit test result aggregator


### PR DESCRIPTION
Add SPDX short-form identifiesr in files with no license

**Self evaluation:**
1. Build test:	 [X]Passed [ ]Failed [ ]Skipped
2. Run test:	 [X]Passed [ ]Failed [ ]Skipped

Signed-off-by: jijoong.moon <jijoong.moon@samsung.com>

