### PR TITLE
[Filter/API] Constify subplugin name. @open sesame 3/26 18:35

### DIFF
--- a/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
+++ b/gst/nnstreamer/include/nnstreamer_plugin_api_filter.h
@@ -175,7 +175,7 @@ typedef struct _GstTensorFilterProperties
  */
 typedef struct _GstTensorFilterFrameworkInfo
 {
-  char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property */
+  const char *name; /**< Name of the neural network framework, searchable by FRAMEWORK property */
   int allow_in_place; /**< TRUE(nonzero) if InPlace transfer of input-to-output is allowed. Not supported in main, yet */
   int allocate_in_invoke; /**< TRUE(nonzero) if invoke_NN is going to allocate outputptr by itself and return the address via outputptr. Do not change this value after cap negotiation is complete (or the stream has been started). */
   int run_without_model; /**< TRUE(nonzero) when the neural network framework does not need a model file. Tensor-filter will run invoke_NN without model. */

--- a/gst/nnstreamer/tensor_filter/tensor_filter_common.c
+++ b/gst/nnstreamer/tensor_filter/tensor_filter_common.c
@@ -425,7 +425,7 @@ nnstreamer_filter_probe (GstTensorFilterFramework * tfsp)
 {
   GstTensorFilterFrameworkInfo info;
   GstTensorFilterProperties prop;
-  char *name = NULL;
+  const char *name = NULL;
 
   g_return_val_if_fail (nnstreamer_filter_validate (tfsp), FALSE);
 


### PR DESCRIPTION

    
Do not let subplugin authors handle alloc/dealloc name
for frequent getFrameworkInfo calls.
    
Allow them to point to a const string instead.
    
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
