### PR TITLE
[Android/Build] Add comments on TF-Lite versions and types.

### DIFF
--- a/api/android/api/src/main/jni/Android.mk
+++ b/api/android/api/src/main/jni/Android.mk
@@ -39,7 +39,7 @@ endif
 #------------------------------------------------------
 ifeq ($(ENABLE_TF_LITE),true)
 NNS_API_FLAGS += -DENABLE_TENSORFLOW_LITE=1
-# define types in tensorflow-lite sub-plugin
+# define types in tensorflow-lite sub-plugin. This assumes tensorflow-lite >= 1.13 (older versions don't have INT8/INT16)
 NNS_API_FLAGS += -DTFLITE_INT8=1 -DTFLITE_INT16=1
 NNS_API_STATIC_LIBS += tensorflow-lite cpufeatures
 


### PR DESCRIPTION
INT8/INT16 may incur build errors with older TF-Lite.
For users with older TF-Lite, leave some comments.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
