### PR TITLE
[Filter/Python/CXX] Do not use 'register' as a storage-class-specifier @open sesame 03/26 13:46

### DIFF
--- a/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
+++ b/ext/nnstreamer/tensor_filter/tensor_filter_python.cc
@@ -41,7 +41,16 @@
 #pragma GCC diagnostic ignored "-Wformat"
 #endif
 
+/**
+ * NOTE: This workaround is only for python2.7. If we are going to use external
+ * open-source projects written in cpp with the 'register' keyword, we need to
+ * project-widely apply this.
+ */
+#if __cplusplus > 199711L
+#define register          /* Deprecated in C++11 */
+#endif /* __cplusplus > 199711L */
 #include <Python.h>
+
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <structmember.h>


### PR DESCRIPTION
In C++11, the use of the register keyword as a storage-class-specifier is deprecated [1] and this keyword is excluded from storage-class-specifiers in C++17 [2]. In order to avoid build warnings
from the old python2.7 code, this patch adds a workaround for it.

[1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4193.html#809
[2] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4340

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [*]Skipped