### PR TITLE
[Dist/Tizen] Add workaround for mvnc filter test failure on Tizen

### DIFF
--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -382,12 +382,12 @@ export NNSTREAMER_DECODERS=$(pwd)/build/ext/nnstreamer/tensor_decoder
     bash %{test_script} ./tests/tizen_nnfw_runtime/unittest_nnfw_runtime_raw
     ln -s ext/nnstreamer/tensor_source/*.so .
     bash %{test_script} ./tests/tizen_capi/unittest_tizen_sensor
-    LD_LIBRARY_PATH=./tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
 %endif #if tizen
 %if 0%{?unit_test}
     bash %{test_script} ./tests
     bash %{test_script} ./tests/tizen_capi/unittest_tizen_capi
     bash %{test_script} ./tests/nnstreamer_filter_extensions_common
+    LD_LIBRARY_PATH=./tests/nnstreamer_filter_mvncsdk2:. bash %{test_script} ./tests/nnstreamer_filter_mvncsdk2/unittest_filter_mvncsdk2
 %ifarch aarch64 x86_64
     LD_LIBRARY_PATH=./tests/nnstreamer_filter_edgetpu:. bash %{test_script} ./tests/nnstreamer_filter_edgetpu/unittest_edgetpu
 %endif #ifarch 64


### PR DESCRIPTION
This patch disables the test cases for the mvnc2 tensor filter which fails on Tizen 6.0 DA FHUB.

Signed-off-by: Wook Song <wook16.song@samsung.com>
**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped